### PR TITLE
feat(reporting): add junit reporting

### DIFF
--- a/build/lint.mk
+++ b/build/lint.mk
@@ -27,7 +27,8 @@ GOTOOLS += github.com/client9/misspell/cmd/misspell \
            github.com/llorllale/go-gitlint/cmd/go-gitlint \
            github.com/psampaz/go-mod-outdated \
            github.com/golangci/golangci-lint/cmd/golangci-lint \
-           golang.org/x/tools/cmd/goimports
+           golang.org/x/tools/cmd/goimports \
+		   gotest.tools/gotestsum
 
 
 lint: deps spell-check gofmt lint-commit golangci goimports outdated

--- a/build/test.mk
+++ b/build/test.mk
@@ -6,6 +6,7 @@ GO           ?= go
 GOLINTER     ?= golangci-lint
 MISSPELL     ?= misspell
 GOFMT        ?= gofmt
+TEST_RUNNER  ?= gotestsum
 
 COVERAGE_DIR ?= ./coverage/
 COVERMODE    ?= atomic
@@ -22,16 +23,15 @@ GOTOOLS += github.com/stretchr/testify/assert
 test: test-only
 test-only: test-unit test-integration
 
-test-unit:
+test-unit: tools
 	@echo "=== $(PROJECT_NAME) === [ test-unit        ]: running unit tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@$(GO) test -v -ldflags=$(LDFLAGS_UNIT) -parallel 4 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
+	@$(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/unit.xml -- -v -ldflags=$(LDFLAGS_UNIT) -parallel 4 -tags unit -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/unit.tmp $(GO_PKGS)
 
-test-integration:
+test-integration: tools
 	@echo "=== $(PROJECT_NAME) === [ test-integration ]: running integration tests..."
 	@mkdir -p $(COVERAGE_DIR)
-	@$(GO) test -v -parallel 4 -tags integration -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp $(GO_PKGS)
-
+	@$(TEST_RUNNER) -f testname --junitfile $(COVERAGE_DIR)/integration.xml --rerun-fails=3 --packages $(GO_PKGS) -- -v -parallel 4 -tags integration -covermode=$(COVERMODE) -coverprofile $(COVERAGE_DIR)/integration.tmp $(GO_PKGS)
 
 #
 # Coverage

--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/nerdgraph"
 	"github.com/newrelic/newrelic-cli/internal/nerdstorage"
 	"github.com/newrelic/newrelic-cli/internal/nrql"
+	"github.com/newrelic/newrelic-cli/internal/reporting"
 	"github.com/newrelic/newrelic-cli/internal/workload"
 )
 
@@ -34,6 +35,7 @@ func init() {
 	Command.AddCommand(nerdgraph.Command)
 	Command.AddCommand(nerdstorage.Command)
 	Command.AddCommand(nrql.Command)
+	Command.AddCommand(reporting.Command)
 	Command.AddCommand(workload.Command)
 
 	CheckPrereleaseMode(Command)

--- a/go.mod
+++ b/go.mod
@@ -6,10 +6,12 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/git-chglog/git-chglog v0.0.0-20200414013904-db796966b373
 	github.com/golangci/golangci-lint v1.29.0
+	github.com/google/uuid v1.1.1
 	github.com/goreleaser/goreleaser v0.140.1
 	github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e
 	github.com/imdario/mergo v0.3.10
 	github.com/jedib0t/go-pretty/v6 v6.0.4
+	github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909
 	github.com/llorllale/go-gitlint v0.0.0-20190914155841-58c0b8cef0e5
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,5 @@ require (
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899
 	golang.org/x/tools v0.0.0-20200722181740-bd1e9de8d890
 	gopkg.in/yaml.v2 v2.3.0
+	gotest.tools/gotestsum v0.5.2
 )

--- a/go.sum
+++ b/go.sum
@@ -374,6 +374,7 @@ github.com/google/pprof v0.0.0-20200507031123-427632fa3b1c/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/rpmpack v0.0.0-20200721073823-11a45a65cb40 h1:igTDauCa3sFf6EsKD+CzLLc+y1gW3w/Ol4Ms5GdzAgk=
 github.com/google/rpmpack v0.0.0-20200721073823-11a45a65cb40/go.mod h1:+y9lKiqDhR4zkLl+V9h4q0rdyrYVsWWm6LLCQP33DIk=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/subcommands v1.0.1/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1184,7 +1185,9 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
 gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/gotestsum v0.5.2 h1:sSKWtEFqorHhuBCHU6MeUl50cq9U2J3d1m5NlQTVrbY=
 gotest.tools/gotestsum v0.5.2/go.mod h1:hC9TQserDVTWcJuARh76Ydp3ZwuE+pIIWpt2BzDLD6M=
+gotest.tools/v3 v3.0.2 h1:kG1BFyqVHuQoVQiR1bWGnfz/fmHvvuiSPIV7rvl360E=
 gotest.tools/v3 v3.0.2/go.mod h1:3SzNCllyD9/Y+b5r9JIKQ474KzkZyqLqEfYqMsX94Bk=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -478,6 +478,8 @@ github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xl
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909 h1:3BBiJ4qMIiesYqTk4zbLZnHrNIE3LYL1UUpaMIYGPSo=
+github.com/joshdk/go-junit v0.0.0-20200702055522-6efcf4050909/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=

--- a/internal/reporting/command.go
+++ b/internal/reporting/command.go
@@ -1,0 +1,11 @@
+package reporting
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Command represents the reporting command.
+var Command = &cobra.Command{
+	Use:   "reporting",
+	Short: "Commands for reporting data into New Relic",
+}

--- a/internal/reporting/command_junit.go
+++ b/internal/reporting/command_junit.go
@@ -1,0 +1,109 @@
+package reporting
+
+import (
+	"io/ioutil"
+
+	"github.com/google/uuid"
+	"github.com/joshdk/go-junit"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/credentials"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+const junitEventType = "TestRun"
+
+var (
+	accountID   int
+	path        string
+	convertOnly bool
+)
+
+var cmdJUnit = &cobra.Command{
+	Use:   "junit",
+	Short: "Send JUnit test run results to New Relic",
+	Long: `Send JUnit test run results to New Relic
+
+`,
+	Example: `newrelic reporting junit --accountId 12345678 --path unit.xml`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClientAndProfile(func(nrClient *newrelic.NewRelic, profile *credentials.Profile) {
+			if profile.InsightsInsertKey == "" {
+				log.Fatal("an Insights insert key is required, set one in your default profile or use the NEW_RELIC_INSIGHTS_INSERT_KEY environment variable")
+			}
+
+			id, err := uuid.NewRandom()
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			xml, err := ioutil.ReadFile(path)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			suites, err := junit.Ingest(xml)
+			if err != nil {
+				log.Fatalf("failed to ingest JUnit xml %v", err)
+			}
+
+			events := []map[string]interface{}{}
+
+			for _, suite := range suites {
+				for _, test := range suite.Tests {
+					events = append(events, createTestRunEvent(id, suite, test))
+				}
+			}
+
+			if convertOnly {
+				utils.LogIfFatal(output.Print(events))
+				return
+			}
+
+			if err := nrClient.Events.CreateEvent(accountID, events); err != nil {
+				log.Fatal(err)
+			}
+
+			log.Info("success")
+		})
+	},
+}
+
+func createTestRunEvent(testRunID uuid.UUID, suite junit.Suite, test junit.Test) map[string]interface{} {
+	e := map[string]interface{}{}
+	e["eventType"] = junitEventType
+	e["id"] = testRunID.String()
+	e["test"] = test.Name
+	e["classname"] = test.Classname
+	e["suite"] = suite.Name
+	e["package"] = suite.Package
+	e["status"] = test.Status
+	e["durationMs"] = test.Duration.Milliseconds()
+
+	if test.Error != nil {
+		e["errorMessage"] = test.Error.Error()
+	}
+
+	for key, value := range suite.Properties {
+		e[key] = value
+	}
+
+	for key, value := range test.Properties {
+		e[key] = value
+	}
+
+	return e
+}
+
+func init() {
+	Command.AddCommand(cmdJUnit)
+	cmdJUnit.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID to send test run results to")
+	cmdJUnit.Flags().StringVarP(&path, "path", "p", "", "the path to a JUnit-formatted test results file")
+	cmdJUnit.Flags().BoolVarP(&convertOnly, "convertOnly", "c", false, "convert to custom event format without posting events")
+	utils.LogIfError(cmdJUnit.MarkFlagRequired("accountId"))
+	utils.LogIfError(cmdJUnit.MarkFlagRequired("path"))
+}

--- a/internal/reporting/command_junit.go
+++ b/internal/reporting/command_junit.go
@@ -18,9 +18,10 @@ import (
 const junitEventType = "TestRun"
 
 var (
-	accountID   int
-	path        string
-	convertOnly bool
+	accountID    int
+	path         string
+	dryRun       bool
+	outputEvents bool
 )
 
 var cmdJUnit = &cobra.Command{
@@ -59,8 +60,11 @@ var cmdJUnit = &cobra.Command{
 				}
 			}
 
-			if convertOnly {
+			if outputEvents {
 				utils.LogIfFatal(output.Print(events))
+			}
+
+			if dryRun {
 				return
 			}
 
@@ -103,7 +107,8 @@ func init() {
 	Command.AddCommand(cmdJUnit)
 	cmdJUnit.Flags().IntVarP(&accountID, "accountId", "a", 0, "the New Relic account ID to send test run results to")
 	cmdJUnit.Flags().StringVarP(&path, "path", "p", "", "the path to a JUnit-formatted test results file")
-	cmdJUnit.Flags().BoolVarP(&convertOnly, "convertOnly", "c", false, "convert to custom event format without posting events")
+	cmdJUnit.Flags().BoolVarP(&outputEvents, "output", "o", false, "output generated custom events to stdout")
+	cmdJUnit.Flags().BoolVar(&dryRun, "dryRun", false, "suppress posting custom events to NRDB")
 	utils.LogIfError(cmdJUnit.MarkFlagRequired("accountId"))
 	utils.LogIfError(cmdJUnit.MarkFlagRequired("path"))
 }

--- a/internal/reporting/command_junit_test.go
+++ b/internal/reporting/command_junit_test.go
@@ -1,0 +1,18 @@
+// +build unit
+
+package reporting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestJUnit(t *testing.T) {
+	assert.Equal(t, "junit", cmdJUnit.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdJUnit)
+	testcobra.CheckCobraRequiredFlags(t, cmdJUnit, []string{"accountId", "path"})
+}

--- a/internal/reporting/command_test.go
+++ b/internal/reporting/command_test.go
@@ -1,0 +1,18 @@
+// +build unit
+
+package reporting
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestNerdGraphCommand(t *testing.T) {
+	assert.Equal(t, "reporting", Command.Name())
+
+	testcobra.CheckCobraMetadata(t, Command)
+	testcobra.CheckCobraRequiredFlags(t, Command, []string{})
+}

--- a/tools.go
+++ b/tools.go
@@ -19,4 +19,7 @@ import (
 
 	// build/release.mk
 	_ "github.com/goreleaser/goreleaser"
+
+	// build/test.mk
+	_ "gotest.tools/gotestsum"
 )


### PR DESCRIPTION
Add JUnit reporting to NRDB via the `newrelic reporting junit` command.

This PR also adds JUnit test output to the build pipeline, so it can be used for testing of this functionality.  

### Testing
```
./bin/darwin/newrelic reporting junit --accountId 2520528 --path ./coverage/integration.xml
```