### PR TITLE
Fix: Goreleaser Release Notes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,7 +5,6 @@ env:
 
 before:
   hooks:
-    - make clean
     - go mod download
 
 builds:


### PR DESCRIPTION
goreleaser was configured to run `make clean` which breaks other make tasks run prior to goreleaser being called in `make release-publish`.  This removes the pre-hook, as the expected work-flow is to always use make targets.