### PR TITLE
fix(install): ensure all scope writes during complete reporting

### DIFF
--- a/internal/install/execution/status.go
+++ b/internal/install/execution/status.go
@@ -119,9 +119,13 @@ func (s *StatusRollup) ReportRecipeSkipped(event RecipeStatusEvent) {
 	}
 }
 
-func (s *StatusRollup) ReportComplete() {
+func (s *StatusRollup) ReportComplete(event RecipeStatusEvent) {
 	s.Complete = true
 	s.Timestamp = utils.GetTimestamp()
+
+	if event.EntityGUID != "" {
+		s.withEntityGUID(event.EntityGUID)
+	}
 
 	for _, r := range s.statusReporters {
 		if err := r.ReportComplete(s); err != nil {

--- a/internal/install/execution/status_test.go
+++ b/internal/install/execution/status_test.go
@@ -129,8 +129,9 @@ func TestStatusRollup_statusUpdateMethods(t *testing.T) {
 	require.Equal(t, result.Status, StatusTypes.SKIPPED)
 	require.False(t, s.hasFailed())
 
-	s.ReportComplete()
+	s.ReportComplete(RecipeStatusEvent{EntityGUID: "123"})
+	require.Equal(t, s.EntityGUIDs[0], "testGUID")
+	require.Equal(t, s.EntityGUIDs[1], "123")
 	require.True(t, s.Complete)
 	require.NotNil(t, s.Timestamp)
-
 }

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -198,7 +198,7 @@ func (i *RecipeInstaller) Install() error {
 		log.Debugf("Skipping installing integrations")
 	}
 
-	i.status.ReportComplete()
+	i.status.ReportComplete(execution.RecipeStatusEvent{EntityGUID: entityGUID})
 
 	return nil
 }
@@ -491,7 +491,7 @@ func (i *RecipeInstaller) userAcceptsInstall(r types.Recipe) (bool, error) {
 }
 
 func (i *RecipeInstaller) fail(err error) error {
-	i.status.ReportComplete()
+	i.status.ReportComplete(execution.RecipeStatusEvent{Msg: err.Error()})
 	return err
 }
 


### PR DESCRIPTION
Without this change, only the user scope is updated, even when we know the
entities that should be updated as well.  Here we ensure that the entity scope
is included as well when we report complete.