### PR TITLE
refactor(install): avoid spinner while prompting

### DIFF
--- a/internal/install/execution/go_task_recipe_executor_test.go
+++ b/internal/install/execution/go_task_recipe_executor_test.go
@@ -81,7 +81,10 @@ func TestExecute_SystemVariableInterpolation(t *testing.T) {
 		File: string(fs),
 	}
 
-	err = e.Execute(context.Background(), m, r)
+	v, err := e.Prepare(context.Background(), m, r)
+	require.NoError(t, err)
+
+	err = e.Execute(context.Background(), m, r, v)
 	require.NoError(t, err)
 
 	dat, err := ioutil.ReadFile(tmpFile.Name())

--- a/internal/install/execution/mock_recipe_executor.go
+++ b/internal/install/execution/mock_recipe_executor.go
@@ -16,6 +16,10 @@ func NewMockRecipeExecutor() *MockRecipeExecutor {
 	}
 }
 
-func (m *MockRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) error {
+func (m *MockRecipeExecutor) Prepare(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) (types.RecipeVars, error) {
+	return types.RecipeVars{}, nil
+}
+
+func (m *MockRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe, v types.RecipeVars) error {
 	return nil
 }

--- a/internal/install/execution/recipe_executor.go
+++ b/internal/install/execution/recipe_executor.go
@@ -9,5 +9,6 @@ import (
 // RecipeExecutor is responsible for execution of the task steps defined in a
 // recipe.
 type RecipeExecutor interface {
-	Execute(context.Context, types.DiscoveryManifest, types.Recipe) error
+	Prepare(context.Context, types.DiscoveryManifest, types.Recipe) (types.RecipeVars, error)
+	Execute(context.Context, types.DiscoveryManifest, types.Recipe, types.RecipeVars) error
 }

--- a/internal/install/recipes/service_recipe_fetcher.go
+++ b/internal/install/recipes/service_recipe_fetcher.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/newrelic/newrelic-cli/internal/install/types"
+	log "github.com/sirupsen/logrus"
 )
 
 // ServiceRecipeFetcher is an implementation of the recipeFetcher interface that
@@ -25,6 +26,10 @@ func NewServiceRecipeFetcher(client NerdGraphClient) RecipeFetcher {
 
 // FetchRecipe gets a recipe by name from the recipe service.
 func (f *ServiceRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.DiscoveryManifest, friendlyName string) (*types.Recipe, error) {
+	log.WithFields(log.Fields{
+		"name": friendlyName,
+	}).Debug("fetching recipe")
+
 	c, err := createRecipeSearchInput(manifest, friendlyName)
 	if err != nil {
 		return nil, err

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -28,6 +28,8 @@ type LogMatchAttributes struct {
 	LogType string `yaml:"logtype"`
 }
 
+type RecipeVars map[string]string
+
 // AddVar is responsible for including a new variable on the recipe Vars
 // struct, which is used by go-task executor.
 func (r *Recipe) AddVar(key string, value interface{}) {


### PR DESCRIPTION
Without this change, the UX for a user is less than ideal while prompting for
input vars on a given recipe.  Currently, the spinner for the task continues to
spin even while the process waits for input from the user.  To avoid confusing
the users, this work breaks the Execute() phase of a recipe execution into two
steps, Preapre() and Execute() to allow the process to gather all required input
up front and build the set of variables to be passed in to the Execute() phase.
This allows only the Execute() phase to show the spinner, while the Prepare()
phase does not.