### PR TITLE
Allow overriding the version on make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Global vars
 #############################
 PROJECT_NAME := $(shell basename $(shell pwd))
-PROJECT_VER  := $(shell git describe --tags --always --dirty | sed -e '/^v/s/^v\(.*\)$$/\1/g') # Strip leading 'v' if found
+PROJECT_VER  ?= $(shell git describe --tags --always --dirty | sed -e '/^v/s/^v\(.*\)$$/\1/g') # Strip leading 'v' if found
 # Last released version (not dirty
 PROJECT_VER_TAGGED  := $(shell git describe --tags --always --abbrev=0 | sed -e '/^v/s/^v\(.*\)$$/\1/g') # Strip leading 'v' if found
 SRCDIR       ?= .


### PR DESCRIPTION
Homebrew formula require local build of the binary from a tar.gz of the source.  We currently get the version from the latest git tag, so this breaks.

Change PROJECT_VER to allow it to be overridden on make.