### PR TITLE
chore(client): Sanitize Region override

### DIFF
--- a/internal/client/client_integration_test.go
+++ b/internal/client/client_integration_test.go
@@ -1,0 +1,87 @@
+// +build integration
+
+package client
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-client-go/pkg/region"
+
+	"github.com/newrelic/newrelic-cli/internal/credentials"
+)
+
+var overrideEnvVars = []string{
+	"NEW_RELIC_API_KEY",
+	"NEW_RELIC_REGION",
+}
+
+func TestApplyOverrides(t *testing.T) {
+	// Do not run this in parallel, we are messing with the environment
+
+	f, err := ioutil.TempDir("/tmp", "newrelic")
+	assert.NoError(t, err)
+	defer os.RemoveAll(f)
+
+	// Initialize the new configuration directory
+	c, err := credentials.LoadCredentials(f)
+	assert.NoError(t, err)
+
+	// Create an initial profile to work with
+	err = c.AddProfile("testCase1", "us", "apiKeyGoesHere")
+	assert.NoError(t, err)
+	p := c.Profiles["testCase1"]
+	assert.NotNil(t, p)
+
+	// Clear env vars we are going to mess with, and reset on exit
+	for _, v := range overrideEnvVars {
+		if val, ok := os.LookupEnv(v); ok {
+			defer os.Setenv(v, val)
+			os.Unsetenv(v)
+		}
+	}
+
+	// Default case (no overrides)
+	p2 := applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, p.APIKey, p2.APIKey)
+	assert.Equal(t, p.Region, p2.Region)
+
+	// Override just the API Key
+	os.Setenv("NEW_RELIC_API_KEY", "anotherAPIKey")
+	p2 = applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, "anotherAPIKey", p2.APIKey)
+	assert.Equal(t, p.Region, p2.Region)
+
+	// Both
+	os.Setenv("NEW_RELIC_REGION", "US")
+	p2 = applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, "anotherAPIKey", p2.APIKey)
+	assert.Equal(t, region.US, p2.Region)
+
+	// Override just the REGION (valid)
+	os.Unsetenv("NEW_RELIC_API_KEY")
+	p2 = applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, p.APIKey, p2.APIKey)
+	assert.Equal(t, region.US, p2.Region)
+
+	// Region lowercase
+	os.Setenv("NEW_RELIC_REGION", "eu")
+	p2 = applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, p.APIKey, p2.APIKey)
+	assert.Equal(t, region.EU, p2.Region)
+
+	// Invalid REGION (Should be region.Default)
+	os.Setenv("NEW_RELIC_REGION", "test")
+	p2 = applyOverrides(&p)
+	assert.NotNil(t, p2)
+	assert.Equal(t, p.APIKey, p2.APIKey)
+	assert.Equal(t, region.Default, p2.Region)
+}


### PR DESCRIPTION
Add logic in the overrides function to ensure the regions are valid before continuing.  Region attempt order is ENV, Profile, Default with error messages on every failure.

This should resolve #101 