### PR TITLE
chore(build): Update GH Action to fix release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+      # Needed for release notes
+    - name: Full git history
+      run: |
+        git fetch --prune --unshallow
+
     - name: Install Snapcraft
       uses: samuelmeuli/action-snapcraft@v1
 

--- a/build/document.mk
+++ b/build/document.mk
@@ -25,7 +25,7 @@ changelog: tools
 	@$(CHANGELOG_CMD) --silent -o $(CHANGELOG_FILE)
 
 release-notes: tools
-	@echo "=== $(PROJECT_NAME) === [ release-notes    ]: Generating release notes..."
+	@echo "=== $(PROJECT_NAME) === [ release-notes    ]: Generating release notes for v$(PROJECT_VER_TAGGED) ..."
 	@mkdir -p $(SRCDIR)/tmp
 	@$(CHANGELOG_CMD) --silent -o $(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) v$(PROJECT_VER_TAGGED)
 

--- a/build/release.mk
+++ b/build/release.mk
@@ -26,7 +26,7 @@ release-publish: clean tools docker-login snapcraft-login release-notes
 snapshot: clean tools release-notes
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]: Creating release via $(REL_CMD)"
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]:   THIS WILL NOT BE PUBLISHED!"
-	$(REL_CMD) --skip-publish --snapshot --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
+	@$(REL_CMD) --skip-publish --snapshot --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE)
 
 release-homebrew:
 ifeq ($(HOMEBREW_GITHUB_API_TOKEN), "")


### PR DESCRIPTION
Github Actions do not have the entire log, so release note generation fails.