### PR TITLE
Git Hooks

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo
+echo "Checking commit message..."
+echo
+
+make lint-commit COMMIT_MSG_FILE=$1
+

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+echo
+echo "Running pre-commit checks..."
+echo
+
+make lint

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo
+echo "Running tests before pushing..."
+echo
+
+make test
+

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PROJECT_MODULE  ?= $(shell $(GO) list -m)
 all: build
 
 # Humans running make:
-build: check-version clean lint test cover-report compile
+build: git-hooks check-version clean lint test cover-report compile
 
 # Build command for CI tooling
 build-ci: check-version clean lint test compile-only

--- a/build/lint.mk
+++ b/build/lint.mk
@@ -10,6 +10,7 @@ GOIMPORTS    ?= goimports
 COMMIT_LINT_CMD   ?= go-gitlint
 COMMIT_LINT_REGEX ?= "(Scoop update|(chore|docs|feat|fix|refactor|tests?)(\([^\)]+\))?:) .*"
 COMMIT_LINT_START ?= "2020-05-08"
+COMMIT_MSG_FILE   ?= ""
 
 GOLINTER      = golangci-lint
 
@@ -57,7 +58,8 @@ goimports: deps
 
 lint-commit: deps
 	@echo "=== $(PROJECT_NAME) === [ lint-commit      ]: Checking that commit messages are properly formatted ($(COMMIT_LINT_CMD))..."
-	@$(COMMIT_LINT_CMD) --since=$(COMMIT_LINT_START) --subject-minlen=10 --subject-maxlen=120 --subject-regex=$(COMMIT_LINT_REGEX)
+	@$(COMMIT_LINT_CMD) --since=$(COMMIT_LINT_START) --subject-minlen=10 --subject-maxlen=120 --subject-regex=$(COMMIT_LINT_REGEX) --msg-file=$(COMMIT_MSG_FILE)
+
 
 golangci: deps
 	@echo "=== $(PROJECT_NAME) === [ golangci-lint    ]: Linting using $(GOLINTER) ($(COMMIT_LINT_CMD))..."

--- a/build/util.mk
+++ b/build/util.mk
@@ -5,6 +5,11 @@
 NATIVEOS    ?= $(shell go version | awk -F '[ /]' '{print $$4}')
 NATIVEARCH  ?= $(shell go version | awk -F '[ /]' '{print $$5}')
 
+GIT_HOOKS_PATH ?= .githooks
+
+git-hooks:
+	@echo "=== $(PROJECT_NAME) === [ git-hooks        ]: Configuring git hooks..."
+	@git config core.hooksPath $(GIT_HOOKS_PATH)
 
 check-version:
 ifdef GOOS


### PR DESCRIPTION
This PR adds three hooks to git, and alters `make` to install them:
* pre-commit: Run `make lint` before the commit
* commit-msg: Check commit message format at commit time
* pre-push: Run `make test` before pushing

The pre-commit might be a bit too much, but the others should be our standard.