### PR TITLE
feat(credentials): allow overriding api keys via env vars

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/credentials"
@@ -19,6 +20,9 @@ func CreateNRClient(cfg *config.Config, creds *credentials.Credentials) (*newrel
 
 	// Create the New Relic Client
 	defProfile := creds.Default()
+
+	defProfile = applyOverrides(defProfile)
+
 	if defProfile != nil {
 		adminAPIKey = defProfile.AdminAPIKey
 		personalAPIKey = defProfile.PersonalAPIKey
@@ -38,4 +42,36 @@ func CreateNRClient(cfg *config.Config, creds *credentials.Credentials) (*newrel
 	}
 
 	return nrClient, nil
+}
+
+func applyOverrides(p *credentials.Profile) *credentials.Profile {
+	envAPIKey := os.Getenv("NEWRELIC_API_KEY")
+	envAdminAPIKey := os.Getenv("NEWRELIC_ADMIN_API_KEY")
+	envRegion := os.Getenv("NEWRELIC_REGION")
+
+	if envAPIKey == "" && envAdminAPIKey == "" && envRegion == "" {
+		return p
+	}
+
+	var out credentials.Profile
+
+	if p == nil {
+		out = credentials.Profile{}
+	} else {
+		out = *p
+	}
+
+	if envAPIKey != "" {
+		out.PersonalAPIKey = envAPIKey
+	}
+
+	if envAdminAPIKey != "" {
+		out.AdminAPIKey = envAdminAPIKey
+	}
+
+	if envRegion != "" {
+		out.Region = envRegion
+	}
+
+	return &out
 }

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -44,12 +44,12 @@ func LoadCredentials(configDir string) (*Credentials, error) {
 
 	profiles, err := LoadProfiles(configDir)
 	if err != nil {
-		log.Warnf("no credential profiles: see newrelic profiles --help")
+		log.Debugf("no credential profiles: see newrelic profiles --help")
 	}
 
 	defaultProfile, err := LoadDefaultProfile(configDir)
 	if err != nil {
-		log.Warnf("no default profile set: see newrelic profiles --help")
+		log.Debugf("no default profile set: see newrelic profiles --help")
 	}
 
 	creds.Profiles = *profiles


### PR DESCRIPTION
Resolves #42.

This PR allows overriding API key and region values via env vars:

- `NEWRELIC_API_KEY` (apiks)
- `NEWRELIC_ADMIN_API_KEY` (we will retire this shortly)
- `NEWRELIC_REGION`

### Testing:
`make docker-image`
`docker run -e "NEWRELIC_API_KEY=<API_KEY>" <DOCKER_IMAGE> newrelic entities search --name test`