### PR TITLE
Initial work on defining a CircleCI Orb for the CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ build-ci: check-version clean lint test compile-only
 clean: cover-clean compile-clean release-clean
 
 # Import fragments
+include build/circleci.mk
 include build/compile.mk
 include build/deps.mk
 include build/docker.mk

--- a/build/circleci.mk
+++ b/build/circleci.mk
@@ -1,0 +1,30 @@
+#
+# Makefile fragment for CircleCI Stuff
+#
+CIRCLE_NAMESPACE ?= newrelic
+ORB_NAME         ?= cli
+
+CIRCLE_CMD   ?= circleci
+DIST_DIR     ?= ./dist
+ORB_DIR      ?= build/package/circleci-orb
+
+circle-clean:
+	@echo "=== $(PROJECT_NAME) === [ circle-clean         ]: distribution files..."
+	@rm -rfv $(DIST_DIR)/*
+
+circle-orb-pack:
+	@echo "=== $(PROJECT_NAME) === [ circle-orb-pack      ]: Creating orb config from '$(ORB_DIR)'"
+	@mkdir -p $(DIST_DIR)
+	@$(CIRCLE_CMD) config pack $(ORB_DIR) > $(DIST_DIR)/orb.yml
+
+circle-orb-validate: circle-orb-pack
+	@echo "=== $(PROJECT_NAME) === [ circle-orb-validate  ]: Validating orb..."
+	@$(CIRCLE_CMD) orb validate $(DIST_DIR)/orb.yml
+
+circle-orb-publish: circle-orb-pack circle-orb-validate
+	@echo "=== $(PROJECT_NAME) === [ circle-orb-validate  ]: Publishing  orb to dev..."
+	@$(CIRCLE_CMD) orb publish $(DIST_DIR)/orb.yml $(CIRCLE_NAMESPACE)/$(ORB_NAME)@dev:$(PROJECT_VER_TAGGED)
+
+circle-orb: circle-clean circle-orb-pack circle-orb-validate circle-orb-publish
+
+.PHONY: circle-clean circle-orb circle-orb-pack circle-orb-publish circle-orb-validate

--- a/build/package/circleci-orb/@orb.yml
+++ b/build/package/circleci-orb/@orb.yml
@@ -1,0 +1,8 @@
+version: 2.1
+description: >
+  Integrate New Relic with your CircleCI CI/CD pipeline easily with the newrelic/cli orb.
+display:
+  home_url: https://developer.newrelic.com
+  source_url: https://github.com/newrelic/newrelic-cli
+
+

--- a/build/package/circleci-orb/commands/mark-deployment.yml
+++ b/build/package/circleci-orb/commands/mark-deployment.yml
@@ -1,0 +1,44 @@
+description: Create a New Relic APM Deployment marker for your application
+
+parameters:
+  applicationId:
+    description: The New Relic Application ID to create the marker for
+    type: string
+    default: ${NEW_RELIC_APPLICATION_ID}
+
+  accountId:
+    description: The New Relic Account ID where the application is reporting
+    type: string
+    default: ${NEW_RELIC_ACCOUNT_ID}
+
+  apiKey:
+    description: The New Relic Personal API key used to create the deployment marker
+    type: string
+    default: ${NEW_RELIC_API_KEY}
+
+  revision:
+    description: The code revision for this deployment
+    type: string
+    default: ${CIRCLE_SHA1}
+
+  user:
+    description: Name recorded as making the deployment
+    type: string
+    default: ${CIRCLE_USERNAME}
+
+  description:
+    description: Text describing the deployment
+    type: string
+    default: Marker created by CircleCI build ${CIRCLE_BUILD_NUM}
+
+  changelog:
+    description: Change log for this deployment
+    type: string
+
+steps:
+  - run:
+      name: New Relic CLI - APM Deployment
+      command: |
+        echo "Not implemented"
+
+

--- a/build/package/circleci-orb/commands/mark-deployment.yml
+++ b/build/package/circleci-orb/commands/mark-deployment.yml
@@ -16,6 +16,11 @@ parameters:
     type: string
     default: ${NEW_RELIC_API_KEY}
 
+  region:
+    description: The New Relic Region the application is reporting to
+    type: string
+    default: ${NEW_RELIC_REGION}
+
   revision:
     description: The code revision for this deployment
     type: string
@@ -39,6 +44,22 @@ steps:
   - run:
       name: New Relic CLI - APM Deployment
       command: |
-        echo "Not implemented"
+        export NEW_RELIC_API_KEY=<< parameters.apiKey >>
+        <<# parameters.region >>
+          export NEW_RELIC_REGION=<< parameters.region >>
+        <</ parameters.region >>
+
+        /bin/newrelic apm deployment create \
+          --applicationId << parameters.applicationId >> \
+          --revision << parameters.revision >> \
+          <<# parameters.changelog >>
+          --change-log << parameters.changelog >> \
+          <</ parameters.changelog >>
+          <<# parameters.description >>
+          --description << parameters.description >> \
+          <</ parameters.description >>
+          <<# parameters.user >>
+          --user << parameters.user >>
+          <</ parameters.user >>
 
 

--- a/build/package/circleci-orb/examples/mark-deployment.yml
+++ b/build/package/circleci-orb/examples/mark-deployment.yml
@@ -1,0 +1,26 @@
+description: "Create a New Relic APM Application deployment marker. More docs here: https://github.com/newrelic/newrelic-cli"
+
+usage:
+  version: 2.1
+
+  orbs:
+    newrelic: newrelic/cli@x.y.z
+
+  jobs:
+    build:
+      docker:
+        - image: <docker image>
+      steps:
+        - newrelic/mark-deployment:
+            applicationId: "1234567"                   # (required) The New Relic Application ID to create the marker for
+            apiKey:        "<My New Relic API Key>"    # (required) The New Relic Personal API key used to create the deployment marker (Default: $NEW_RELIC_API_KEY)
+            accountId:     "<My New Relic Account ID>" # (required) The New Relic Account ID where the application is reporting (Default: $NEW_RELIC_ACCOUNT_ID)
+            revision:      "v0.1.0"                    # (optional) The code revision for this deployment (Default: $CIRCLE_SHA1)
+            user:          "My Username"               # (optional) Name recorded as making the deployment (Default: $CIRCLE_USERNAME)
+            description:   "My test deployment"        # (optional) Text describing the deployment (Default: 'Marker created by CircleCI build ${CIRCLE_BUILD_NUM}')
+            changelog:     "Lots of stuff changes"     # (optional) Change log for this deployment
+
+  workflows:
+    your-workflow:
+      jobs:
+        - build

--- a/build/package/circleci-orb/executors/default.yml
+++ b/build/package/circleci-orb/executors/default.yml
@@ -1,0 +1,5 @@
+resource_class: small
+docker:
+  - image: newrelic/cli:latest
+    environment:
+      TERM: dumb


### PR DESCRIPTION
Creating a CircleCI Orb with a single command (to be implemented...)

Requirements to finish:
- [ ] Get CirlceCI setup so we can create orbs (request out to admins)
- [X] Create base orb setup
- [X] Create mark-deployment command
- [X] Create mark-deployment usage example
- [ ] Implement mark-deployment
- [ ] Release automation for publishing the orb
- [ ] Testing, testing, testing

Example usage:
```yaml
usage:
  version: 2.1

  orbs:
    newrelic: newrelic/cli@x.y.z

  jobs:
    build:
      docker:
        - image: <docker image>
      steps:
        - newrelic/mark-deployment:
            applicationId: "1234567"                   # (required) The New Relic Application ID to create the marker for
            apiKey:        "<My New Relic API Key>"    # (required) The New Relic Personal API key used to create the deployment marker (Default: $NEW_RELIC_API_KEY)
            accountId:     "<My New Relic Account ID>" # (required) The New Relic Account ID where the application is reporting (Default: $NEW_RELIC_ACCOUNT_ID)
            revision:      "v0.1.0"                    # (optional) The code revision for this deployment (Default: $CIRCLE_SHA1)
            user:          "My Username"               # (optional) Name recorded as making the deployment (Default: $CIRCLE_USERNAME)
            description:   "My test deployment"        # (optional) Text describing the deployment (Default: 'Marker created by CircleCI build ${CIRCLE_BUILD_NUM}')
            changelog:     "Lots of stuff changes"     # (optional) Change log for this deployment

  workflows:
    your-workflow:
      jobs:
        - build
```