### PR TITLE
Custom release note generation

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,42 +1,40 @@
 {{ if .Versions -}}
+{{   if .Unreleased.CommitGroups -}}
 <a name="unreleased"></a>
 ## [Unreleased]
 
-{{ if .Unreleased.CommitGroups -}}
-{{ range .Unreleased.CommitGroups -}}
+{{     range .Unreleased.CommitGroups -}}
 ### {{ .Title }}
-{{ range .Commits -}}
+{{       range .Commits -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{ end }}
-{{ end -}}
-{{ end -}}
-{{ end -}}
+{{       end -}}
+{{     end -}}
+{{   end -}}
 
-{{ range .Versions }}
+{{ range .Versions -}}
 <a name="{{ .Tag.Name }}"></a>
 ## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
-{{ range .CommitGroups -}}
+{{   range .CommitGroups -}}
 ### {{ .Title }}
-{{ range .Commits -}}
+{{     range .Commits -}}
 - {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
-{{ end }}
-{{ end -}}
+{{     end }}
+{{   end -}}
 
-{{- if .NoteGroups -}}
-{{ range .NoteGroups -}}
+{{   if .NoteGroups -}}
+{{     range .NoteGroups -}}
 ### {{ .Title }}
-{{ range .Notes }}
-{{ .Body }}
-{{ end }}
-{{ end -}}
-{{ end -}}
+{{       range .Notes }}
+{{         .Body }}
+{{       end }}
+{{     end -}}
+{{   end -}}
 {{ end -}}
 
-{{- if .Versions }}
 [Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
-{{ range .Versions -}}
-{{ if .Tag.Previous -}}
+{{   range .Versions -}}
+{{     if .Tag.Previous -}}
 [{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
-{{ end -}}
-{{ end -}}
+{{     end -}}
+{{   end -}}
 {{ end -}}

--- a/build/document.mk
+++ b/build/document.mk
@@ -7,8 +7,9 @@ GOTOOLS     += golang.org/x/tools/cmd/godoc \
 GODOC       ?= godoc
 GODOC_HTTP  ?= "localhost:6060"
 
-CHANGELOG_CMD  ?= git-chglog
-CHANGELOG_FILE ?= CHANGELOG.md
+CHANGELOG_CMD      ?= git-chglog
+CHANGELOG_FILE     ?= CHANGELOG.md
+RELEASE_NOTES_FILE ?= relnotes.md
 
 docs: tools
 	@echo "=== $(PROJECT_NAME) === [ docs             ]: Starting godoc server..."
@@ -23,5 +24,9 @@ changelog: tools
 	@echo "=== $(PROJECT_NAME) === [ changelog        ]: Generating changelog..."
 	@$(CHANGELOG_CMD) --silent -o $(CHANGELOG_FILE)
 
+release-notes: tools
+	@echo "=== $(PROJECT_NAME) === [ release-notes    ]: Generating release notes..."
+	@mkdir -p $(SRCDIR)/tmp
+	@$(CHANGELOG_CMD) --silent -o $(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) v$(PROJECT_VER_TAGGED)
 
-.PHONY: docs changelog
+.PHONY: docs changelog release-notes

--- a/build/release.mk
+++ b/build/release.mk
@@ -16,11 +16,11 @@ release: build
 
 release-clean:
 	@echo "=== $(PROJECT_NAME) === [ release-clean    ]: distribution files..."
-	@rm -rfv $(DIST_DIR)
+	@rm -rfv $(DIST_DIR) $(SRCDIR)/tmp
 
-release-publish: clean tools docker-login
+release-publish: clean tools docker-login release-notes
 	@echo "=== $(PROJECT_NAME) === [ release-publish  ]: Publishing release via $(REL_CMD)"
-	$(REL_CMD)
+	$(REL_CMD) --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
 
 # Local Snapshot
 snapshot: release-clean


### PR DESCRIPTION
goreleaser supports (though not well documented) custom release notes.  Since we aren't using the build-in changelog we have not had release notes, and have had to manually add them.  The changes that behavior to automatically generate notes based on the last tag, and use them when goreleaser pushes a new release.