### PR TITLE
fix(newrelic): avoid duplicate error message output

### DIFF
--- a/cmd/newrelic/command.go
+++ b/cmd/newrelic/command.go
@@ -84,5 +84,9 @@ func Execute() error {
 	Command.Use = appName
 	Command.Version = version
 
+	// Silence Cobra's internal handling of error messaging
+	// since we have a custom error handler in main.go
+	Command.SilenceErrors = true
+
 	return Command.Execute()
 }


### PR DESCRIPTION
Addresses line item from #49 

> Address duplication of errors (top & bottom of stderr output)