### PR TITLE
fix(logging): set client logger level

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -44,8 +44,10 @@ var Command = &cobra.Command{
 		client.WithClientAndProfile(func(nrClient *newrelic.NewRelic, profile *credentials.Profile) {
 			if trace {
 				log.SetLevel(log.TraceLevel)
+				nrClient.SetLogLevel("trace")
 			} else if debug {
 				log.SetLevel(log.DebugLevel)
+				nrClient.SetLogLevel("debug")
 			}
 
 			err := assertProfileIsValid(profile)


### PR DESCRIPTION
Without this change, the client is not aware of the user's desires, and the log
level is confined to the logged messages in the CLI code.  Here we use a new
method on the client to set the log level when debug or trace are requested by
the user.