### PR TITLE
Region fix (again)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/jedib0t/go-pretty v4.3.0+incompatible
 	github.com/llorllale/go-gitlint v0.0.0-20190914155841-58c0b8cef0e5
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/mapstructure v1.2.2
 	github.com/newrelic/newrelic-client-go v0.21.0
 	github.com/psampaz/go-mod-outdated v0.5.0
 	github.com/sirupsen/logrus v1.5.0


### PR DESCRIPTION
Region is still broken when stored in lower-case (nr1 format) with a confusing error:

`FATAL[] unable to create New Relic client with error: unknown region: us, using default: US`

This adds a custom decoder so when the profiles are loaded, we run the region through `region.Parse` to validate them.