### PR TITLE
Output refactor + formatting options

### DIFF
--- a/cmd/newrelic/command.go
+++ b/cmd/newrelic/command.go
@@ -2,7 +2,13 @@ package main
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 )
+
+var outputFormat string
+var outputPlain bool
 
 // Command represents the base command when called without any subcommands
 var Command = &cobra.Command{
@@ -24,4 +30,16 @@ func Execute() error {
 	Command.SilenceErrors = true
 
 	return Command.Execute()
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	Command.PersistentFlags().StringVar(&outputFormat, "format", output.DefaultFormat.String(), "output text format ["+output.FormatOptions()+"]")
+	Command.PersistentFlags().BoolVar(&outputPlain, "plain", false, "output compact text")
+}
+
+func initConfig() {
+	utils.LogIfError(output.SetFormat(output.ParseFormat(outputFormat)))
+	utils.LogIfError(output.SetPrettyPrint(!outputPlain))
 }

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,5 @@ require (
 	github.com/spf13/viper v1.6.3
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/tools v0.0.0-20200406213809-066fd1390ee0
+	gopkg.in/yaml.v2 v2.2.8
 )

--- a/internal/apm/command_application.go
+++ b/internal/apm/command_application.go
@@ -1,9 +1,6 @@
 package apm
 
 import (
-	"fmt"
-
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -11,6 +8,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 )
 
@@ -77,10 +75,7 @@ The search command performs a query for an APM application name and/or account I
 				utils.LogIfFatal(err)
 			}
 
-			json, err := prettyjson.Marshal(results)
-			utils.LogIfFatal(err)
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(results))
 		})
 	},
 }
@@ -107,10 +102,7 @@ The get command performs a query for an APM application by GUID.
 				log.Fatal(" --guid <entityGUID> is required")
 			}
 
-			json, err := prettyjson.Marshal(results)
-			utils.LogIfFatal(err)
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(results))
 		})
 	},
 }

--- a/internal/apm/command_deployment.go
+++ b/internal/apm/command_deployment.go
@@ -1,9 +1,6 @@
 package apm
 
 import (
-	"fmt"
-
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
@@ -11,6 +8,7 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/apm"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 )
 
@@ -49,10 +47,7 @@ The list command returns deployments for a New Relic APM application.
 			deployments, err := nrClient.APM.ListDeployments(apmAppID)
 			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(deployments)
-			utils.LogIfFatal(err)
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(deployments))
 		})
 	},
 }
@@ -76,10 +71,7 @@ application.
 			d, err := nrClient.APM.CreateDeployment(apmAppID, deployment)
 			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(d)
-			utils.LogIfFatal(err)
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(d))
 		})
 	},
 }
@@ -102,10 +94,7 @@ The delete command performs a delete operation for an APM deployment.
 			d, err := nrClient.APM.DeleteDeployment(apmAppID, deployment.ID)
 			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(d)
-			utils.LogIfFatal(err)
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(d))
 		})
 	},
 }

--- a/internal/entities/command_search.go
+++ b/internal/entities/command_search.go
@@ -1,14 +1,13 @@
 package entities
 
 import (
-	"fmt"
 	"strconv"
 
-	prettyjson "github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
@@ -49,10 +48,7 @@ The search command performs a search for New Relic entities.
 
 			if entityTag != "" {
 				tag, err := assembleTagValue(entityTag)
-
-				if err != nil {
-					log.Fatal(err)
-				}
+				utils.LogIfFatal(err)
 
 				params.Tags = &tag
 			}
@@ -68,33 +64,27 @@ The search command performs a search for New Relic entities.
 			}
 
 			entities, err := nrClient.Entities.SearchEntities(params)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			var json []byte
+			var result interface{}
 
 			if len(entityFields) > 0 {
 				mapped := mapEntities(entities, entityFields, utils.StructToMap)
 
 				if len(mapped) == 1 {
-					json, err = prettyjson.Marshal(mapped[0])
+					result = mapped[0]
 				} else {
-					json, err = prettyjson.Marshal(mapped)
+					result = mapped
 				}
 			} else {
 				if len(entities) == 1 {
-					json, err = prettyjson.Marshal(entities[0])
+					result = entities[0]
 				} else {
-					json, err = prettyjson.Marshal(entities)
+					result = entities
 				}
 			}
 
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(result))
 		})
 	},
 }

--- a/internal/entities/command_tags.go
+++ b/internal/entities/command_tags.go
@@ -2,14 +2,14 @@ package entities
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
-	prettyjson "github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
 )
@@ -41,16 +41,9 @@ The get command returns JSON output of the tags for the requested entity.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := nrClient.Entities.ListTags(entityGUID)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(tags)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(string(json))
+			utils.LogIfError(output.Print(tags))
 		})
 	},
 }
@@ -67,9 +60,7 @@ that match the specified keys.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			err := nrClient.Entities.DeleteTags(entityGUID, entityTags)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -87,14 +78,10 @@ The delete-values command deletes the specified tag:value pairs on a given entit
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tagValues, err := assembleTagValues(entityValues)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			err = nrClient.Entities.DeleteTagValues(entityGUID, tagValues)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -112,14 +99,10 @@ The create command adds tag:value pairs to the given entity.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := assembleTags(entityTags)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			err = nrClient.Entities.AddTags(entityGUID, tags)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -138,14 +121,10 @@ provided for the given entity.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			tags, err := assembleTags(entityTags)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			err = nrClient.Entities.ReplaceTags(entityGUID, tags)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -218,66 +197,33 @@ func assembleTagValue(tagValueString string) (entities.TagValue, error) {
 }
 
 func init() {
-	var err error
-
 	Command.AddCommand(cmdTags)
 
 	cmdTags.AddCommand(cmdTagsGet)
 	cmdTagsGet.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to retrieve tags for")
-	err = cmdTagsGet.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdTagsGet.MarkFlagRequired("guid"))
 
 	cmdTags.AddCommand(cmdTagsDelete)
 	cmdTagsDelete.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tags on")
 	cmdTagsDelete.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag keys to delete from the entity")
-	err = cmdTagsDelete.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdTagsDelete.MarkFlagRequired("tag")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdTagsDelete.MarkFlagRequired("guid"))
+	utils.LogIfError(cmdTagsDelete.MarkFlagRequired("tag"))
 
 	cmdTags.AddCommand(cmdTagsDeleteValues)
 	cmdTagsDeleteValues.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to delete tag values on")
 	cmdTagsDeleteValues.Flags().StringSliceVarP(&entityValues, "value", "v", []string{}, "the tag key:value pairs to delete from the entity")
-	err = cmdTagsDeleteValues.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdTagsDeleteValues.MarkFlagRequired("value")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdTagsDeleteValues.MarkFlagRequired("guid"))
+	utils.LogIfError(cmdTagsDeleteValues.MarkFlagRequired("value"))
 
 	cmdTags.AddCommand(cmdTagsCreate)
 	cmdTagsCreate.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to create tag values on")
 	cmdTagsCreate.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to add to the entity")
-	err = cmdTagsCreate.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdTagsCreate.MarkFlagRequired("tag")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdTagsCreate.MarkFlagRequired("guid"))
+	utils.LogIfError(cmdTagsCreate.MarkFlagRequired("tag"))
 
 	cmdTags.AddCommand(cmdTagsReplace)
 	cmdTagsReplace.Flags().StringVarP(&entityGUID, "guid", "g", "", "the entity GUID to replace tag values on")
 	cmdTagsReplace.Flags().StringSliceVarP(&entityTags, "tag", "t", []string{}, "the tag names to replace on the entity")
-	err = cmdTagsReplace.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdTagsReplace.MarkFlagRequired("tag")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdTagsReplace.MarkFlagRequired("guid"))
+	utils.LogIfError(cmdTagsReplace.MarkFlagRequired("tag"))
 }

--- a/internal/nerdgraph/command_query.go
+++ b/internal/nerdgraph/command_query.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	ng "github.com/newrelic/newrelic-client-go/pkg/nerdgraph"
 )
@@ -64,18 +64,9 @@ keys are the variables to be referenced in the GraphQL query.
 			err = encoder.Encode(ng.QueryResponse{
 				Actor: result.(ng.QueryResponse).Actor,
 			})
+			utils.LogIfFatal(err)
 
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			formatted, err := prettyjson.Format(reqBodyBytes.Bytes())
-
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(bytes.NewBuffer(formatted).String())
+			utils.LogIfFatal(output.Print(reqBodyBytes))
 		})
 	},
 }

--- a/internal/nerdstorage/command_collection.go
+++ b/internal/nerdstorage/command_collection.go
@@ -1,14 +1,13 @@
 package nerdstorage
 
 import (
-	"fmt"
 	"strings"
 
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
@@ -64,13 +63,8 @@ GUID.  A valid Nerdpack package ID is required.
 				log.Fatal(err)
 			}
 
-			json, err := prettyjson.Marshal(resp)
-			if err != nil {
-				log.Fatal(err)
-			}
-
+			utils.LogIfFatal(output.Print(resp))
 			log.Info("success")
-			fmt.Println(string(json))
 		})
 	},
 }

--- a/internal/nerdstorage/command_document.go
+++ b/internal/nerdstorage/command_document.go
@@ -2,14 +2,13 @@ package nerdstorage
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
@@ -66,13 +65,8 @@ GUID.  A valid Nerdpack package ID is required.
 				log.Fatal(err)
 			}
 
-			json, err := prettyjson.Marshal(document)
-			if err != nil {
-				log.Fatal(err)
-			}
-
+			utils.LogIfFatal(output.Print(document))
 			log.Info("success")
-			fmt.Println(string(json))
 		})
 	},
 }

--- a/internal/output/config.go
+++ b/internal/output/config.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"fmt"
+
+	"github.com/hokaccha/go-prettyjson"
+)
+
+// New creates a new outputter with the specific config options
+func New(opts ...ConfigOption) (*Output, error) {
+	config := Output{
+		format:      FormatJSON,
+		prettyPrint: true,
+	}
+
+	// Loop through config options
+	for _, fn := range opts {
+		if nil != fn {
+			if err := fn(&config); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	switch config.format {
+	case FormatJSON:
+		config.jsonFormatter = prettyjson.NewFormatter()
+		if !config.prettyPrint {
+			config.jsonFormatter.DisabledColor = true
+			config.jsonFormatter.Indent = 0
+			config.jsonFormatter.Newline = ""
+		}
+	default:
+		return nil, fmt.Errorf("unsupported output format %#v", config.format)
+	}
+
+	return &config, nil
+}
+
+type ConfigOption func(*Output) error
+
+func ConfigFormat(format Format) ConfigOption {
+	return func(cfg *Output) error {
+		cfg.format = format
+		return nil
+	}
+}
+
+func ConfigPrettyPrint(pretty bool) ConfigOption {
+	return func(cfg *Output) error {
+		cfg.prettyPrint = pretty
+		return nil
+	}
+}

--- a/internal/output/config.go
+++ b/internal/output/config.go
@@ -1,40 +1,28 @@
 package output
 
 import (
-	"fmt"
-
 	"github.com/hokaccha/go-prettyjson"
 )
 
 // New creates a new outputter with the specific config options
 func New(opts ...ConfigOption) (*Output, error) {
-	config := Output{
-		format:      FormatJSON,
-		prettyPrint: true,
+	config := &Output{
+		format:      DefaultFormat,
+		prettyPrint: DefaultPretty,
 	}
 
 	// Loop through config options
 	for _, fn := range opts {
 		if nil != fn {
-			if err := fn(&config); err != nil {
+			if err := fn(config); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	switch config.format {
-	case FormatJSON:
-		config.jsonFormatter = prettyjson.NewFormatter()
-		if !config.prettyPrint {
-			config.jsonFormatter.DisabledColor = true
-			config.jsonFormatter.Indent = 0
-			config.jsonFormatter.Newline = ""
-		}
-	default:
-		return nil, fmt.Errorf("unsupported output format %#v", config.format)
-	}
+	config.jsonFormatter = prettyjson.NewFormatter()
 
-	return &config, nil
+	return config, nil
 }
 
 type ConfigOption func(*Output) error

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -6,6 +6,26 @@ import (
 	"fmt"
 )
 
+// jsonSetPrettyPrint toggles the pretty printing within
+// the json formatter
+func (o *Output) jsonSetPrettyPrint(pretty bool) error {
+	if o == nil || o.jsonFormatter == nil {
+		return errors.New("invalid output formatter")
+	}
+
+	if pretty {
+		o.jsonFormatter.DisabledColor = false
+		o.jsonFormatter.Indent = 2
+		o.jsonFormatter.Newline = "\n"
+	} else {
+		o.jsonFormatter.DisabledColor = true
+		o.jsonFormatter.Indent = 0
+		o.jsonFormatter.Newline = ""
+	}
+
+	return nil
+}
+
 // JSON prints out data as JSON
 func (o *Output) json(data interface{}) error {
 	var (
@@ -21,6 +41,9 @@ func (o *Output) json(data interface{}) error {
 	if o == nil || o.jsonFormatter == nil {
 		return errors.New("invalid output formatter")
 	}
+
+	// ensure right printing config
+	o.jsonSetPrettyPrint(o.prettyPrint)
 
 	// Let's see what they sent us
 	switch d := data.(type) {

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -1,0 +1,42 @@
+package output
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+)
+
+// JSON prints out data as JSON
+func (o *Output) json(data interface{}) error {
+	var (
+		formatted []byte
+		err       error
+	)
+
+	// Early quit on no data
+	if data == nil {
+		return nil
+	}
+
+	if o == nil || o.jsonFormatter == nil {
+		return errors.New("invalid output formatter")
+	}
+
+	// Let's see what they sent us
+	switch d := data.(type) {
+	case *bytes.Buffer:
+		formatted, err = o.jsonFormatter.Format(d.Bytes())
+	case []byte:
+		formatted, err = o.jsonFormatter.Format(d)
+	default:
+		formatted, err = o.jsonFormatter.Marshal(d)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(bytes.NewBuffer(formatted).String())
+
+	return nil
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,64 @@
+package output
+
+import (
+	"github.com/hokaccha/go-prettyjson"
+
+	"github.com/newrelic/newrelic-cli/internal/utils"
+)
+
+// globalOutput is the package level config of Output
+var globalOutput *Output
+
+// Format provides the list of output formats supported
+type Format uint
+
+const (
+	FormatJSON Format = iota
+	FormatYAML
+	//FormatCSV
+)
+
+// Output is the main ref for the output package
+type Output struct {
+	format      Format
+	prettyPrint bool
+
+	jsonFormatter *prettyjson.Formatter
+}
+
+func SetFormat(format Format) (err error) {
+	if err = ensureGlobalOutput(); err != nil {
+		return err
+	}
+
+	globalOutput.format = format
+
+	return nil
+}
+
+func SetPrettyPrint(pretty bool) (err error) {
+	if err = ensureGlobalOutput(); err != nil {
+		return err
+	}
+
+	globalOutput.prettyPrint = pretty
+
+	return nil
+}
+
+// ensureGlobalOutput is a helper function to make sure that
+// we have a global instance of the outputter at all times
+func ensureGlobalOutput() (err error) {
+	if globalOutput == nil {
+		globalOutput, err = New()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	utils.LogIfFatal(ensureGlobalOutput())
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,6 +1,8 @@
 package output
 
 import (
+	"strings"
+
 	"github.com/hokaccha/go-prettyjson"
 
 	"github.com/newrelic/newrelic-cli/internal/utils"
@@ -12,11 +14,46 @@ var globalOutput *Output
 // Format provides the list of output formats supported
 type Format uint
 
+const DefaultFormat = FormatJSON
+const DefaultPretty = true
+
 const (
 	FormatJSON Format = iota
 	FormatYAML
 	//FormatCSV
 )
+
+var formatStrings = map[Format]string{
+	FormatJSON: "JSON",
+	FormatYAML: "YAML",
+}
+
+func (f Format) String() string {
+	if name, ok := formatStrings[f]; ok {
+		return name
+	}
+
+	return ""
+}
+
+func FormatOptions() string {
+	ret := make([]string, 0, len(formatStrings))
+
+	for _, v := range formatStrings {
+		ret = append(ret, v)
+	}
+	return strings.Join(ret, ", ")
+}
+
+func ParseFormat(name string) Format {
+	for k, v := range formatStrings {
+		if strings.EqualFold(name, v) {
+			return k
+		}
+	}
+
+	return DefaultFormat
+}
 
 // Output is the main ref for the output package
 type Output struct {

--- a/internal/output/print.go
+++ b/internal/output/print.go
@@ -1,0 +1,29 @@
+package output
+
+// Print outputs the data in the expected format
+func Print(data interface{}) (err error) {
+	if err = ensureGlobalOutput(); err != nil {
+		return err
+	}
+
+	switch globalOutput.format {
+	case FormatJSON:
+		err = globalOutput.json(data)
+	case FormatYAML:
+		err = globalOutput.yaml(data)
+	default:
+		err = globalOutput.json(data)
+	}
+
+	return err
+}
+
+// JSON allows you to override the default output method and
+// explicitly print JSON to the screen
+func JSON(data interface{}) (err error) {
+	if err = ensureGlobalOutput(); err != nil {
+		return err
+	}
+
+	return globalOutput.json(data)
+}

--- a/internal/output/yaml.go
+++ b/internal/output/yaml.go
@@ -1,0 +1,43 @@
+package output
+
+import (
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+// yaml prints out data as yaml
+func (o *Output) yaml(data interface{}) error {
+	var (
+		formatted []byte
+		err       error
+	)
+
+	// Early quit on no data
+	if data == nil {
+		return nil
+	}
+
+	if o == nil || o.jsonFormatter == nil {
+		return errors.New("invalid output formatter")
+	}
+
+	// Let's see what they sent us
+	switch d := data.(type) {
+	//case *bytes.Buffer:
+	//	formatted, err = o.jsonFormatter.Format(d.Bytes())
+	//case []byte:
+	//	formatted, err = o.jsonFormatter.Format(d)
+	default:
+		formatted, err = yaml.Marshal(d)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(formatted))
+
+	return nil
+}

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -1,13 +1,12 @@
 package workload
 
 import (
-	"fmt"
-
-	"github.com/hokaccha/go-prettyjson"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/workloads"
 )
@@ -33,16 +32,9 @@ The get command retrieves a specific workload by its account ID and workload ID.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			workload, err := nrClient.Workloads.GetWorkload(accountID, id)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(workload)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(workload))
 		})
 	},
 }
@@ -58,16 +50,9 @@ The list command retrieves the workloads for the given account ID.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			workload, err := nrClient.Workloads.ListWorkloads(accountID)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(workload)
-			if err != nil {
-				log.Fatal(err)
-			}
-
-			fmt.Println(string(json))
+			utils.LogIfFatal(output.Print(workload))
 		})
 	},
 }
@@ -108,17 +93,10 @@ you also have access to.
 			}
 
 			workload, err := nrClient.Workloads.CreateWorkload(accountID, createInput)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(workload)
-			if err != nil {
-				log.Fatal(err)
-			}
-
+			utils.LogIfFatal(output.Print(workload))
 			log.Info("success")
-			fmt.Println(string(json))
 		})
 	},
 }
@@ -159,9 +137,7 @@ entities from different sub-accounts that you also have access to.
 			}
 
 			_, err := nrClient.Workloads.UpdateWorkload(guid, updateInput)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -186,17 +162,10 @@ compose the new name.
 			}
 
 			workload, err := nrClient.Workloads.DuplicateWorkload(accountID, guid, duplicateInput)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
-			json, err := prettyjson.Marshal(workload)
-			if err != nil {
-				log.Fatal(err)
-			}
-
+			utils.LogIfFatal(output.Print(workload))
 			log.Info("success")
-			fmt.Println(string(json))
 		})
 	},
 }
@@ -212,9 +181,7 @@ The delete command accepts a workload's entity GUID.
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			_, err := nrClient.Workloads.DeleteWorkload(guid)
-			if err != nil {
-				log.Fatal(err)
-			}
+			utils.LogIfFatal(err)
 
 			log.Info("success")
 		})
@@ -226,23 +193,13 @@ func init() {
 	Command.AddCommand(cmdGet)
 	cmdGet.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID where you want to create the workload")
 	cmdGet.Flags().IntVarP(&id, "id", "i", 0, "the identifier of the workload")
-	err := cmdGet.MarkFlagRequired("accountId")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdGet.MarkFlagRequired("id")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdGet.MarkFlagRequired("accountId"))
+	utils.LogIfError(cmdGet.MarkFlagRequired("id"))
 
 	// List
 	Command.AddCommand(cmdList)
 	cmdList.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID where you want to create the workload")
-	err = cmdList.MarkFlagRequired("accountId")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdList.MarkFlagRequired("accountId"))
 
 	// Create
 	Command.AddCommand(cmdCreate)
@@ -251,15 +208,8 @@ func init() {
 	cmdCreate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "e", []string{}, "the list of entity Guids composing the workload")
 	cmdCreate.Flags().StringSliceVarP(&entitySearchQueries, "entitySearchQuery", "q", []string{}, "a list of search queries, combined using an OR operator")
 	cmdCreate.Flags().IntSliceVarP(&scopeAccountIDs, "scopeAccountIds", "s", []int{}, "accounts that will be used to get entities from")
-	err = cmdCreate.MarkFlagRequired("accountId")
-	if err != nil {
-		log.Error(err)
-	}
-
-	err = cmdCreate.MarkFlagRequired("name")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdCreate.MarkFlagRequired("accountId"))
+	utils.LogIfError(cmdCreate.MarkFlagRequired("name"))
 
 	// Update
 	Command.AddCommand(cmdUpdate)
@@ -268,31 +218,18 @@ func init() {
 	cmdUpdate.Flags().StringSliceVarP(&entityGUIDs, "entityGuid", "e", []string{}, "the list of entity Guids composing the workload")
 	cmdUpdate.Flags().StringSliceVarP(&entitySearchQueries, "entitySearchQuery", "q", []string{}, "a list of search queries, combined using an OR operator")
 	cmdUpdate.Flags().IntSliceVarP(&scopeAccountIDs, "scopeAccountIds", "s", []int{}, "accounts that will be used to get entities from")
-
-	err = cmdUpdate.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdUpdate.MarkFlagRequired("guid"))
 
 	// Duplicate
 	Command.AddCommand(cmdDuplicate)
 	cmdDuplicate.Flags().StringVarP(&guid, "guid", "g", "", "the GUID of the workload you want to duplicate")
 	cmdDuplicate.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic Account ID where you want to create the new workload")
 	cmdDuplicate.Flags().StringVarP(&name, "name", "n", "", "the name of the workload to duplicate")
-
-	err = cmdDuplicate.MarkFlagRequired("accountId")
-	if err != nil {
-		log.Error(err)
-	}
-	err = cmdDuplicate.MarkFlagRequired("guid")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdDuplicate.MarkFlagRequired("accountId"))
+	utils.LogIfError(cmdDuplicate.MarkFlagRequired("guid"))
 
 	// Delete
 	Command.AddCommand(cmdDelete)
 	cmdDelete.Flags().StringVarP(&guid, "guid", "g", "", "the GUID of the workload to delete")
-	if err != nil {
-		log.Error(err)
-	}
+	utils.LogIfError(cmdDelete.MarkFlagRequired("guid"))
 }


### PR DESCRIPTION
Previously, we had one method of output: Pretty Print JSON.  This is fine for folks that are interacting with the CLI, but more options would be better.

This PR:
* Consolidates all output to a new `output` package (creative right?)
* Adds support for YAML output.  Since the data is structured, it was a logical choice though not sure it will get much use
* Adds `--format (json|yaml)` flag that allow runtime changes of the format
* Enables plain / compact output of JSON via `--plain` flag
