### PR TITLE
fix(scoop): fix bot email address

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -110,7 +110,7 @@ scoop:
     name: newrelic-cli
   commit_author:
     name: nr-developer-toolkit
-    email: "{{ .Env.DEV_TOOLKIT_EMAIL }}"
+    email: developer-toolkit@newrelic.com
   commit_msg_template: "chore(scoop): update for {{ .ProjectName }} version {{ .Tag }}"
   homepage: https://github.com/newrelic/newrelic-cli
   url_template: "https://github.com/newrelic/newrelic-cli/releases/download/{{ .Tag }}/{{ .ArtifactName }}"


### PR DESCRIPTION
This PR fixes the Scoop commit message author email, which was being set as `<{{ .Env.DEV_TOOLKIT_EMAIL }}>`. 