### PR TITLE
fix(install): capture guid from validation when alternate format

### DIFF
--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -95,11 +95,12 @@ func (r NerdstorageStatusReporter) writeStatus(status *StatusRollup, entityGUID 
 	}
 
 	if entityGUID != "" {
-		log.Debug("No entity GUID available, skipping entity-scoped status update.")
 		_, err := r.client.WriteDocumentWithEntityScope(entityGUID, i)
 		if err != nil {
 			return err
 		}
+	} else {
+		log.Debug("No entity GUID available, skipping entity-scoped status update.")
 	}
 
 	return nil

--- a/internal/install/validation/polling_recipe_validator.go
+++ b/internal/install/validation/polling_recipe_validator.go
@@ -98,9 +98,17 @@ func (m *PollingRecipeValidator) tryValidate(ctx context.Context, dm types.Disco
 	count := results[0]["count"].(float64)
 
 	if count > 0 {
-		// Try and parse an entity GUID from the results
-		// The query is assumed to optionally use a facet over entityGuid
+		// Try and parse an entity GUID from the results.  The query is assumed to
+		// optionally use a facet over entityGuid.  The standard case seems to be
+		// that all entities contain a facet of "entityGuid", and so if we find it
+		// here, we return it.
 		if entityGUID, ok := results[0]["entityGuid"]; ok {
+			return true, entityGUID.(string), nil
+		}
+
+		// In the logs integration, the facet doesn't contain "entityGuid", but
+		// does contain, "entity.guid", so here we check for that also.
+		if entityGUID, ok := results[0]["entity.guids"]; ok {
 			return true, entityGUID.(string), nil
 		}
 


### PR DESCRIPTION
Without this change, the GUID is not returned from a logs validation query due
to the different format.  The standard case seems to use entityGuid, while logs
uses entity.guids.  Here we ensure we capture both cases for the return.