### PR TITLE
fix: duplicitous task running

### DIFF
--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -89,18 +89,6 @@ func executeRecipeSteps(r recipe) error {
 	return nil
 }
 
-func getTaskKeys(m map[string]*taskfile.Task) []string {
-	keys := make([]string, len(m))
-
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
-	}
-
-	return keys
-}
-
 func getSignalContext() context.Context {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -79,9 +79,7 @@ func executeRecipeSteps(r recipe) error {
 		return err
 	}
 
-	taskKeys := getTaskKeys(map[string]*taskfile.Task(tf.Tasks))
-
-	calls, globals := taskargs.ParseV3(taskKeys...)
+	calls, globals := taskargs.ParseV3()
 	e.Taskfile.Vars.Merge(globals)
 
 	if err := e.Run(getSignalContext(), calls...); err != nil {


### PR DESCRIPTION
Currently, we execute all the tasks in the file you pass, even if you've used a 'named' task to encapsulate your other tasks.

For example:

```yaml
tasks:
    parent_task:
        cmds:
          - task: named_task_1
          - task: named_task_2
    
    named_task_1:
      cmds:
        - echo "Hello world 1"

    named_task_2:
      cmds:
        - echo "Hello world 2"
```

Without this change, we will run the `parent_task` which runs `named_task_1` and `named_task_2` and then it will individually run `named_task_1` and `named_task_2` again.

With this change, we will need to update the yaml to look like:
 ```yaml
tasks:
    default:
        cmds:
          - task: named_task_1
          - task: named_task_2
    
    named_task_1:
      cmds:
        - echo "Hello world 1"

    named_task_2:
      cmds:
        - echo "Hello world 2"
```

If `ParseV3` is not passed a specifically named task, it will attempt to (only) run a task named `default`. In this example, it cuts out the duplicitous running of the other tasks in the definition.

Short-term this operates more as you might expect it to, so long as you know the convention of having a `default` task as an entry-point.

Long-term maybe we allow you to specify a named task as the one to execute on the command line?