### PR TITLE
feat(workloads): add a workloads subcommand

### DIFF
--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/entities"
 	"github.com/newrelic/newrelic-cli/internal/nerdgraph"
+	"github.com/newrelic/newrelic-cli/internal/workload"
 )
 
 var (
@@ -24,6 +25,7 @@ func init() {
 	Command.AddCommand(apm.Command)
 	Command.AddCommand(config.Command)
 	Command.AddCommand(nerdgraph.Command)
+	Command.AddCommand(workload.Command)
 }
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/llorllale/go-gitlint v0.0.0-20190914155841-58c0b8cef0e5
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go v0.16.0
+	github.com/newrelic/newrelic-client-go v0.18.0
 	github.com/psampaz/go-mod-outdated v0.5.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -201,8 +201,6 @@ github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee h1:J2XAy40+7yz70u
 github.com/golangci/gocyclo v0.0.0-20180528134321-2becd97e67ee/go.mod h1:ozx7R9SIwqmqf5pRP90DhR2Oay2UIjGuKheCBCNwAYU=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a h1:iR3fYXUjHCR97qWS8ch1y9zPNsgXThGwjKPrYfqMPks=
 github.com/golangci/gofmt v0.0.0-20190930125516-244bba706f1a/go.mod h1:9qCChq59u/eW8im404Q2WWTrnBUQKjpNYKMbU4M7EFU=
-github.com/golangci/golangci-lint v1.23.8 h1:NlD+Ld2TKH8qVmADy4iEvPxVmXaqPIeQu3d1cGQP4jc=
-github.com/golangci/golangci-lint v1.23.8/go.mod h1:g/38bxfhp4rI7zeWSxcdIeHTQGS58TCak8FYcyCmavQ=
 github.com/golangci/golangci-lint v1.24.0 h1:OcmSTTMPqI/VT4GvN1fKuE9NX15dDXIwolO0l08334U=
 github.com/golangci/golangci-lint v1.24.0/go.mod h1:yIqiAZ2SSQqg+1JeFlAdvEWjGVz4uu5jr4lrciqA1gE=
 github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc h1:gLLhTLMk2/SutryVJ6D4VZCU3CUqr8YloG7FPIBWFpI=
@@ -259,12 +257,8 @@ github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/goreleaser/goreleaser v0.128.0 h1:H+eD0N/Ypvy6ltmNG1aDysUrXps0teCdr4B2QO60dyg=
-github.com/goreleaser/goreleaser v0.128.0/go.mod h1:YE06TwR5768HesL2uap5HnSSofE+4Y1CzKHP6ArDX8A=
 github.com/goreleaser/goreleaser v0.129.0 h1:hJHsgxxNck3oe/MU4K+yznH2qgAVGNcxARTRP8ODSRk=
 github.com/goreleaser/goreleaser v0.129.0/go.mod h1:tzHV+xcU9AJMYNby0QS0lHm1DRrTCBkJXW9ic2reepY=
-github.com/goreleaser/nfpm v1.1.10 h1:0nwzKUJTcygNxTzVKq2Dh9wpVP1W2biUH6SNKmoxR3w=
-github.com/goreleaser/nfpm v1.1.10/go.mod h1:oOcoGRVwvKIODz57NUfiRwFWGfn00NXdgnn6MrYtO5k=
 github.com/goreleaser/nfpm v1.2.1 h1:AEnu9XVmupRDTR930Z2rAs31Mj6sLIPxFcR9ESYvgDA=
 github.com/goreleaser/nfpm v1.2.1/go.mod h1:TtWrABZozuLOttX2uDlYyECfQX7x5XYkVxhjYcR6G9w=
 github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
@@ -395,8 +389,8 @@ github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/newrelic/newrelic-client-go v0.16.0 h1:gNc2rAGIyZ3Nk/MpEGuXfKSaPQ1w7tLhAM9f6IFx8Mw=
-github.com/newrelic/newrelic-client-go v0.16.0/go.mod h1:t5cDNddE1yqC6ph7VdeRbFoVMZrxY06d0+xseKQozfY=
+github.com/newrelic/newrelic-client-go v0.18.0 h1:fkjjRwR7Nb/kWy1UgkuuqQGE4gtpckZxCdWRdnBKD/Y=
+github.com/newrelic/newrelic-client-go v0.18.0/go.mod h1:A2j/O6Wcy7z1sgI49wr5LGsg+5fj171BvPLJI6DmLI4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -516,8 +510,6 @@ github.com/tj/go-kinesis v0.0.0-20171128231115-08b17f58cb1b/go.mod h1:/yhzCV0xPf
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 h1:LnC5Kc/wtumK+WB441p7ynQJzVuNRJiqddSIE3IlSEQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tommy-muehle/go-mnd v1.1.1 h1:4D0wuPKjOTiK2garzuPGGvm4zZ/wLYDOH8TJSABC7KU=
-github.com/tommy-muehle/go-mnd v1.1.1/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa h1:RC4maTWLKKwb7p1cnoygsbKIgNlJqSYBeAFON3Ar8As=
 github.com/tommy-muehle/go-mnd v1.3.1-0.20200224220436-e6f9a994e8fa/go.mod h1:dSUh0FtTP8VhvkL1S+gUR1OKd9ZnSaozuI6r3m6wOig=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
@@ -542,8 +534,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/xanzy/go-gitlab v0.27.0 h1:zy7xBB8+PID6izH07ZArtkEisJ192dtQajRaeo4+glg=
-github.com/xanzy/go-gitlab v0.27.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xanzy/go-gitlab v0.28.0 h1:nsyjDVvBrP4KRXEN4b1m1ewiqmTNL4BOWW041nKGV7k=
 github.com/xanzy/go-gitlab v0.28.0/go.mod h1:t4Bmvnxj7k37S4Y17lfLx+nLqkf/oQwT2HagfWKv5Og=
 github.com/xanzy/ssh-agent v0.2.0 h1:Adglfbi5p9Z0BmK2oKU9nTG+zKfniSfnaMYB+ULd+Ro=
@@ -682,7 +672,6 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190521203540-521d6ed310dd/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190719005602-e377ae9d6386/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20190910044552-dd2b5c81c578/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -692,8 +681,6 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200102140908-9497f49d5709/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200204192400-7124308813f3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/tools v0.0.0-20200305224536-de023d59a5d1 h1:A6Mu2vcvuNXbBiGKuVHG74fmEPmzsZ5dzG0WhV2GcqI=
-golang.org/x/tools v0.0.0-20200305224536-de023d59a5d1/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/tools v0.0.0-20200317190434-d05f4d6edb1c h1:RO17pvmq2QtgOGu4jHRnfyUW3VB9v6zlpzL1HqBfYCI=
 golang.org/x/tools v0.0.0-20200317190434-d05f4d6edb1c/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
@@ -770,8 +757,6 @@ gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
-honnef.co/go/tools v0.0.1-2019.2.3 h1:3JgtbtFHMiCmsznwGVTUWbgGov+pVqnlf1dEJTNAXeM=
-honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3 h1:sXmLre5bzIR6ypkjXCDI3jHPssRhc8KD/Ome589sc3U=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed h1:WX1yoOaKQfddO/mLzdV4wptyWgoH/6hwLs7QHTixo0I=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-client-go/newrelic"
+	clientConfig "github.com/newrelic/newrelic-client-go/pkg/config"
 )
 
 var (
@@ -42,7 +43,7 @@ func CreateNRClient(cfg *config.Config, creds *credentials.Credentials) (*newrel
 	nrClient, err := newrelic.New(
 		newrelic.ConfigPersonalAPIKey(apiKey),
 		newrelic.ConfigLogLevel(cfg.LogLevel),
-		newrelic.ConfigRegion(region),
+		newrelic.ConfigRegion(clientConfig.RegionType(region)),
 		newrelic.ConfigUserAgent(userAgent),
 		newrelic.ConfigServiceName(serviceName),
 	)

--- a/internal/nerdgraph/command.go
+++ b/internal/nerdgraph/command.go
@@ -7,5 +7,5 @@ import (
 // Command represents the nerdgraph command.
 var Command = &cobra.Command{
 	Use:   "nerdgraph",
-	Short: "Execute GraphQL requests to the NerdGraph API.",
+	Short: "Execute GraphQL requests to the NerdGraph API",
 }

--- a/internal/workload/command.go
+++ b/internal/workload/command.go
@@ -7,5 +7,5 @@ import (
 // Command represents the workloads command.
 var Command = &cobra.Command{
 	Use:   "workload",
-	Short: "Interact with New Relic One workloads.",
+	Short: "Interact with New Relic One workloads",
 }

--- a/internal/workload/command.go
+++ b/internal/workload/command.go
@@ -1,0 +1,11 @@
+package workload
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Command represents the workloads command.
+var Command = &cobra.Command{
+	Use:   "workload",
+	Short: "Interact with New Relic One workloads.",
+}

--- a/internal/workload/command_test.go
+++ b/internal/workload/command_test.go
@@ -1,0 +1,18 @@
+// +build unit
+
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestNerdGraphCommand(t *testing.T) {
+	assert.Equal(t, "workload", Command.Name())
+
+	testcobra.CheckCobraMetadata(t, Command)
+	testcobra.CheckCobraRequiredFlags(t, Command, []string{})
+}

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -107,12 +107,18 @@ you also have access to.
 				createInput.ScopeAccountsInput = &workloads.ScopeAccountsInput{AccountIDs: scopeAccountIDs}
 			}
 
-			_, err := nrClient.Workloads.CreateWorkload(accountID, createInput)
+			workload, err := nrClient.Workloads.CreateWorkload(accountID, createInput)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			json, err := prettyjson.Marshal(workload)
 			if err != nil {
 				log.Fatal(err)
 			}
 
 			log.Info("success")
+			fmt.Println(string(json))
 		})
 	},
 }
@@ -184,12 +190,18 @@ compose the new name.
 				}
 			}
 
-			_, err := nrClient.Workloads.DuplicateWorkload(accountID, guid, duplicateInput)
+			workload, err := nrClient.Workloads.DuplicateWorkload(accountID, guid, duplicateInput)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			json, err := prettyjson.Marshal(workload)
 			if err != nil {
 				log.Fatal(err)
 			}
 
 			log.Info("success")
+			fmt.Println(string(json))
 		})
 	},
 }

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -24,11 +24,11 @@ var cmdCreate = &cobra.Command{
 	Long: `Create a New Relic One workload
 
 The create command accepts several different arguments for explicit and dynamic
-workloads.  Entity GUIDs can be provided for explicit inclusion of entities, or
-entity search queries can be provided for dynamic inclusion of entities.  Multiple
-queries will be aggregated together with an OR.  An account scope can optionally
-be provided to include entities from different sub-accounts that you also have
-access to.
+workloads.   Multiple entity GUIDs can be provided for explicit inclusion of entities,
+or multiple entity search queries can be provided for dynamic inclusion of entities.
+Multiple queries will be aggregated together with an OR.  Multiple account scope
+IDs can optionally be provided to include entities from different sub-accounts that
+you also have access to.
 `,
 	Example: `newrelic workload create --name 'Example workload' --accountId 12345678 --entitySearchQuery "name like 'Example application'"`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -62,6 +62,54 @@ access to.
 		})
 	},
 }
+
+var cmdUpdate = &cobra.Command{
+	Use:   "update",
+	Short: "Update a New Relic One workload.",
+	Long: `Update a New Relic One workload
+
+The update command targets an existing workload by its entity GUID, and accepts
+several different arguments for explicit and dynamic workloads.  Multiple entity GUIDs can
+be provided for explicit inclusion of entities, or multiple entity search queries can be
+provided for dynamic inclusion of entities.  Multiple queries will be aggregated
+together with an OR.  Multiple account scope IDs can optionally be provided to include
+entities from different sub-accounts that you also have access to.
+`,
+	Example: `newrelic workload update --guid 'MjUyMDUyOHxBOE28QVBQTElDQVRDT058MjE1MDM3Nzk1' --name 'Updated workflow'`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			updateInput := workloads.UpdateInput{}
+
+			if name != "" {
+				updateInput.Name = &name
+			}
+
+			if len(entityGUIDs) > 0 {
+				updateInput.EntityGUIDs = entityGUIDs
+			}
+
+			if len(entitySearchQueries) > 0 {
+				var queryInputs []workloads.EntitySearchQueryInput
+				for _, q := range entitySearchQueries {
+					queryInputs = append(queryInputs, workloads.EntitySearchQueryInput{Query: q})
+				}
+				updateInput.EntitySearchQueries = queryInputs
+			}
+
+			if len(scopeAccountIDs) > 0 {
+				updateInput.ScopeAccountsInput = &workloads.ScopeAccountsInput{AccountIDs: scopeAccountIDs}
+			}
+
+			_, err := nrClient.Workloads.UpdateWorkload(guid, updateInput)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			log.Info("success")
+		})
+	},
+}
+
 var cmdDelete = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete a New Relic One workload.",
@@ -83,10 +131,11 @@ The delete command accepts a workload's entity GUID.
 }
 
 func init() {
+	// Create
 	Command.AddCommand(cmdCreate)
 	cmdCreate.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID where you want to create the workload")
 	cmdCreate.Flags().StringVarP(&name, "name", "n", "", "the name of the workload")
-	cmdCreate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "g", []string{}, "the list of entity Guids composing the workload")
+	cmdCreate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "e", []string{}, "the list of entity Guids composing the workload")
 	cmdCreate.Flags().StringSliceVarP(&entitySearchQueries, "entitySearchQuery", "q", []string{}, "a list of search queries, combined using an OR operator")
 	cmdCreate.Flags().IntSliceVarP(&scopeAccountIDs, "scopeAccountIds", "s", []int{}, "accounts that will be used to get entities from")
 	err := cmdCreate.MarkFlagRequired("accountId")
@@ -99,8 +148,22 @@ func init() {
 		log.Error(err)
 	}
 
+	// Delete
 	Command.AddCommand(cmdDelete)
 	cmdDelete.Flags().StringVarP(&guid, "guid", "g", "", "the GUID of the workload to delete")
+	if err != nil {
+		log.Error(err)
+	}
+
+	// Update
+	Command.AddCommand(cmdUpdate)
+	cmdUpdate.Flags().StringVarP(&guid, "guid", "g", "", "the GUID of the workload you want to update")
+	cmdUpdate.Flags().StringVarP(&name, "name", "n", "", "the name of the workload")
+	cmdUpdate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "e", []string{}, "the list of entity Guids composing the workload")
+	cmdUpdate.Flags().StringSliceVarP(&entitySearchQueries, "entitySearchQuery", "q", []string{}, "a list of search queries, combined using an OR operator")
+	cmdUpdate.Flags().IntSliceVarP(&scopeAccountIDs, "scopeAccountIds", "s", []int{}, "accounts that will be used to get entities from")
+
+	err = cmdUpdate.MarkFlagRequired("guid")
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -47,6 +47,31 @@ The get command retrieves a specific workload by its account ID and workload ID.
 	},
 }
 
+var cmdList = &cobra.Command{
+	Use:   "list",
+	Short: "List the New Relic One workloads for an account.",
+	Long: `List the New Relic One workloads for an account
+
+The list command retrieves the workloads for the given account ID.
+`,
+	Example: `newrelic workload list --accountId 12345678`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			workload, err := nrClient.Workloads.ListWorkloads(accountID)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			json, err := prettyjson.Marshal(workload)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			fmt.Println(string(json))
+		})
+	},
+}
+
 var cmdCreate = &cobra.Command{
 	Use:   "create",
 	Short: "Create a New Relic One workload.",
@@ -200,6 +225,14 @@ func init() {
 	}
 
 	err = cmdGet.MarkFlagRequired("id")
+	if err != nil {
+		log.Error(err)
+	}
+
+	// List
+	Command.AddCommand(cmdList)
+	cmdList.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID where you want to create the workload")
+	err = cmdList.MarkFlagRequired("accountId")
 	if err != nil {
 		log.Error(err)
 	}

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -1,0 +1,85 @@
+package workload
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-client-go/pkg/workloads"
+)
+
+var (
+	accountID           int
+	name                string
+	entityGUIDs         []string
+	entitySearchQueries []string
+	scopeAccountIDs     []int
+)
+
+var cmdCreate = &cobra.Command{
+	Use:   "create",
+	Short: "Create a New Relic One workload.",
+	Long: `Create a New Relic One workload
+
+The create command accepts several different arguments for explicit and dynamic
+workloads.  Entity GUIDs can be provided for explicit inclusion of entities, or
+entity search queries can be provided for dynamic inclusion of entities.  Multiple
+queries will be aggregated together with an OR.  An account scope can optionally
+be provided to include entities from different sub-accounts that you also have
+access to.
+`,
+	Example: `newrelic workload create --name 'Example workload' --accountId 12345678 --entitySearchQuery "name like 'Example application'"`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			createInput := workloads.CreateInput{
+				Name: name,
+			}
+
+			if len(entityGUIDs) > 0 {
+				createInput.EntityGUIDs = entityGUIDs
+			}
+
+			if len(entitySearchQueries) > 0 {
+				var queryInputs []workloads.EntitySearchQueryInput
+				for _, q := range entitySearchQueries {
+					queryInputs = append(queryInputs, workloads.EntitySearchQueryInput{Query: q})
+				}
+				createInput.EntitySearchQueries = queryInputs
+			}
+
+			if len(scopeAccountIDs) > 0 {
+				createInput.ScopeAccountsInput = &workloads.ScopeAccountsInput{AccountIDs: scopeAccountIDs}
+			}
+
+			_, err := nrClient.Workloads.CreateWorkload(accountID, createInput)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			log.Info("success")
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdCreate)
+	cmdCreate.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID where you want to create the workload")
+	cmdCreate.Flags().StringVarP(&name, "name", "n", "", "the name of the workload")
+	err := cmdCreate.MarkFlagRequired("accountId")
+	if err != nil {
+		log.Error(err)
+	}
+
+	err = cmdCreate.MarkFlagRequired("name")
+	if err != nil {
+		log.Error(err)
+	}
+
+	cmdCreate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "g", []string{}, "the list of entity Guids composing the workload")
+	cmdCreate.Flags().StringSliceVarP(&entitySearchQueries, "entitySearchQuery", "q", []string{}, "a list of search queries, combined using an OR operator")
+	cmdCreate.Flags().IntSliceVarP(&scopeAccountIDs, "scopeAccountIds", "s", []int{}, "accounts that will be used to get entities from")
+}

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/testcobra"
 )
 
+func TestList(t *testing.T) {
+	assert.Equal(t, "list", cmdList.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdList)
+	testcobra.CheckCobraRequiredFlags(t, cmdList, []string{})
+}
+
 func TestGet(t *testing.T) {
 	assert.Equal(t, "get", cmdGet.Name())
 

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -17,16 +17,23 @@ func TestCreate(t *testing.T) {
 	testcobra.CheckCobraRequiredFlags(t, cmdCreate, []string{})
 }
 
-func TestDelete(t *testing.T) {
-	assert.Equal(t, "delete", cmdDelete.Name())
-
-	testcobra.CheckCobraMetadata(t, cmdDelete)
-	testcobra.CheckCobraRequiredFlags(t, cmdDelete, []string{})
-}
-
 func TestUpdate(t *testing.T) {
 	assert.Equal(t, "update", cmdUpdate.Name())
 
 	testcobra.CheckCobraMetadata(t, cmdUpdate)
 	testcobra.CheckCobraRequiredFlags(t, cmdUpdate, []string{})
+}
+
+func TestDuplicate(t *testing.T) {
+	assert.Equal(t, "duplicate", cmdDuplicate.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdDuplicate)
+	testcobra.CheckCobraRequiredFlags(t, cmdDuplicate, []string{})
+}
+
+func TestDelete(t *testing.T) {
+	assert.Equal(t, "delete", cmdDelete.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdDelete)
+	testcobra.CheckCobraRequiredFlags(t, cmdDelete, []string{})
 }

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -10,6 +10,13 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/testcobra"
 )
 
+func TestGet(t *testing.T) {
+	assert.Equal(t, "get", cmdGet.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdGet, []string{})
+}
+
 func TestCreate(t *testing.T) {
 	assert.Equal(t, "create", cmdCreate.Name())
 

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -23,3 +23,10 @@ func TestDelete(t *testing.T) {
 	testcobra.CheckCobraMetadata(t, cmdDelete)
 	testcobra.CheckCobraRequiredFlags(t, cmdDelete, []string{})
 }
+
+func TestUpdate(t *testing.T) {
+	assert.Equal(t, "update", cmdUpdate.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdUpdate)
+	testcobra.CheckCobraRequiredFlags(t, cmdUpdate, []string{})
+}

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -16,3 +16,10 @@ func TestCreate(t *testing.T) {
 	testcobra.CheckCobraMetadata(t, cmdCreate)
 	testcobra.CheckCobraRequiredFlags(t, cmdCreate, []string{})
 }
+
+func TestDelete(t *testing.T) {
+	assert.Equal(t, "delete", cmdDelete.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdDelete)
+	testcobra.CheckCobraRequiredFlags(t, cmdDelete, []string{})
+}

--- a/internal/workload/command_workload_test.go
+++ b/internal/workload/command_workload_test.go
@@ -1,0 +1,18 @@
+// +build unit
+
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestCreate(t *testing.T) {
+	assert.Equal(t, "create", cmdCreate.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdCreate)
+	testcobra.CheckCobraRequiredFlags(t, cmdCreate, []string{})
+}


### PR DESCRIPTION
This PR adds workloads to the CLI.

Output is prettified and sent to stdout for get, list, create, and duplicate methods only.  Otherwise success/failure is indicated on stderr and command exit status.