### PR TITLE
[feat] Add pre-release config option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,9 +39,10 @@ var (
 
 // Config contains the main CLI configuration
 type Config struct {
-	LogLevel      string  `mapstructure:"logLevel"`      // LogLevel for verbose output
-	PluginDir     string  `mapstructure:"pluginDir"`     // PluginDir is the directory where plugins will be installed
-	SendUsageData Ternary `mapstructure:"sendUsageData"` // SendUsageData enables sending usage statistics to New Relic
+	LogLevel           string  `mapstructure:"logLevel"`           // LogLevel for verbose output
+	PluginDir          string  `mapstructure:"pluginDir"`          // PluginDir is the directory where plugins will be installed
+	SendUsageData      Ternary `mapstructure:"sendUsageData"`      // SendUsageData enables sending usage statistics to New Relic
+	PreReleaseFeatures Ternary `mapstructure:"PreReleaseFeatures"` // PreReleaseFeatures enables display on features within the CLI that are announced but not generally available to customers
 
 	configDir string
 }
@@ -64,8 +65,9 @@ func (c *Value) IsDefault() bool {
 
 func init() {
 	defaultConfig = &Config{
-		LogLevel:      DefaultLogLevel,
-		SendUsageData: TernaryValues.Unknown,
+		LogLevel:           DefaultLogLevel,
+		SendUsageData:      TernaryValues.Unknown,
+		PreReleaseFeatures: TernaryValues.Unknown,
 	}
 
 	cfgDir, err := getDefaultConfigDirectory()
@@ -170,6 +172,7 @@ func (c *Config) Set(key string, value interface{}) error {
 	}
 
 	renderer.Set(key, value)
+
 	return nil
 }
 
@@ -335,7 +338,7 @@ func (c *Config) validate() error {
 			if !stringInStrings(v.Value.(string), validValues) {
 				return fmt.Errorf("\"%s\" is not a valid %s value; Please use one of: %s", v.Value, v.Name, validValues)
 			}
-		case "sendusagedata":
+		case "sendusagedata", "prereleasefeatures":
 			err := (v.Value.(Ternary)).Valid()
 			if err != nil {
 				return fmt.Errorf("invalid value for '%s': %s", v.Name, err)

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -62,6 +62,31 @@ func TestConfigSetSendUsageData(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestConfigSetPreReleaseFeatures(t *testing.T) {
+	f, err := ioutil.TempDir("/tmp", "newrelic")
+	assert.NoError(t, err)
+	defer os.RemoveAll(f)
+
+	// Initialize the new configuration directory
+	c, err := LoadConfig(f)
+	assert.NoError(t, err)
+	assert.Equal(t, c.configDir, f)
+
+	// Set the valid pre-release feature values
+	for _, l := range []Ternary{
+		TernaryValues.Allow,
+		TernaryValues.Disallow,
+		TernaryValues.Unknown,
+	} {
+		err = c.Set("preReleaseFeatures", l)
+		assert.NoError(t, err)
+		assert.Equal(t, l, c.PreReleaseFeatures)
+	}
+
+	err = c.Set("preReleaseFeatures", "INVALID_VALUE")
+	assert.Error(t, err)
+}
+
 func TestConfigSetPluginDir(t *testing.T) {
 	f, err := ioutil.TempDir("/tmp", "newrelic")
 	assert.NoError(t, err)

--- a/internal/config/config_integration_test.go
+++ b/internal/config/config_integration_test.go
@@ -47,11 +47,11 @@ func TestConfigSetSendUsageData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, c.configDir, f)
 
-	// Set the valid log levels
-	for _, l := range []string{
-		"NOT_ASKED",
-		"DISALLOW",
-		"ALLOW",
+	// Set the valid send-usage-date values
+	for _, l := range []Ternary{
+		TernaryValues.Allow,
+		TernaryValues.Disallow,
+		TernaryValues.Unknown,
 	} {
 		err = c.Set("sendUsageData", l)
 		assert.NoError(t, err)

--- a/internal/config/table_renderer.go
+++ b/internal/config/table_renderer.go
@@ -35,9 +35,10 @@ func (tr *TableRenderer) Delete(key string) {
 }
 
 // Set renders output for the set command.
-func (tr *TableRenderer) Set(key string, value string) {
+func (tr *TableRenderer) Set(key string, value interface{}) {
 	bold := color.New(color.Bold).SprintFunc()
 	cyan := color.New(color.FgHiCyan).SprintFunc()
+
 	log.Debugf("%s set to %s\n", bold(key), cyan(value))
 }
 

--- a/internal/config/ternary.go
+++ b/internal/config/ternary.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Ternary is like a bool, but includes the unknown state
+type Ternary string
+
+// TernaryValues provides the set of Ternary values
+var TernaryValues = struct {
+	// Allow the option
+	Allow Ternary
+
+	// Disallow the option
+	Disallow Ternary
+
+	// Unknown is the unknown state
+	Unknown Ternary
+}{
+	Allow:    "ALLOW",
+	Disallow: "DISALLOW",
+	Unknown:  "NOT_ASKED",
+}
+
+// Valid returns true for a valid value, false otherwise
+func (t Ternary) Valid() error {
+	val := string(t)
+
+	if strings.EqualFold(val, string(TernaryValues.Allow)) ||
+		strings.EqualFold(val, string(TernaryValues.Disallow)) ||
+		strings.EqualFold(val, string(TernaryValues.Unknown)) {
+		return nil
+	}
+
+	return fmt.Errorf("\"%s\" is not a valid value; Please use one of: %s", val, TernaryValues)
+}
+
+// String returns the string value of the ternary
+func (t Ternary) String() string {
+	return string(t)
+}

--- a/internal/config/ternary.go
+++ b/internal/config/ternary.go
@@ -37,6 +37,11 @@ func (t Ternary) Valid() error {
 	return fmt.Errorf("\"%s\" is not a valid value; Please use one of: %s", val, TernaryValues)
 }
 
+// Bool returns true if the ternary is set and contains the true value
+func (t Ternary) Bool() bool {
+	return strings.EqualFold(t.String(), TernaryValues.Allow.String())
+}
+
 // String returns the string value of the ternary
 func (t Ternary) String() string {
 	return string(t)

--- a/internal/config/ternary_test.go
+++ b/internal/config/ternary_test.go
@@ -1,0 +1,69 @@
+// +build unit
+
+package config
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testTernaryInfo = []struct {
+	Name  Ternary
+	Value string
+	Bool  bool
+	Err   error
+}{
+	{
+		Name:  TernaryValues.Allow,
+		Value: "ALLOW",
+		Bool:  true,
+	},
+	{
+		Name:  TernaryValues.Disallow,
+		Value: "DISALLOW",
+		Bool:  false,
+	},
+	{
+		Name:  TernaryValues.Unknown,
+		Value: "NOT_ASKED",
+		Bool:  false,
+	},
+	{
+		Name:  Ternary("invalid"),
+		Value: "invalid",
+		Bool:  false,
+		Err:   errors.New("\"invalid\" is not a valid value; Please use one of: {ALLOW DISALLOW NOT_ASKED}"),
+	},
+}
+
+func TestTernaryString(t *testing.T) {
+	t.Parallel()
+
+	// Set the valid pre-release feature values
+	for _, info := range testTernaryInfo {
+		assert.Equal(t, info.Value, info.Name.String())
+	}
+}
+
+func TestTernaryValid(t *testing.T) {
+	t.Parallel()
+
+	// Set the valid pre-release feature values
+	for _, info := range testTernaryInfo {
+		assert.Equal(t, info.Err, info.Name.Valid())
+	}
+
+}
+
+func TestTernaryBool(t *testing.T) {
+	t.Parallel()
+
+	for _, info := range testTernaryInfo {
+		assert.Equal(t, info.Bool, info.Name.Bool())
+	}
+
+	// Invalid data
+	assert.Equal(t, false, Ternary("asdf").Bool())
+}


### PR DESCRIPTION
We want to ship features that have been announced, but not GA in a way that is not confusing to our users.  To do so, we will add a config option to display the non-GA features within the CLI if a user chooses to do so.  Otherwise hide them by default.

This resolves #274 