### PR TITLE
chore(newrelic): update newrelic-client-go to v0.19.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/llorllale/go-gitlint v0.0.0-20190914155841-58c0b8cef0e5
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go v0.18.0
+	github.com/newrelic/newrelic-client-go v0.19.0
 	github.com/psampaz/go-mod-outdated v0.5.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/mozilla/tls-observatory v0.0.0-20190404164649-a3c1b6cfecfd/go.mod h1:
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1ORQBMvzfzBgpsctsbQikCVpvC+tX285E=
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
-github.com/newrelic/newrelic-client-go v0.18.0 h1:fkjjRwR7Nb/kWy1UgkuuqQGE4gtpckZxCdWRdnBKD/Y=
-github.com/newrelic/newrelic-client-go v0.18.0/go.mod h1:A2j/O6Wcy7z1sgI49wr5LGsg+5fj171BvPLJI6DmLI4=
+github.com/newrelic/newrelic-client-go v0.19.0 h1:Rq3fsIHlqv//Qe1CEXLw58dfohcgKZMm6g4R8MRCCb4=
+github.com/newrelic/newrelic-client-go v0.19.0/go.mod h1:A2j/O6Wcy7z1sgI49wr5LGsg+5fj171BvPLJI6DmLI4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -138,10 +138,8 @@ entities from different sub-accounts that you also have access to.
 	Example: `newrelic workload update --guid 'MjUyMDUyOHxBOE28QVBQTElDQVRDT058MjE1MDM3Nzk1' --name 'Updated workflow'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
-			updateInput := workloads.UpdateInput{}
-
-			if name != "" {
-				updateInput.Name = &name
+			updateInput := workloads.UpdateInput{
+				Name: name,
 			}
 
 			if len(entityGUIDs) > 0 {
@@ -183,11 +181,8 @@ compose the new name.
 	Example: `newrelic workload duplicate --guid 'MjUyMDUyOHxBOE28QVBQTElDQVRDT058MjE1MDM3Nzk1' --accountID 12345678 --name 'New Workload'`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
-			var duplicateInput *workloads.DuplicateInput
-			if name != "" {
-				duplicateInput = &workloads.DuplicateInput{
-					Name: &name,
-				}
+			duplicateInput := &workloads.DuplicateInput{
+				Name: name,
 			}
 
 			workload, err := nrClient.Workloads.DuplicateWorkload(accountID, guid, duplicateInput)


### PR DESCRIPTION
This PR updates newrelic-client-go to v0.19.0.