### PR TITLE
chore(chocolatey): remove unnecessary variables from ps1 install script

### DIFF
--- a/build/package/chocolatey/tools/VERIFICATION.txt
+++ b/build/package/chocolatey/tools/VERIFICATION.txt
@@ -6,4 +6,4 @@ Releases can be verified against the github releases.
 
 https://github.com/newrelic/newrelic-cli/releases
 
-The Developer Toolkit Team authors this software for New New Relic.
+The Developer Toolkit Team authors this software for New Relic.

--- a/build/package/chocolatey/tools/chocolateyinstall.ps1
+++ b/build/package/chocolatey/tools/chocolateyinstall.ps1
@@ -2,15 +2,12 @@
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $fileLocation = Join-Path $toolsDir 'NewRelicCLIInstaller.msi'
 
-$url        = '' # download url, HTTPS preferred
-$url64      = '' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
-
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi' #only one of these: exe, msi, msu
-  url           = $url
-  url64bit      = $url64
+  url           = '' # download url, HTTPS preferred
+  url64bit      = '' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
   file          = $fileLocation
 
   softwareName  = 'newrelic-cli' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique

--- a/build/package/chocolatey/tools/chocolateyinstall.ps1
+++ b/build/package/chocolatey/tools/chocolateyinstall.ps1
@@ -6,19 +6,10 @@ $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
   fileType      = 'msi' #only one of these: exe, msi, msu
-  url           = '' # download url, HTTPS preferred
-  url64bit      = '' # 64bit URL here (HTTPS preferred) or remove - if installer contains both (very rare), use $url
   file          = $fileLocation
-
   softwareName  = 'newrelic-cli' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique
-
-  checksum      = ''
-  checksumType  = 'sha256' #default is md5, can also be sha1, sha256 or sha512
-  checksum64    = ''
-  checksumType64= 'sha256' #default is checksumType
-
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0
   validExitCodes= @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs # https://chocolatey.org/docs/helpers-install-chocolatey-package
+Install-ChocolateyInstallPackage @packageArgs # https://chocolatey.org/docs/helpers-install-chocolatey-package

--- a/build/package/chocolatey/tools/chocolateyinstall.ps1
+++ b/build/package/chocolatey/tools/chocolateyinstall.ps1
@@ -12,4 +12,4 @@ $packageArgs = @{
   validExitCodes= @(0, 3010, 1641)
 }
 
-Install-ChocolateyInstallPackage @packageArgs # https://chocolatey.org/docs/helpers-install-chocolatey-package
+Install-ChocolateyInstallPackage @packageArgs # https://chocolatey.org/docs/helpers-install-chocolatey-install-package


### PR DESCRIPTION
Related: #170

A Chocolately [reviewer has requested](https://chocolatey.org/packages/newrelic-cli/0.7.0) we remove unnecessary variables from the install script. 

2020.22.05 - Still awaiting response [here](https://chocolatey.org/packages/newrelic-cli/0.7.0)
2020.26.05 - Heard back. Made updates. Ready for review.