### PR TITLE
feat(nerdgraph): add nerdgraph command with query subcommand

### DIFF
--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/entities"
+	"github.com/newrelic/newrelic-cli/internal/nerdgraph"
 )
 
 var (
@@ -30,6 +31,7 @@ func init() {
 	Command.AddCommand(credentials.Command)
 	Command.AddCommand(apm.Command)
 	Command.AddCommand(config.Command)
+	Command.AddCommand(nerdgraph.Command)
 }
 
 func main() {

--- a/internal/entities/command.go
+++ b/internal/entities/command.go
@@ -83,7 +83,7 @@ more information.
 				params.Reporting = &reporting
 			}
 
-			entities, err := nrClient.Entities.SearchEntities(params, nil)
+			entities, err := nrClient.Entities.SearchEntities(params)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/entities/command.go
+++ b/internal/entities/command.go
@@ -83,7 +83,7 @@ more information.
 				params.Reporting = &reporting
 			}
 
-			entities, err := nrClient.Entities.SearchEntities(params)
+			entities, err := nrClient.Entities.SearchEntities(params, nil)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/internal/nerdgraph/command.go
+++ b/internal/nerdgraph/command.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -75,7 +76,13 @@ keys are the variables to be referenced in the GraphQL query.
 				log.Fatal(err)
 			}
 
-			fmt.Println(reqBodyBytes.String())
+			formatted, err := prettyjson.Format(reqBodyBytes.Bytes())
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(bytes.NewBuffer(formatted).String())
 		})
 	},
 }

--- a/internal/nerdgraph/command.go
+++ b/internal/nerdgraph/command.go
@@ -65,11 +65,17 @@ keys are the variables to be referenced in the GraphQL query.
 			}
 
 			reqBodyBytes := new(bytes.Buffer)
-			json.NewEncoder(reqBodyBytes).Encode(ng.QueryResponse{
+
+			encoder := json.NewEncoder(reqBodyBytes)
+			err = encoder.Encode(ng.QueryResponse{
 				Actor: result.(ng.QueryResponse).Actor,
 			})
 
-			fmt.Println(string(reqBodyBytes.Bytes()))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(reqBodyBytes.String())
 		})
 	},
 }

--- a/internal/nerdgraph/command.go
+++ b/internal/nerdgraph/command.go
@@ -1,16 +1,17 @@
 package nerdgraph
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 
-	prettyjson "github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
 	"github.com/newrelic/newrelic-client-go/newrelic"
+	ng "github.com/newrelic/newrelic-client-go/pkg/nerdgraph"
 )
 
 var (
@@ -63,12 +64,12 @@ keys are the variables to be referenced in the GraphQL query.
 				log.Fatal(err)
 			}
 
-			json, err := prettyjson.Marshal(result)
-			if err != nil {
-				log.Fatal(err)
-			}
+			reqBodyBytes := new(bytes.Buffer)
+			json.NewEncoder(reqBodyBytes).Encode(ng.QueryResponse{
+				Actor: result.(ng.QueryResponse).Actor,
+			})
 
-			fmt.Println(string(json))
+			fmt.Println(string(reqBodyBytes.Bytes()))
 		})
 	},
 }

--- a/internal/nerdgraph/command.go
+++ b/internal/nerdgraph/command.go
@@ -1,0 +1,79 @@
+package nerdgraph
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	prettyjson "github.com/hokaccha/go-prettyjson"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+var (
+	variables string
+)
+
+// Command represents the nerdgraph command.
+var Command = &cobra.Command{
+	Use:   "nerdgraph",
+	Short: "Top-level command for executing raw GraphQL requests to the NerdGraph API.",
+}
+
+var queryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Execute a raw GraphQL query request to the NerdGraph API.",
+	Long: `
+Execute a raw GraphQL query request to the NerdGraph API.
+
+The query command accepts a single argument in the form of a GraphQL query as a string.
+This command accepts an optional flag, --variables, which should be a JSON string where the
+keys are the variables to be referenced in the GraphQL query.
+`,
+	Example: `newrelic nerdgraph query 'query($guid: EntityGuid!) { actor { entity(guid: $guid) { guid name domain entityType } } }' --variables '{"guid": "<GUID>"}'`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		argsCount := len(args)
+
+		if argsCount < 1 {
+			return errors.New("missing graph query argument")
+		}
+
+		if argsCount > 1 {
+			return errors.New("command expects only 1 argument")
+		}
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			var variablesParsed map[string]interface{}
+
+			err := json.Unmarshal([]byte(variables), &variablesParsed)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			query := args[0]
+
+			result, err := nrClient.NerdGraph.Query(query, variablesParsed)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			json, err := prettyjson.Marshal(result)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(string(json))
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(queryCmd)
+	queryCmd.Flags().StringVar(&variables, "variables", "{}", "(Optional) The variables to pass to the GraphQL query, represented as a JSON string.")
+}

--- a/internal/nerdgraph/command_test.go
+++ b/internal/nerdgraph/command_test.go
@@ -1,0 +1,26 @@
+package nerdgraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNerdGraphCommand(t *testing.T) {
+	assert.NotEmptyf(t, Command.Use, "Need to set Command.%s on Command %s", "Use", Command.CalledAs())
+	assert.NotEmptyf(t, Command.Short, "Need to set Command.%s on Command %s", "Short", Command.CalledAs())
+
+	for _, c := range Command.Commands() {
+		assert.NotEmptyf(t, c.Use, "Need to set Command.%s on Command %s", "Use", c.CommandPath())
+		assert.NotEmptyf(t, c.Short, "Need to set Command.%s on Command %s", "Short", c.CommandPath())
+		assert.NotEmptyf(t, c.Long, "Need to set Command.%s on Command %s", "Long", c.CommandPath())
+		assert.NotEmptyf(t, c.Example, "Need to set Command.%s on Command %s", "Example", c.CommandPath())
+	}
+}
+
+func TestQuery(t *testing.T) {
+	command := queryCmd
+
+	assert.Equal(t, "query", command.Name())
+	assert.True(t, command.HasFlags())
+}


### PR DESCRIPTION
Depends on PR [#147](https://github.com/newrelic/newrelic-client-go/pull/147) in **newrelic-client-go** being released.

Resolves: #60
Resolves: #84 

Example command:
```
newrelic nerdgraph query "{ actor { user { email id name } } }"
```