### PR TITLE
feat(build): provide installation via Scoop (Windows)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,7 +106,7 @@ scoop:
     name: newrelic-cli
   commit_author:
     name: nr-developer-toolkit
-    email: developer-toolkit-team@newrelic.com
+    email: "{{ .Env.DEV_TOOLKIT_EMAIL }}"
   homepage: https://github.com/newrelic/newrelic-cli
   url_template: "https://github.com/newrelic/newrelic-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   description: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -99,3 +99,17 @@ snapcrafts:
         # things they allow:
         # https://snapcraft.io/docs/reference/interfaces.
         plugs: ["home", "network"]
+
+scoop:
+  bucket:
+    owner: newrelic
+    name: newrelic-cli
+  commit_author:
+    name: nr-developer-toolkit
+    email: developer-toolkit-team@newrelic.com
+  homepage: https://github.com/newrelic/newrelic-cli
+  url_template: "https://github.com/newrelic/newrelic-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+  description: |
+    The New Relic CLI is an officially supported command line interface for New
+    Relic, released as part of the Developer Toolkit.
+  license: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ brew install newrelic-cli
 ### Windows
 Installation is supported on 64-bit Windows.
 
+#### Scoop
+```powershell
+scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
+scoop install newrelic-cli
+```
+
 #### Standalone installer
 A standalone MSI installer is available on the GitHub releases page.  You can download the installer for the latest version [here](https://github.com/newrelic/newrelic-cli/releases).
 
@@ -66,12 +72,6 @@ Silent installation of the latest version of the CLI can be achieved via the fol
 ```powershell
 (New-Object System.Net.WebClient).DownloadFile("https://github.com/newrelic/newrelic-cli/releases/latest/download/NewRelicCLIInstaller.msi", "$env:TEMP\NewRelicCLIInstaller.msi"); `
 msiexec.exe /qn /i "$env:TEMP\NewRelicCLIInstaller.msi" | Out-Null; `
-```
-
-#### Scoop
-```powershell
-scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
-scoop install newrelic-cli
 ```
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ sudo snap install newrelic-cli
 ### Pre-built binaries
 Pre-built binaries are created on the GitHub releases page for all of the above platforms.  You can download the latest releases [here](https://github.com/newrelic/newrelic-cli/releases).
 
+### Install via Scoop
+```bash
+scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
+scoop install newrelic-cli
+```
+
 ### Docker
 
 There is an official [docker image](https://hub.docker.com/r/newrelic/cli) that can be utilized for running commands as well.
@@ -226,7 +232,7 @@ $ make docs
 
 ## Community
 
-New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. 
+New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices.
 
 * [Roadmap](https://newrelic.github.io/developer-toolkit/roadmap/) - As part of the Developer Toolkit, the roadmap for this project follows the same RFC process
 * [Issues or Enhancement Requests](https://github.com/newrelic/newrelic-cli/issues) - Issues and enhancement requests can be submitted in the Issues tab of this repository. Please search for and review the existing open issues before submitting a new issue.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Silent installation of the latest version of the CLI can be achieved via the fol
 msiexec.exe /qn /i "$env:TEMP\NewRelicCLIInstaller.msi" | Out-Null; `
 ```
 
+#### Scoop
+```powershell
+scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
+scoop install newrelic-cli
+```
+
 ### Linux
 Linux binaries can be installed via [Snapcraft](https://snapcraft.io/).  With the `snapd` daemon installed, run:
 
@@ -77,12 +83,6 @@ sudo snap install newrelic-cli
 
 ### Pre-built binaries
 Pre-built binaries are created on the GitHub releases page for all of the above platforms.  You can download the latest releases [here](https://github.com/newrelic/newrelic-cli/releases).
-
-### Install via Scoop
-```bash
-scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
-scoop install newrelic-cli
-```
 
 ### Docker
 


### PR DESCRIPTION
Resolves: #167 

This PR adds Scoop to the GoReleaser, which will generate and publish a Scoop App Manifest into our repository. Windows users should be able to install the CLI via `scoop`.

The README has also been updated with installation instructions for Scoop.

Installing with Scoop:
```bash
scoop bucket add newrelic-cli https://github.com/newrelic/newrelic-cli.git
scoop install newrelic-cli
```

