### PR TITLE
chore(install): remove the option to skip infra install

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -17,7 +17,6 @@ var (
 	recipeNames        []string
 	recipePaths        []string
 	skipDiscovery      bool
-	skipInfraInstall   bool
 	skipIntegrations   bool
 	skipLoggingInstall bool
 	testMode           bool
@@ -36,7 +35,6 @@ var Command = &cobra.Command{
 			RecipeNames:        recipeNames,
 			RecipePaths:        recipePaths,
 			SkipDiscovery:      skipDiscovery,
-			SkipInfraInstall:   skipInfraInstall,
 			SkipIntegrations:   skipIntegrations,
 			SkipLoggingInstall: skipLoggingInstall,
 		}
@@ -76,7 +74,6 @@ func init() {
 	Command.Flags().StringSliceVarP(&recipePaths, "recipePath", "c", []string{}, "the path to a recipe file to install")
 	Command.Flags().StringSliceVarP(&recipeNames, "recipe", "n", []string{}, "the name of a recipe to install")
 	Command.Flags().BoolVarP(&skipDiscovery, "skipDiscovery", "d", false, "skips discovery of recommended New Relic integrations")
-	Command.Flags().BoolVarP(&skipInfraInstall, "skipInfraInstall", "i", false, "skips installation of New Relic Infrastructure Agent")
 	Command.Flags().BoolVarP(&skipIntegrations, "skipIntegrations", "r", false, "skips installation of recommended New Relic integrations")
 	Command.Flags().BoolVarP(&skipLoggingInstall, "skipLoggingInstall", "l", false, "skips installation of New Relic Logging")
 	Command.Flags().BoolVarP(&testMode, "testMode", "t", false, "fakes operations for UX testing")

--- a/internal/install/install_context.go
+++ b/internal/install/install_context.go
@@ -6,7 +6,6 @@ type InstallerContext struct {
 	RecipeNames        []string
 	RecipePaths        []string
 	SkipDiscovery      bool
-	SkipInfraInstall   bool
 	SkipIntegrations   bool
 	SkipLoggingInstall bool
 }
@@ -16,7 +15,7 @@ func (i *InstallerContext) ShouldRunDiscovery() bool {
 }
 
 func (i *InstallerContext) ShouldInstallInfraAgent() bool {
-	return !i.RecipesProvided() && !i.SkipInfraInstall
+	return !i.RecipesProvided()
 }
 
 func (i *InstallerContext) ShouldInstallLogging() bool {

--- a/internal/install/install_context_test.go
+++ b/internal/install/install_context_test.go
@@ -17,9 +17,6 @@ func TestShouldRunDiscovery_Default(t *testing.T) {
 func TestShouldInstallInfraAgent_Default(t *testing.T) {
 	ic := InstallerContext{}
 	require.True(t, ic.ShouldInstallInfraAgent())
-
-	ic.SkipInfraInstall = true
-	require.False(t, ic.ShouldInstallInfraAgent())
 }
 
 func TestShouldInstallInfraAgent_RecipePathsProvided(t *testing.T) {

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -589,7 +589,7 @@ func (i *RecipeInstaller) filterSkippedRecipes(recipes []types.Recipe) ([]types.
 	log.Debugf("reportedDisplayNames: %+v", reportedDisplayNames)
 	log.Debugf("recipes: %+v", recipes)
 
-	selectedRecipeNames := []string{}
+	var selectedRecipeNames []string
 	if i.AssumeYes {
 		// When -y is supplied, select all the recipes that were in the report for install.
 		selectedRecipeNames = reportedDisplayNames

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -236,16 +236,6 @@ func (i *RecipeInstaller) Install() error {
 		log.Debugf("Done installing integrations.")
 	}
 
-	isAppTarget := func(recipe types.Recipe) bool {
-		for _, target := range recipe.InstallTargets {
-			if target.Type != types.OpenInstallationTargetTypeTypes.APPLICATION {
-				return false
-			}
-		}
-
-		return true
-	}
-
 	for _, r := range allRecipes {
 		if isAppTarget(r) {
 			i.status.ReportRecipeRecommended(execution.RecipeStatusEvent{
@@ -651,4 +641,14 @@ func (i *RecipeInstaller) filterSkippedRecipes(recipes []types.Recipe) ([]types.
 	}
 
 	return filteredRecipes, nil
+}
+
+func isAppTarget(recipe types.Recipe) bool {
+	for _, target := range recipe.InstallTargets {
+		if target.Type != types.OpenInstallationTargetTypeTypes.APPLICATION {
+			return false
+		}
+	}
+
+	return true
 }

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -46,7 +46,6 @@ func TestNewRecipeInstaller_InstallerContextFields(t *testing.T) {
 		RecipePaths:        []string{"testRecipePath"},
 		RecipeNames:        []string{"testRecipeName"},
 		SkipDiscovery:      true,
-		SkipInfraInstall:   true,
 		SkipIntegrations:   true,
 		SkipLoggingInstall: true,
 	}
@@ -110,21 +109,26 @@ func TestInstall_ReportRecipeInstalled(t *testing.T) {
 	status = execution.NewStatusRollup(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.Recipe{{
+		Name:           testRecipeName,
+		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
 	f.FetchRecipeVals = []types.Recipe{
 		{
 			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
 			ValidationNRQL: "testNrql",
 		},
 		{
 			Name:           loggingRecipeName,
+			DisplayName:    loggingRecipeName,
 			ValidationNRQL: "testNrql",
 		},
 	}
 
 	p = &ux.MockPrompter{
-		PromptYesNoVal: true,
+		PromptYesNoVal:       true,
+		PromptMultiSelectAll: true,
 	}
 
 	v = validation.NewMockRecipeValidator()
@@ -137,20 +141,32 @@ func TestInstall_ReportRecipeInstalled(t *testing.T) {
 
 func TestInstall_ReportRecipeFailed(t *testing.T) {
 	ic := InstallerContext{
-		SkipInfraInstall:   true,
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusReporter{execution.NewMockStatusReporter()}
 	status = execution.NewStatusRollup(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.Recipe{{
-		Name:           "test-recipe",
+		Name:           testRecipeName,
+		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{{}, {}}
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+		{
+			Name:           loggingRecipeName,
+			DisplayName:    loggingRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
 
 	p = &ux.MockPrompter{
-		PromptYesNoVal: true,
+		PromptYesNoVal:       true,
+		PromptMultiSelectAll: true,
 	}
 
 	v = validation.NewMockRecipeValidator()
@@ -161,12 +177,11 @@ func TestInstall_ReportRecipeFailed(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 1, v.ValidateCallCount)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeFailedCallCount)
-	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
 }
 
 func TestInstall_ReportComplete(t *testing.T) {
 	ic := InstallerContext{
-		SkipInfraInstall:   true,
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusReporter{execution.NewMockStatusReporter()}
@@ -181,7 +196,7 @@ func TestInstall_ReportComplete(t *testing.T) {
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportCompleteCallCount)
-	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
 }
 
 func TestInstall_ReportCompleteError(t *testing.T) {
@@ -215,7 +230,6 @@ func TestInstall_ReportCompleteError(t *testing.T) {
 
 func TestInstall_ReportRecipeSkipped(t *testing.T) {
 	ic := InstallerContext{
-		SkipInfraInstall:   true,
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusReporter{execution.NewMockStatusReporter()}
@@ -223,26 +237,36 @@ func TestInstall_ReportRecipeSkipped(t *testing.T) {
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.Recipe{{
 		Name:           testRecipeName,
+		DisplayName:    "test displayName",
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{{Name: "one"}, {Name: "two"}}
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:        infraAgentRecipeName,
+			DisplayName: "Infra Recipe",
+		},
+		{
+			Name:        loggingRecipeName,
+			DisplayName: "Logging Recipe",
+		},
+	}
 
 	v = validation.NewMockRecipeValidator()
 	p = &ux.MockPrompter{
-		PromptYesNoVal: true,
+		PromptYesNoVal:       true,
+		PromptMultiSelectAll: true,
 	}
 
 	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
 	err := i.Install()
 	require.NoError(t, err)
-	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstallingCallCount)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstallingCallCount)
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
 }
 
-func TestInstall_ReportRecipeSkipped_skipping_integrations(t *testing.T) {
+func TestInstall_ReportRecipeSkipped_skipping_everything(t *testing.T) {
 	ic := InstallerContext{
-		SkipInfraInstall:   true,
 		SkipLoggingInstall: true,
 		SkipIntegrations:   true,
 	}
@@ -265,12 +289,12 @@ func TestInstall_ReportRecipeSkipped_skipping_integrations(t *testing.T) {
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 3, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
-	require.Equal(t, 0, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
+	// The infra agent always gets installed
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
 }
 
 func TestInstall_ReportRecipeSkipped_multiselect(t *testing.T) {
 	ic := InstallerContext{
-		SkipInfraInstall:   true,
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusReporter{execution.NewMockStatusReporter()}
@@ -293,8 +317,9 @@ func TestInstall_ReportRecipeSkipped_multiselect(t *testing.T) {
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstallingCallCount)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
+	// The infra agent always gets installed
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstallingCallCount)
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
 }
 
 func TestInstall_ReportRecipeRecommended(t *testing.T) {
@@ -367,7 +392,45 @@ func TestInstallAdvancedMode_bounce_on_enter(t *testing.T) {
 	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
 	err := i.Install()
 	require.NoError(t, err)
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
+}
+
+func TestInstall_ReportRecipeSkipped_assumeYes(t *testing.T) {
+	ic := InstallerContext{
+		AssumeYes: true,
+	}
+
+	statusReporters = []execution.StatusReporter{execution.NewMockStatusReporter()}
+	status = execution.NewStatusRollup(statusReporters)
+	f = recipes.NewMockRecipeFetcher()
+	f.FetchRecommendationsVal = []types.Recipe{{
+		Name:           testRecipeName,
+		DisplayName:    "test displayName",
+		ValidationNRQL: "testNrql",
+	}}
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:        infraAgentRecipeName,
+			DisplayName: "Infra Recipe",
+		},
+		{
+			Name:        loggingRecipeName,
+			DisplayName: "Logging Recipe",
+		},
+	}
+
+	v = validation.NewMockRecipeValidator()
+	p = &ux.MockPrompter{
+		PromptYesNoVal: true,
+		// PromptMultiSelectAll: true,
+	}
+
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	err := i.Install()
+	require.NoError(t, err)
 	require.Equal(t, 0, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeSkippedCallCount)
+	require.Equal(t, 3, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstallingCallCount)
 	require.Equal(t, 3, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
 }
 

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -330,6 +330,7 @@ func TestInstall_ReportRecipeRecommended(t *testing.T) {
 	f.FetchRecommendationsVal = []types.Recipe{
 		{
 			Name:           testRecipeName,
+			DisplayName:    testRecipeName,
 			ValidationNRQL: "testNrql",
 			InstallTargets: []types.OpenInstallationRecipeInstallTarget{
 				{
@@ -351,15 +352,18 @@ func TestInstall_ReportRecipeRecommended(t *testing.T) {
 
 	v = validation.NewMockRecipeValidator()
 	p = &ux.MockPrompter{
-		PromptYesNoVal: true,
+		PromptYesNoVal:       true,
+		PromptMultiSelectVal: []string{testRecipeName},
 	}
 
 	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
 	err := i.Install()
 	require.NoError(t, err)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeRecommendedCallCount)
-	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
+	// The infra agent is always installed
+	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeInstalledCallCount)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportInstalled[testRecipeName])
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportInstalled["one"])
+	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecipeRecommendedCallCount)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).ReportRecommended["java-java-java"])
 }
 

--- a/internal/install/test_command.go
+++ b/internal/install/test_command.go
@@ -22,7 +22,6 @@ var TestCommand = &cobra.Command{
 			RecipePaths:        recipePaths,
 			RecipeNames:        recipeNames,
 			SkipDiscovery:      skipDiscovery,
-			SkipInfraInstall:   skipInfraInstall,
 			SkipIntegrations:   skipIntegrations,
 			SkipLoggingInstall: skipLoggingInstall,
 			AssumeYes:          assumeYes,
@@ -45,7 +44,6 @@ func init() {
 	TestCommand.Flags().StringSliceVarP(&recipePaths, "recipePath", "c", []string{}, "the path to a recipe file to install")
 	TestCommand.Flags().StringSliceVarP(&recipeNames, "recipe", "n", []string{}, "the name of a recipe to install")
 	TestCommand.Flags().BoolVarP(&skipDiscovery, "skipDiscovery", "d", false, "skips discovery of recommended New Relic integrations")
-	TestCommand.Flags().BoolVarP(&skipInfraInstall, "skipInfraInstall", "i", false, "skips installation of New Relic Infrastructure Agent")
 	TestCommand.Flags().BoolVarP(&skipIntegrations, "skipIntegrations", "r", false, "skips installation of recommended New Relic integrations")
 	TestCommand.Flags().BoolVarP(&skipLoggingInstall, "skipLoggingInstall", "l", false, "skips installation of New Relic Logging")
 	TestCommand.Flags().StringVarP(&testScenario, "testScenario", "s", string(Basic), fmt.Sprintf("test scenario to run, defaults to BASIC.  Valid values are %s", strings.Join(TestScenarioValues(), ",")))

--- a/internal/install/ux/mock_prompter.go
+++ b/internal/install/ux/mock_prompter.go
@@ -2,12 +2,12 @@ package ux
 
 type MockPrompter struct {
 	PromptYesNoVal             bool
+	PromptMultiSelectAll       bool
 	PromptYesNoErr             error
 	PromptYesNoCallCount       int
 	PromptMultiSelectVal       []string
 	PromptMultiSelectErr       error
 	PromptMultiSelectCallCount int
-	PromptMultiSelectAll       bool
 }
 
 func NewMockPrompter() *MockPrompter {

--- a/internal/install/ux/mock_prompter.go
+++ b/internal/install/ux/mock_prompter.go
@@ -7,6 +7,7 @@ type MockPrompter struct {
 	PromptMultiSelectVal       []string
 	PromptMultiSelectErr       error
 	PromptMultiSelectCallCount int
+	PromptMultiSelectAll       bool
 }
 
 func NewMockPrompter() *MockPrompter {
@@ -20,5 +21,10 @@ func (p *MockPrompter) PromptYesNo(msg string) (bool, error) {
 
 func (p *MockPrompter) MultiSelect(msg string, options []string) ([]string, error) {
 	p.PromptMultiSelectCallCount++
+
+	if p.PromptMultiSelectAll {
+		return options, nil
+	}
+
 	return p.PromptMultiSelectVal, p.PromptMultiSelectErr
 }


### PR DESCRIPTION
This change means that the infra agent will be installed each time, unless the
user supplies a recipe by name or by URL.