### PR TITLE
chore(build): update workflows to avoid deprecated add-path

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -9,18 +9,12 @@ jobs:
   createPullRequest:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.14.x
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
-
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
 
       - name: Update Changelog
         run: |

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -2,9 +2,9 @@ name: Compiling
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   # Compile on all supported OSes
@@ -12,26 +12,19 @@ jobs:
     strategy:
       matrix:
         go-version:
-           - 1.13.x
-           - 1.14.x
+          - 1.13.x
+          - 1.14.x
+          - 1.15.x
         platform:
           - ubuntu-latest
           - macos-latest
           - windows-latest
     runs-on: ${{ matrix.platform }}
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go-version }}
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Add GOBIN to PATH
-      run: echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
-
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Compile
-      run: make compile-only
-
+      - name: Compile
+        run: make compile-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,26 +3,18 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
-
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          # Needed for release notes
-          fetch-depth: 0
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
@@ -59,7 +51,7 @@ jobs:
         run: ./scripts/brew_formula_pull_request.sh
         env:
           GH_USER_EMAIL: developer-toolkit-team@newrelic.com
-          GH_USER_NAME: 'New Relic Developer Toolkit Bot'
+          GH_USER_NAME: "New Relic Developer Toolkit Bot"
 
       - name: Upload chocolatey package
         shell: bash

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,17 +8,10 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Add GOBIN to PATH
-        run: echo "::add-path::$(go env GOPATH)/bin"
-        shell: bash
-
-      - name: Checkout code
-        uses: actions/checkout@v2
 
       - name: Build artifact
         shell: bash
@@ -40,4 +33,3 @@ jobs:
           cache-from: type=registry,ref=newrelic/cli:latest
           cache-to: type=inline
           tags: newrelic/cli:latest
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,113 +2,91 @@ name: Testing
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14.x
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
 
-    - name: Add GOBIN to PATH
-      run: echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
+      - name: Cache deps
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
-    - name: Cache deps
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Lint
-      run: make lint
+      - name: Lint
+        run: make lint
 
   test-unit:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14.x
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
 
-    - name: Add GOBIN to PATH
-      run: echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
+      - name: Cache deps
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Unit Tests
+        run: make test-unit
 
-    - name: Cache deps
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Unit Tests
-      run: make test-unit
-
-    - name: New Relic JUnit Reporter
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: newrelic/junit-reporter-action@v0.1.1
-      with:
-        accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-        insertApiKey: ${{ secrets.NEW_RELIC_INSIGHTS_INSERT_KEY }}
-        testOutputPath: coverage/unit.xml
-
+      - name: New Relic JUnit Reporter
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: newrelic/junit-reporter-action@v0.1.1
+        with:
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          insertApiKey: ${{ secrets.NEW_RELIC_INSIGHTS_INSERT_KEY }}
+          testOutputPath: coverage/unit.xml
 
   test-integration:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-    - name: Install Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.14.x
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
 
-    - name: Add GOBIN to PATH
-      run: echo "::add-path::$(go env GOPATH)/bin"
-      shell: bash
+      - name: Cache deps
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+      - name: Integration Tests
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: make test-integration
+        env:
+          NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          NEW_RELIC_ADMIN_API_KEY: ${{ secrets.NEW_RELIC_ADMIN_API_KEY }}
+          NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
+          NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
+          NEW_RELIC_REGION: ${{ secrets.NEW_RELIC_REGION }}
 
-    - name: Cache deps
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Integration Tests
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      run: make test-integration
-      env:
-        NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-        NEW_RELIC_ADMIN_API_KEY: ${{ secrets.NEW_RELIC_ADMIN_API_KEY }}
-        NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
-        NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY }}
-        NEW_RELIC_REGION: ${{ secrets.NEW_RELIC_REGION }}
-
-    - name: New Relic JUnit Reporter
-      if: github.event.pull_request.head.repo.full_name == github.repository
-      uses: newrelic/junit-reporter-action@v0.1.1
-      with:
-        accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
-        insertApiKey: ${{ secrets.NEW_RELIC_INSIGHTS_INSERT_KEY }}
-        testOutputPath: coverage/integration.xml
+      - name: New Relic JUnit Reporter
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: newrelic/junit-reporter-action@v0.1.1
+        with:
+          accountId: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
+          insertApiKey: ${{ secrets.NEW_RELIC_INSIGHTS_INSERT_KEY }}
+          testOutputPath: coverage/integration.xml


### PR DESCRIPTION
Without this change, the deprecation is preventing the jobs with add-path from
executing properly.  Here we update the setup and install of the workflows and
allow the PATH handling to be done by setup-go.