### PR TITLE
feat(nerdgraph): implement tutone-generated mutation command alertsPolicyCreate

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -1,0 +1,62 @@
+---
+# Log level for running tutone
+# Default: info
+log_level: debug
+
+# File to store a copy of the schema
+# Default: schema.json
+cache:
+  schema_file: schema.json
+
+# GraphQL endpoint to query for schema
+# Required
+endpoint: https://api.newrelic.com/graphql
+
+# How to authenticate to the API
+auth:
+  header: Api-Key
+  api_key_env_var: NEW_RELIC_API_KEY
+
+packages:
+  - name: nerdgraph
+    path: internal/nerdgraph
+    generators:
+      - command
+    imports:
+      - '"encoding/json"'
+      - '"github.com/spf13/cobra"'
+      - '"github.com/newrelic/newrelic-client-go/newrelic"'
+      - '"github.com/newrelic/newrelic-client-go/pkg/alerts"'
+      - '"github.com/newrelic/newrelic-cli/internal/client"'
+      - '"github.com/newrelic/newrelic-cli/internal/utils"'
+      - '"github.com/newrelic/newrelic-cli/internal/output"'
+    commands:
+      - name: mutation
+        shortDescription: "here is a short description"
+        longDescription: "here is a longer description with more detail"
+        subcommands:
+          - name: alertsPolicyCreate
+            shortDescription: "here is a short description"
+            longDescription: "here is a longer description with more detail"
+            inputType: "alerts.AlertsPolicyInput"
+            clientMethod: "nrClient.Alerts.CreatePolicyMutation"
+            example: >
+              newrelic nerdgraph mutation alertsPolicyCreate --input='{"name": "foo","incidentPreference": "PER_CONDITION"}' --accountId=$NEW_RELIC_ACCOUNT_ID
+            flags:
+              - name: accountId
+                type: int
+                defaultValue: ""
+                required: true # default is false
+                description: "describe the flag here"
+                variableName: accountID
+              - name: input
+                type: string
+                defaultValue: ""
+                required: false # default is false
+                description: "describe the flag here"
+                variableName: alertsPolicyCreateInput
+
+generators:
+  - name: command
+    templateName: "command.go.tmpl"
+    templateDir: "templates"

--- a/internal/nerdgraph/command_mutation.go
+++ b/internal/nerdgraph/command_mutation.go
@@ -1,0 +1,51 @@
+package nerdgraph
+
+import (
+	"encoding/json"
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-client-go/pkg/alerts"
+	"github.com/spf13/cobra"
+)
+
+var cmdMutation = &cobra.Command{
+	Use:     "mutation",
+	Short:   "here is a short description",
+	Long:    "here is a longer description with more detail",
+	Example: "newrelic nerdgraph mutation --help",
+}
+
+var accountID int
+var alertsPolicyCreateInput string
+
+var cmdAlertsPolicyCreate = &cobra.Command{
+	Use:     "alertsPolicyCreate",
+	Short:   "here is a short description",
+	Long:    "here is a longer description with more detail",
+	Example: "newrelic nerdgraph mutation alertsPolicyCreate --input='{\"name\": \"foo\",\"incidentPreference\": \"PER_CONDITION\"}' --accountId=$NEW_RELIC_ACCOUNT_ID\n",
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			var input alerts.AlertsPolicyInput
+			err := json.Unmarshal([]byte(alertsPolicyCreateInput), &input)
+			utils.LogIfFatal(err)
+
+			resp, err := nrClient.Alerts.CreatePolicyMutation(accountID, input)
+			utils.LogIfFatal(err)
+
+			utils.LogIfFatal(output.Print(resp))
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdMutation)
+
+	cmdMutation.AddCommand(cmdAlertsPolicyCreate)
+
+	cmdAlertsPolicyCreate.Flags().IntVar(&accountID, "accountId", 0, "describe the flag here")
+	utils.LogIfError(cmdAlertsPolicyCreate.MarkFlagRequired("accountId"))
+
+	cmdAlertsPolicyCreate.Flags().StringVar(&alertsPolicyCreateInput, "input", "", "describe the flag here")
+}

--- a/templates/command.go.tmpl
+++ b/templates/command.go.tmpl
@@ -1,0 +1,79 @@
+{{- $packageName := .PackageName -}}
+package {{$packageName}}
+
+{{- if gt (len .Imports) 0 }}
+import (
+  {{- range .Imports}}
+  {{.}}
+  {{- end}}
+)
+{{- end}}
+
+{{range .Commands}}
+{{- $cmdNameTitleCase := .Name | title -}}
+{{- $cmdVarName := print "cmd" $cmdNameTitleCase -}}
+
+var {{$cmdVarName}} = &cobra.Command{
+	Use: {{.Name | quote}},
+	Short: {{.ShortDescription | quote}},
+  Long: {{.LongDescription | quote}},
+  Example: "newrelic {{$packageName}} {{.Name}} --help",
+}
+
+{{range .Subcommands}}
+{{- $nameTitleCase := .Name | title -}}
+{{- $cmdVarName := print "cmd" $nameTitleCase -}}
+{{- $inputVarName := print .Name "Input" -}}
+
+{{range .Flags}}
+  var {{.VariableName}} {{.Type}}
+{{- end}}
+
+var {{$cmdVarName}} = &cobra.Command{
+  Use: {{.Name | quote}},
+  Short: {{.ShortDescription | quote}},
+  Long: {{.LongDescription | quote}},
+  Example: {{.Example | quote}},
+  Run: func(cmd *cobra.Command, args []string) {
+    client.WithClient(func(nrClient *newrelic.NewRelic) {
+      var input {{.InputType}}
+			err := json.Unmarshal([]byte({{.Name}}Input), &input)
+			utils.LogIfFatal(err)
+
+      resp, err := {{.ClientMethod}}(accountID, input)
+			utils.LogIfFatal(err)
+
+			utils.LogIfFatal(output.Print(resp))
+    })
+  },
+}
+{{- end}}
+{{- end}}
+
+func init() {
+{{- range .Commands}}
+{{- $parentCmdNameTitleCase := .Name | title -}}
+{{- $parentCmdVarName := print "cmd" $parentCmdNameTitleCase -}}
+  Command.AddCommand({{$parentCmdVarName}})
+
+{{ range .Subcommands}}
+{{- $subCmdNameTitleCase := .Name | title -}}
+{{- $cmdVarName := print "cmd" $subCmdNameTitleCase -}}
+{{- $inputVarName := print .Name "Input" -}}
+
+  {{$parentCmdVarName}}.AddCommand({{$cmdVarName}})
+
+{{ range .Flags}}
+  {{- $defaultVal := .DefaultValue | quote -}}
+  {{- if (eq .Type "int") -}}
+    {{- $defaultVal = 0 -}}
+  {{- end}}
+
+  {{$cmdVarName}}.Flags().{{- .FlagMethodName -}}(&{{.VariableName}}, {{.Name | quote}}, {{$defaultVal}}, {{.Description | quote}})
+  {{- if .Required}}
+  utils.LogIfError({{- $cmdVarName -}}.MarkFlagRequired({{.Name | quote}}))
+  {{end}}
+{{- end}}
+{{- end}}
+{{- end}}
+}


### PR DESCRIPTION
Resolves: #375 

This PR introduces our first command to be created with code generation.

```
make compile-only
```
```
./bin/darwin/newrelic nerdgraph mutation alertsPolicyCreate
```

Depends on: https://github.com/newrelic/tutone/pull/78