### PR TITLE
fix(install): make ctrl-c exit reliably

### DIFF
--- a/internal/install/execution/go_task_recipe_executor.go
+++ b/internal/install/execution/go_task_recipe_executor.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/go-task/task/v3"
 	taskargs "github.com/go-task/task/v3/args"
@@ -123,6 +124,12 @@ func (re *GoTaskRecipeExecutor) Execute(ctx context.Context, m types.DiscoveryMa
 	}
 
 	if err := e.Run(ctx, calls...); err != nil {
+		// go-task does not provide an error type to denote context cancelation
+		// Therefore we need to match inside the error message
+		if strings.Contains(err.Error(), "context canceled") {
+			return types.NewErrInterrupt()
+		}
+
 		return err
 	}
 
@@ -204,6 +211,10 @@ func varsFromInput(inputVars []recipes.VariableConfig, assumeYes bool) (types.Re
 
 			envValue, err = varFromPrompt(envConfig)
 			if err != nil {
+				if err == promptui.ErrInterrupt {
+					return types.RecipeVars{}, types.NewErrInterrupt()
+				}
+
 				return types.RecipeVars{}, fmt.Errorf("prompt failed: %s", err)
 			}
 		}

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -1,0 +1,13 @@
+package types
+
+// ErrInterrupt represents a context cancellation.
+type ErrInterrupt struct{}
+
+func (e *ErrInterrupt) Error() string {
+	return "operation cancelled"
+}
+
+// NewErrInterrupt creates a new instance of ErrInterrupt.
+func NewErrInterrupt() *ErrInterrupt {
+	return &ErrInterrupt{}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -25,7 +25,7 @@ func getSignalContext() context.Context {
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		sig := <-ch
-		log.Warnf("signal received: %s", sig)
+		log.Debugf("signal received: %s", sig)
 		cancel()
 	}()
 	return ctx


### PR DESCRIPTION
At any phase during the install command (prompts, execution, validation), if ctrl-c is pressed the command should cease execution without attempting to do anything else.

In the case of third-party libraries, cancelled contexts are handled from within the libraries and allow for executing IO-blocking procedures with a passed context.

All we need to do is handle the error that comes back from those libraries appropriately.  In the case of the OHI execution loop, we opt to try the next recipe if the current one fails - this leads to unexpected behavior when ctrl-c is the cause of the error.

This PR makes it so that we will try the next recipe, but only if the error that comes back from the various 3rd party libraries was not generated by a context cancellation.