### PR TITLE
chore(install): remove pre-release designation

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -26,9 +26,8 @@ var (
 
 // Command represents the install command.
 var Command = &cobra.Command{
-	Use:    "install",
-	Short:  "Install New Relic.",
-	Hidden: true,
+	Use:   "install",
+	Short: "Install New Relic.",
 	Run: func(cmd *cobra.Command, args []string) {
 		ic := InstallerContext{
 			AssumeYes:          assumeYes,


### PR DESCRIPTION
Removing pre-release designation for the `install` command to prepare for GA.