### PR TITLE
Fix: Docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ FROM alpine:3.11
 # Add the binary
 COPY ./bin/linux/newrelic /bin
 
-CMD ["/bin/newrelic"]
+ENTRYPOINT ["/bin/newrelic"]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ $ docker pull newrelic/cli
 $ docker run -it --rm \
     -e NEW_RELIC_API_KEY="$NEW_RELIC_API_KEY" \
     newrelic/cli \
-    newrelic apm application get --name WebPortal
+    apm application get --name WebPortal
 
 [
   {


### PR DESCRIPTION
We were using CMD for specifying the command to run inside the container which requires the user to specify the binary name again when running.  This removes that behavior.