### PR TITLE
fix(config): set defaults before validating config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,6 +242,11 @@ func (c *Config) set(key string, value interface{}) error {
 		return fmt.Errorf("failed to locate global scope")
 	}
 
+	err = config.setDefaults()
+	if err != nil {
+		return err
+	}
+
 	err = config.validate()
 
 	if err != nil {


### PR DESCRIPTION
Related to #49.

This PR fixes a regression that prevents `config set` commands from working properly if no config file exists.