### PR TITLE
chore(build): revert linter configuration for scoop

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,6 +111,7 @@ scoop:
   commit_author:
     name: nr-developer-toolkit
     email: "{{ .Env.DEV_TOOLKIT_EMAIL }}"
+  commit_msg_template: "chore(scoop): update for {{ .ProjectName }} version {{ .Tag }}"
   homepage: https://github.com/newrelic/newrelic-cli
   url_template: "https://github.com/newrelic/newrelic-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
   description: |

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -8,8 +8,8 @@ GOFMT        ?= gofmt
 GOIMPORTS    ?= goimports
 
 COMMIT_LINT_CMD   ?= go-gitlint
-COMMIT_LINT_REGEX ?= "(Scoop update|(chore|docs|feat|fix|refactor|tests?)(\([^\)]+\))?:) .*"
-COMMIT_LINT_START ?= "2020-01-09"
+COMMIT_LINT_REGEX ?= "(chore|docs|feat|fix|refactor|tests?)(\([^\)]+\))?: .*"
+COMMIT_LINT_START ?= "2020-05-08"
 
 GOLINTER      = golangci-lint
 


### PR DESCRIPTION
This reverts commit 25637ff24bfcddd0a14e51ddae6df4a827d21d4d.

This also updates the commit format for scoop.