### PR TITLE
chore(install): add validation and filtering for platform and platform family

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -903,6 +903,7 @@ github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=

--- a/internal/install/discovery/psutil_discoverer_test.go
+++ b/internal/install/discovery/psutil_discoverer_test.go
@@ -1,0 +1,44 @@
+// +build unit
+
+package discovery
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsValidOpenInstallationPlatform(t *testing.T) {
+	require.True(t, isValidOpenInstallationPlatform(string(types.OpenInstallationPlatformTypes.AMAZON)))
+	require.False(t, isValidOpenInstallationPlatform("invalidValue"))
+}
+
+func TestIsValidOpenInstallationPlatformFamily(t *testing.T) {
+	require.True(t, isValidOpenInstallationPlatformFamily(string(types.OpenInstallationPlatformFamilyTypes.SUSE)))
+	require.False(t, isValidOpenInstallationPlatformFamily("invalidValue"))
+}
+
+func TestFilterValues_ValidPlatform(t *testing.T) {
+	m := types.DiscoveryManifest{
+		OS:             string(types.OpenInstallationOperatingSystemTypes.WINDOWS),
+		Platform:       string(types.OpenInstallationPlatformTypes.AMAZON),
+		PlatformFamily: string(types.OpenInstallationPlatformFamilyTypes.DEBIAN),
+	}
+	m = filterValues(m)
+
+	require.Equal(t, string(types.OpenInstallationPlatformTypes.AMAZON), m.Platform)
+	require.Equal(t, string(types.OpenInstallationPlatformFamilyTypes.DEBIAN), m.PlatformFamily)
+}
+
+func TestFilterValues_InvalidPlatform(t *testing.T) {
+	m := types.DiscoveryManifest{
+		OS:             string(types.OpenInstallationOperatingSystemTypes.WINDOWS),
+		Platform:       "invalidValue",
+		PlatformFamily: "invalidValue",
+	}
+	m = filterValues(m)
+
+	require.Empty(t, m.Platform)
+	require.Empty(t, m.PlatformFamily)
+}

--- a/internal/install/types/discovery_manifest.go
+++ b/internal/install/types/discovery_manifest.go
@@ -6,8 +6,8 @@ type DiscoveryManifest struct {
 	KernelArch      string           `json:"kernelArch"`
 	KernelVersion   string           `json:"kernelVersion"`
 	OS              string           `json:"os"`
-	Platform        string           `json:"platform"`
-	PlatformFamily  string           `json:"platformFamily"`
+	Platform        string           `json:"platform,omitempty"`
+	PlatformFamily  string           `json:"platformFamily,omitempty"`
 	PlatformVersion string           `json:"platformVersion"`
 	Processes       []GenericProcess `json:"processes"`
 }


### PR DESCRIPTION
This PR uses reflection over generated types to ensure that we are not sending invalid values for `platform` or `platformFamily` when retrieving recommendations from the recipe service.

cc @jbeveland27  @michaelkro 