### PR TITLE
chore(install): implement recommended recipe reporting

### DIFF
--- a/internal/install/execution/mock_status_reporter.go
+++ b/internal/install/execution/mock_status_reporter.go
@@ -7,26 +7,29 @@ import (
 // MockStatusReporter is a mock implementation of the ExecutionStatusReporter
 // interface that provides method spies for testing scenarios.
 type MockStatusReporter struct {
-	ReportRecipeAvailableErr        error
-	ReportRecipesAvailableErr       error
-	ReportRecipeFailedErr           error
-	ReportRecipeInstalledErr        error
-	ReportRecipeInstallingErr       error
-	ReportRecipeSkippedErr          error
-	ReportCompleteErr               error
-	ReportRecipeAvailableCallCount  int
-	ReportRecipesAvailableCallCount int
-	ReportRecipeFailedCallCount     int
-	ReportRecipeInstalledCallCount  int
-	ReportRecipeInstallingCallCount int
-	ReportRecipeSkippedCallCount    int
-	ReportCompleteCallCount         int
+	ReportRecipeAvailableErr         error
+	ReportRecipesAvailableErr        error
+	ReportRecipeFailedErr            error
+	ReportRecipeInstalledErr         error
+	ReportRecipeInstallingErr        error
+	ReportRecipeRecommendedErr       error
+	ReportRecipeSkippedErr           error
+	ReportCompleteErr                error
+	ReportRecipeAvailableCallCount   int
+	ReportRecipesAvailableCallCount  int
+	ReportRecipeFailedCallCount      int
+	ReportRecipeInstalledCallCount   int
+	ReportRecipeInstallingCallCount  int
+	ReportRecipeRecommendedCallCount int
+	ReportRecipeSkippedCallCount     int
+	ReportCompleteCallCount          int
 
-	ReportSkipped    map[string]int
-	ReportInstalled  map[string]int
-	ReportInstalling map[string]int
-	ReportFailed     map[string]int
-	ReportAvailable  map[string]int
+	ReportSkipped     map[string]int
+	ReportInstalled   map[string]int
+	ReportInstalling  map[string]int
+	ReportRecommended map[string]int
+	ReportFailed      map[string]int
+	ReportAvailable   map[string]int
 }
 
 // NewMockStatusReporter returns a new instance of MockExecutionStatusReporter.
@@ -59,6 +62,15 @@ func (r *MockStatusReporter) ReportRecipeInstalling(status *StatusRollup, event 
 	}
 	r.ReportInstalling[event.Recipe.Name]++
 	return r.ReportRecipeInstallingErr
+}
+
+func (r *MockStatusReporter) ReportRecipeRecommended(status *StatusRollup, event RecipeStatusEvent) error {
+	r.ReportRecipeRecommendedCallCount++
+	if len(r.ReportRecommended) == 0 {
+		r.ReportRecommended = make(map[string]int)
+	}
+	r.ReportRecommended[event.Recipe.Name]++
+	return r.ReportRecipeRecommendedErr
 }
 
 func (r *MockStatusReporter) ReportRecipeSkipped(status *StatusRollup, event RecipeStatusEvent) error {

--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -71,6 +71,14 @@ func (r NerdstorageStatusReporter) ReportRecipeInstalled(status *StatusRollup, e
 	return nil
 }
 
+func (r NerdstorageStatusReporter) ReportRecipeRecommended(status *StatusRollup, event RecipeStatusEvent) error {
+	if err := r.writeStatus(status, event.EntityGUID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (r NerdstorageStatusReporter) ReportRecipeSkipped(status *StatusRollup, event RecipeStatusEvent) error {
 	if err := r.writeStatus(status, event.EntityGUID); err != nil {
 		return err

--- a/internal/install/execution/status.go
+++ b/internal/install/execution/status.go
@@ -29,17 +29,19 @@ type Status struct {
 type StatusType string
 
 var StatusTypes = struct {
-	AVAILABLE  StatusType
-	INSTALLING StatusType
-	FAILED     StatusType
-	INSTALLED  StatusType
-	SKIPPED    StatusType
+	AVAILABLE   StatusType
+	INSTALLING  StatusType
+	FAILED      StatusType
+	INSTALLED   StatusType
+	SKIPPED     StatusType
+	RECOMMENDED StatusType
 }{
-	AVAILABLE:  "AVAILABLE",
-	INSTALLING: "INSTALLING",
-	FAILED:     "FAILED",
-	INSTALLED:  "INSTALLED",
-	SKIPPED:    "SKIPPED",
+	AVAILABLE:   "AVAILABLE",
+	INSTALLING:  "INSTALLING",
+	FAILED:      "FAILED",
+	INSTALLED:   "INSTALLED",
+	SKIPPED:     "SKIPPED",
+	RECOMMENDED: "RECOMMENDED",
 }
 
 type StatusRecipeError struct {
@@ -84,6 +86,21 @@ func (s *StatusRollup) ReportRecipeInstalled(event RecipeStatusEvent) {
 
 	for _, r := range s.statusReporters {
 		if err := r.ReportRecipeInstalled(s, event); err != nil {
+			log.Errorf("Error writing recipe status for recipe %s: %s", event.Recipe.Name, err)
+		}
+	}
+}
+
+// ReportRecipeRecommended is responsible for setting the nerstorage scopes
+// when a recipe is recommended.  This is used when a recipe is found, but not
+// a "HOST" type, and is used to indicate to the user that it is something they
+// should consider integrating, but not something that the recipe framework
+// will currently assist with.
+func (s *StatusRollup) ReportRecipeRecommended(event RecipeStatusEvent) {
+	s.withRecipeEvent(event, StatusTypes.RECOMMENDED)
+
+	for _, r := range s.statusReporters {
+		if err := r.ReportRecipeRecommended(s, event); err != nil {
 			log.Errorf("Error writing recipe status for recipe %s: %s", event.Recipe.Name, err)
 		}
 	}

--- a/internal/install/execution/status_reporter.go
+++ b/internal/install/execution/status_reporter.go
@@ -9,6 +9,7 @@ type StatusReporter interface {
 	ReportRecipeFailed(status *StatusRollup, event RecipeStatusEvent) error
 	ReportRecipeInstalled(status *StatusRollup, event RecipeStatusEvent) error
 	ReportRecipeInstalling(status *StatusRollup, event RecipeStatusEvent) error
+	ReportRecipeRecommended(status *StatusRollup, event RecipeStatusEvent) error
 	ReportRecipeSkipped(status *StatusRollup, event RecipeStatusEvent) error
 	ReportRecipesAvailable(status *StatusRollup, recipes []types.Recipe) error
 }

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -34,6 +34,10 @@ func (r TerminalStatusReporter) ReportRecipeSkipped(status *StatusRollup, event 
 	return nil
 }
 
+func (r TerminalStatusReporter) ReportRecipeRecommended(status *StatusRollup, event RecipeStatusEvent) error {
+	return nil
+}
+
 func (r TerminalStatusReporter) ReportRecipesAvailable(status *StatusRollup, recipes []types.Recipe) error {
 	if len(recipes) > 0 {
 		fmt.Println("The following will be installed:")

--- a/internal/install/recipes/service_recipe_fetcher.go
+++ b/internal/install/recipes/service_recipe_fetcher.go
@@ -242,6 +242,7 @@ func createRecipe(result types.OpenInstallationRecipe) types.Recipe {
 		Description:    result.Description,
 		DisplayName:    result.DisplayName,
 		File:           result.File,
+		InstallTargets: result.InstallTargets,
 		Keywords:       result.Keywords,
 		LogMatch:       createLogMatches(result.LogMatch),
 		Name:           result.Name,

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -1,16 +1,17 @@
 package types
 
 type Recipe struct {
-	ID             string     `json:"id"`
-	File           string     `json:"file"`
-	Name           string     `json:"name"`
-	DisplayName    string     `json:"displayName"`
-	Description    string     `json:"description"`
-	Repository     string     `json:"repository"`
-	Keywords       []string   `json:"keywords"`
-	ProcessMatch   []string   `json:"processMatch"`
-	LogMatch       []LogMatch `json:"logMatch"`
-	ValidationNRQL string     `json:"validationNrql"`
+	ID             string                                `json:"id"`
+	Description    string                                `json:"description"`
+	DisplayName    string                                `json:"displayName"`
+	File           string                                `json:"file"`
+	InstallTargets []OpenInstallationRecipeInstallTarget `json:"installTargets"`
+	Keywords       []string                              `json:"keywords"`
+	LogMatch       []LogMatch                            `json:"logMatch"`
+	Name           string                                `json:"name"`
+	ProcessMatch   []string                              `json:"processMatch"`
+	Repository     string                                `json:"repository"`
+	ValidationNRQL string                                `json:"validationNrql"`
 	Vars           map[string]interface{}
 }
 


### PR DESCRIPTION
Currently, all the recipes up to this point have been of type HOST.  Here we
seek to report on any non-HOST recipes, but only take the install actions when
the type is a HOST.  This work plumbs through the Recommended() methods through
the reporters and ensures that we only attempt to install recipes that are of
type HOST, regardless of what was returned from the recommendations endpoint.