### PR TITLE
Do not log fatal error if Cobra is printing out the help

### DIFF
--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	// Commands
 	"github.com/newrelic/newrelic-cli/internal/apm"
@@ -36,6 +37,8 @@ func init() {
 
 func main() {
 	if err := Execute(); err != nil {
-		log.Fatal(err)
+		if err != cobra.ErrSubCommandRequired {
+			log.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
Minor issue, but entirely distracting to me...

### Before

```
$ ./bin/darwin/newrelic entities
Interact with New Relic entities

Usage:
  newrelic entities [command]

Available Commands:
  create-tags       Create tag:value pairs for the given entity
  delete-tag-values Delete the given tag/value pairs from the given entity
  delete-tags       Delete the given tag:value pairs from the given entity
  describe-tags     Describe the tags for a given entity
  replace-tags      Replace tag:value pairs for the given entity
  search            Search for New Relic entities

Flags:
  -h, --help   help for entities

Use "newrelic entities [command] --help" for more information about a command.
FATA[0000] subcommand is required
```
That Last Line ^^^

### After

```
$ ./bin/darwin/newrelic entities
Interact with New Relic entities

Usage:
  newrelic entities [command]

Available Commands:
  create-tags       Create tag:value pairs for the given entity
  delete-tag-values Delete the given tag/value pairs from the given entity
  delete-tags       Delete the given tag:value pairs from the given entity
  describe-tags     Describe the tags for a given entity
  replace-tags      Replace tag:value pairs for the given entity
  search            Search for New Relic entities

Flags:
  -h, --help   help for entities

Use "newrelic entities [command] --help" for more information about a command.
```