### PR TITLE
Fix: increase coverage of make snapshot

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -23,10 +23,10 @@ release-publish: clean tools docker-login snapcraft-login release-notes
 	$(REL_CMD) --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
 
 # Local Snapshot
-snapshot: release-clean
+snapshot: clean tools release-notes
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]: Creating release via $(REL_CMD)"
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]:   THIS WILL NOT BE PUBLISHED!"
-	$(REL_CMD) --skip-publish --snapshot
+	$(REL_CMD) --skip-publish --snapshot --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
 
 release-homebrew:
 ifeq ($(HOMEBREW_GITHUB_API_TOKEN), "")


### PR DESCRIPTION
Currently `make snapshot` misses all the other make targets that `make release-publish` does, which means it's not a valid local test.