### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 ## [Unreleased]
 
 
+<a name="v0.2.2"></a>
+## [v0.2.2] - 2020-03-04
+### Bug Fixes
+- **build:** Remove version.go generation from make release
+- **build:** Add docker login to release-push process
+
+
 <a name="v0.2.1"></a>
 ## [v0.2.1] - 2020-03-03
 ### Bug Fixes
@@ -61,6 +68,7 @@
 - **profile:** Add listing of profiles to command
 
 
-[Unreleased]: https://github.com/newrelic/newrelic-client-go/compare/v0.2.1...HEAD
+[Unreleased]: https://github.com/newrelic/newrelic-client-go/compare/v0.2.2...HEAD
+[v0.2.2]: https://github.com/newrelic/newrelic-client-go/compare/v0.2.1...v0.2.2
 [v0.2.1]: https://github.com/newrelic/newrelic-client-go/compare/v0.2.0...v0.2.1
 [v0.2.0]: https://github.com/newrelic/newrelic-client-go/compare/v0.1.0...v0.2.0

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -32,10 +32,7 @@ git checkout -b release/v${RELEASE_VERSION}
 # Auto-generate CHANGELOG updates
 git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md
 
-# Update version in version.go file
-echo -e "package version\n\n// Version of this library\nconst Version string = \"${RELEASE_VERSION}\"" > internal/version/version.go
-
 # Commit CHANGELOG updates
-git add CHANGELOG.md internal/version/version.go
-git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION}"
+git add CHANGELOG.md
+git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION} [skip ci]"
 git push origin release/v${RELEASE_VERSION}

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -34,5 +34,5 @@ git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md
 
 # Commit CHANGELOG updates
 git add CHANGELOG.md
-git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION} [skip ci]"
+git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION}"
 git push origin release/v${RELEASE_VERSION}


### PR DESCRIPTION
## [v0.2.2] - 2020-03-04
### Bug Fixes
- **build:** Remove version.go generation from make release
- **build:** Add docker login to release-push process