### PR TITLE
Change command to entity, rename commands

### DIFF
--- a/internal/entities/command.go
+++ b/internal/entities/command.go
@@ -6,18 +6,18 @@ import (
 
 // Should these be moved out or made into higher-level flags?
 var (
-	entityName          string
-	entityGUID          string
-	entityValues        []string
-	entityType          string
 	entityAlertSeverity string
 	entityDomain        string
-	entityReporting     string
 	entityFields        []string
+	entityGUID          string
+	entityName          string
+	entityReporting     string
+	entityType          string
+	entityValues        []string
 )
 
 // Command represents the entities command
 var Command = &cobra.Command{
-	Use:   "entities",
+	Use:   "entity",
 	Short: "Interact with New Relic entities",
 }

--- a/internal/entities/command_search.go
+++ b/internal/entities/command_search.go
@@ -14,14 +14,14 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
 )
 
-var entitiesSearch = &cobra.Command{
+var cmdEntitySearch = &cobra.Command{
 	Use:   "search",
 	Short: "Search for New Relic entities",
 	Long: `Search for New Relic entities
 
 The search command performs a search for New Relic entities.
 `,
-	Example: "newrelic entities search --name <applicationName>",
+	Example: "newrelic entity search --name <applicationName>",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			params := entities.SearchEntitiesParams{}
@@ -97,12 +97,12 @@ func mapEntities(entities []*entities.Entity, fields []string, fn utils.StructTo
 }
 
 func init() {
-	Command.AddCommand(entitiesSearch)
-	entitiesSearch.Flags().StringVarP(&entityName, "name", "n", "", "search for entities matching the given name")
-	entitiesSearch.Flags().StringVarP(&entityType, "type", "t", "", "search for entities matching the given type")
-	entitiesSearch.Flags().StringVarP(&entityAlertSeverity, "alert-severity", "a", "", "search for entities matching the given alert severity type")
-	entitiesSearch.Flags().StringVarP(&entityReporting, "reporting", "r", "", "search for entities based on whether or not an entity is reporting (true or false)")
-	entitiesSearch.Flags().StringVarP(&entityDomain, "domain", "d", "", "search for entities matching the given entity domain")
-	entitiesSearch.Flags().StringVar(&entityTag, "tag", "", "search for entities matching the given entity tag")
-	entitiesSearch.Flags().StringSliceVarP(&entityFields, "fields-filter", "f", []string{}, "filter search results to only return certain fields for each search result")
+	Command.AddCommand(cmdEntitySearch)
+	cmdEntitySearch.Flags().StringVarP(&entityName, "name", "n", "", "search for entities matching the given name")
+	cmdEntitySearch.Flags().StringVarP(&entityType, "type", "t", "", "search for entities matching the given type")
+	cmdEntitySearch.Flags().StringVarP(&entityAlertSeverity, "alert-severity", "a", "", "search for entities matching the given alert severity type")
+	cmdEntitySearch.Flags().StringVarP(&entityReporting, "reporting", "r", "", "search for entities based on whether or not an entity is reporting (true or false)")
+	cmdEntitySearch.Flags().StringVarP(&entityDomain, "domain", "d", "", "search for entities matching the given entity domain")
+	cmdEntitySearch.Flags().StringVar(&entityTag, "tag", "", "search for entities matching the given entity tag")
+	cmdEntitySearch.Flags().StringSliceVarP(&entityFields, "fields-filter", "f", []string{}, "filter search results to only return certain fields for each search result")
 }

--- a/internal/entities/command_search_test.go
+++ b/internal/entities/command_search_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEntitiesSearch(t *testing.T) {
-	command := entitiesSearch
+	command := cmdEntitySearch
 
 	assert.Equal(t, "search", command.Name())
 	assert.True(t, command.HasFlags())

--- a/internal/entities/command_tags.go
+++ b/internal/entities/command_tags.go
@@ -19,14 +19,25 @@ var (
 	entityTags []string
 )
 
-var entitiesDescribeTags = &cobra.Command{
-	Use:   "describe-tags",
-	Short: "Describe the tags for a given entity",
-	Long: `Describe the tags for a given entity
+var cmdTags = &cobra.Command{
+	Use:   "tags",
+	Short: "Manage tags on New Relic entities",
+	Long: `Manage entity tags
 
-The describe-tags command returns JSON output of the tags for the requested entity.
+The tag command allows users to manage the tags applied on the requested
+entity. Use --help for more information.
 `,
-	Example: "newrelic entities describe-tags --guid <entityGUID>",
+	Example: "newrelic entity tags get --guid <guid>",
+}
+
+var cmdTagsGet = &cobra.Command{
+	Use:   "get",
+	Short: "Get the tags for a given entity",
+	Long: `Get the tags for a given entity
+
+The get command returns JSON output of the tags for the requested entity.
+`,
+	Example: "newrelic entity tags get --guid <entityGUID>",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := nrClient.Entities.ListTags(entityGUID)
@@ -44,15 +55,15 @@ The describe-tags command returns JSON output of the tags for the requested enti
 	},
 }
 
-var entitiesDeleteTags = &cobra.Command{
-	Use:   "delete-tags",
+var cmdTagsDelete = &cobra.Command{
+	Use:   "delete",
 	Short: "Delete the given tag:value pairs from the given entity",
 	Long: `Delete the given tag:value pairs from the given entity
 
-The delete-tag-values command deletes all tags on the given entity 
+The delete command deletes all tags on the given entity 
 that match the specified keys.
 `,
-	Example: "newrelic entities delete-tags --guid <entityGUID> --tag tag1 --tag tag2 --tag tag3,tag4",
+	Example: "newrelic entity tags delete --guid <entityGUID> --tag tag1 --tag tag2 --tag tag3,tag4",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			err := nrClient.Entities.DeleteTags(entityGUID, entityTags)
@@ -63,14 +74,14 @@ that match the specified keys.
 	},
 }
 
-var entitiesDeleteTagValues = &cobra.Command{
-	Use:   "delete-tag-values",
+var cmdTagsDeleteValues = &cobra.Command{
+	Use:   "delete-values",
 	Short: "Delete the given tag/value pairs from the given entity",
 	Long: `Delete the given tag/value pairs from the given entity
 
-The delete-tags command deletes the specified tag:value pairs on a given entity.
+The delete-values command deletes the specified tag:value pairs on a given entity.
 `,
-	Example: "newrelic entities delete-tag-values --guid <guid> --tag tag1:value1",
+	Example: "newrelic entity tags delete-values --guid <guid> --tag tag1:value1",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tagValues, err := assembleTagValues(entityValues)
@@ -86,14 +97,14 @@ The delete-tags command deletes the specified tag:value pairs on a given entity.
 	},
 }
 
-var entitiesCreateTags = &cobra.Command{
-	Use:   "create-tags",
+var cmdTagsCreate = &cobra.Command{
+	Use:   "create",
 	Short: "Create tag:value pairs for the given entity",
 	Long: `Create tag:value pairs for the given entity
 
-The create-tags command adds tag:value pairs to the given entity.
+The create command adds tag:value pairs to the given entity.
 `,
-	Example: "newrelic entities create-tags --guid <entityGUID> --tag tag1:value1",
+	Example: "newrelic entity tags create --guid <entityGUID> --tag tag1:value1",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := assembleTags(entityTags)
@@ -109,15 +120,15 @@ The create-tags command adds tag:value pairs to the given entity.
 	},
 }
 
-var entitiesReplaceTags = &cobra.Command{
-	Use:   "replace-tags",
+var cmdTagsReplace = &cobra.Command{
+	Use:   "replace",
 	Short: "Replace tag:value pairs for the given entity",
 	Long: `Replace tag:value pairs for the given entity
 
-The replace-tags command replaces any existing tag:value pairs with those
+The replace command replaces any existing tag:value pairs with those
 provided for the given entity.
 `,
-	Example: "newrelic entities replace-tags --guid <entityGUID> --tag tag1:value1",
+	Example: "newrelic entity tags replace --guid <entityGUID> --tag tag1:value1",
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := assembleTags(entityTags)
@@ -201,61 +212,63 @@ func assembleTagValue(tagValueString string) (entities.TagValue, error) {
 func init() {
 	var err error
 
-	Command.AddCommand(entitiesDescribeTags)
-	entitiesDescribeTags.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to retrieve tags for")
-	err = entitiesDescribeTags.MarkFlagRequired("guid")
+	Command.AddCommand(cmdTags)
+
+	cmdTags.AddCommand(cmdTagsGet)
+	cmdTagsGet.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to retrieve tags for")
+	err = cmdTagsGet.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}
 
-	Command.AddCommand(entitiesDeleteTags)
-	entitiesDeleteTags.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tags on")
-	entitiesDeleteTags.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag keys to delete from the entity")
-	err = entitiesDeleteTags.MarkFlagRequired("guid")
+	cmdTags.AddCommand(cmdTagsDelete)
+	cmdTagsDelete.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tags on")
+	cmdTagsDelete.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag keys to delete from the entity")
+	err = cmdTagsDelete.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}
 
-	err = entitiesDeleteTags.MarkFlagRequired("tag")
+	err = cmdTagsDelete.MarkFlagRequired("tag")
 	if err != nil {
 		log.Error(err)
 	}
 
-	Command.AddCommand(entitiesDeleteTagValues)
-	entitiesDeleteTagValues.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tag values on")
-	entitiesDeleteTagValues.Flags().StringSliceVarP(&entityValues, "value", "v", []string{}, "the tag key:value pairs to delete from the entity")
-	err = entitiesDeleteTagValues.MarkFlagRequired("guid")
+	cmdTags.AddCommand(cmdTagsDeleteValues)
+	cmdTagsDeleteValues.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tag values on")
+	cmdTagsDeleteValues.Flags().StringSliceVarP(&entityValues, "value", "v", []string{}, "the tag key:value pairs to delete from the entity")
+	err = cmdTagsDeleteValues.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}
 
-	err = entitiesDeleteTagValues.MarkFlagRequired("value")
+	err = cmdTagsDeleteValues.MarkFlagRequired("value")
 	if err != nil {
 		log.Error(err)
 	}
 
-	Command.AddCommand(entitiesCreateTags)
-	entitiesCreateTags.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to create tag values on")
-	entitiesCreateTags.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to add to the entity")
-	err = entitiesCreateTags.MarkFlagRequired("guid")
+	cmdTags.AddCommand(cmdTagsCreate)
+	cmdTagsCreate.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to create tag values on")
+	cmdTagsCreate.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to add to the entity")
+	err = cmdTagsCreate.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}
 
-	err = entitiesCreateTags.MarkFlagRequired("tag")
+	err = cmdTagsCreate.MarkFlagRequired("tag")
 	if err != nil {
 		log.Error(err)
 	}
 
-	Command.AddCommand(entitiesReplaceTags)
-	entitiesReplaceTags.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to replace tag values on")
-	entitiesReplaceTags.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to replace on the entity")
-	err = entitiesReplaceTags.MarkFlagRequired("guid")
+	cmdTags.AddCommand(cmdTagsReplace)
+	cmdTagsReplace.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to replace tag values on")
+	cmdTagsReplace.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to replace on the entity")
+	err = cmdTagsReplace.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}
 
-	err = entitiesReplaceTags.MarkFlagRequired("tag")
+	err = cmdTagsReplace.MarkFlagRequired("tag")
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/entities/command_tags_test.go
+++ b/internal/entities/command_tags_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEntitiesDescribeTags(t *testing.T) {
-	assert.Equal(t, "describe-tags", entitiesDescribeTags.Name())
+func TestEntitiesGetTags(t *testing.T) {
+	assert.Equal(t, "get", cmdTagsGet.Name())
 
 	requiredFlags := []string{"guid"}
 
 	for _, r := range requiredFlags {
-		x := entitiesDescribeTags.Flag(r)
+		x := cmdTagsGet.Flag(r)
 		if x == nil {
 			t.Errorf("missing required flag: %s\n", r)
 			continue
@@ -28,12 +28,12 @@ func TestEntitiesDescribeTags(t *testing.T) {
 }
 
 func TestEntitiesDeleteTags(t *testing.T) {
-	assert.Equal(t, "delete-tags", entitiesDeleteTags.Name())
+	assert.Equal(t, "delete", cmdTagsDelete.Name())
 
 	requiredFlags := []string{"guid", "tag"}
 
 	for _, r := range requiredFlags {
-		x := entitiesDeleteTags.Flag(r)
+		x := cmdTagsDelete.Flag(r)
 		if x == nil {
 			t.Errorf("missing required flag: %s\n", r)
 			continue
@@ -44,12 +44,12 @@ func TestEntitiesDeleteTags(t *testing.T) {
 }
 
 func TestEntitiesDeleteTagValues(t *testing.T) {
-	assert.Equal(t, "delete-tag-values", entitiesDeleteTagValues.Name())
+	assert.Equal(t, "delete-values", cmdTagsDeleteValues.Name())
 
 	requiredFlags := []string{"guid", "value"}
 
 	for _, r := range requiredFlags {
-		x := entitiesDeleteTagValues.Flag(r)
+		x := cmdTagsDeleteValues.Flag(r)
 		if x == nil {
 			t.Errorf("missing required flag: %s\n", r)
 			continue
@@ -60,8 +60,8 @@ func TestEntitiesDeleteTagValues(t *testing.T) {
 }
 
 func TestEntitiesCreateTags(t *testing.T) {
-	cur := *entitiesCreateTags
-	assert.Equal(t, "create-tags", cur.Name())
+	cur := *cmdTagsCreate
+	assert.Equal(t, "create", cur.Name())
 
 	requiredFlags := []string{"guid", "tag"}
 
@@ -77,8 +77,8 @@ func TestEntitiesCreateTags(t *testing.T) {
 }
 
 func TestEntitiesReplaceTags(t *testing.T) {
-	cur := *entitiesReplaceTags
-	assert.Equal(t, "replace-tags", cur.Name())
+	cur := *cmdTagsReplace
+	assert.Equal(t, "replace", cur.Name())
 
 	requiredFlags := []string{"guid", "tag"}
 


### PR DESCRIPTION
First pass at some command cleanup for the `entities` package related to #110 

* Renames all the variables to standards we discussed
* Adds a middle command `tags` which I'm not sure I love TBH (or could be `tag`)

### Entity

```bash
$ ./bin/darwin/newrelic entity
Subcommands to interact with New Relic entities

Usage:
  newrelic entity [command]

Available Commands:
  search      Search for New Relic entities
  tags        Manage tags on New Relic entities

Flags:
  -h, --help   help for entity

Use "newrelic entity [command] --help" for more information about a command.
FATA[0000] subcommand is required
```

### Search
```
$ ./bin/darwin/newrelic entity search -h
Search for New Relic entities

The search command performs a search for New Relic entities. Optionally, you can
provide additional search flags as filters to narrow search results. Use --help for
more information.

Usage:
  newrelic entity search [flags]

Examples:
newrelic entity search --name test

Flags:
  -a, --alert-severity string      search for results matching the given alert severity type
  -f, --attribute-filter strings   Only return the specific attributes for each entity result
  -d, --domain string              results matching the given entity domain
  -h, --help                       help for search
  -n, --name string                results matching the given name
  -r, --reporting string           search for results based on whether or not an entity is reporting (true or false)
      --tag string                 search for results matching the given entity tag
  -t, --type string                results matching the given type
```

### Tags
```bash
$ ./bin/darwin/newrelic entity tags help
Manage entity tags

The tag command allows users to manage the ags that are applied on the specified
entity. Use --help for more information.

Usage:
  newrelic entity tags [command]

Examples:
newrelic entity tags describe --guid <guid>

Available Commands:
  create        Create tag:value pairs for the given entitiy
  delete        Delete the given tag:value pairs from the given entitiy
  delete-values Delete the given tag/value pairs from the given entitiy
  describe      Describe the tags for a given entity
  replace       Replace tag:value pairs for the given entitiy

Flags:
  -h, --help   help for tags

Use "newrelic entity tags [command] --help" for more information about a command.
FATA[0000] subcommand is required
```