### PR TITLE
chore(renovate): update the renovate config with postUpdateOptions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "gomodTidy": true,
   "ignoreDeps": [
     "golang.org/x/crypto",
@@ -9,8 +7,7 @@
     "golang.org/x/sys",
     "golang.org/x/tools"
   ],
-  "labels": [
-    "dependencies"
-  ],
-  "prConcurrentLimit": 4
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 4,
+  "postUpdateOptions": ["gomodTidy"]
 }


### PR DESCRIPTION
Renovate seems to have stopped running `go mod tidy` and hasn't been updating our `go.sum` file. Hoping the [postUpdateOptions](https://docs.renovatebot.com/configuration-options/#postupdateoptions) config option fixes that.