### PR TITLE
Chore/report all entities

### DIFF
--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -41,6 +41,7 @@ func TestReportRecipeSucceeded_Basic(t *testing.T) {
 
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
 	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID(entityGUID)
 
 	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -39,10 +39,8 @@ func TestRecipeInstalled_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	err := r.RecipeInstalled(status, e)
 	require.NoError(t, err)
@@ -54,7 +52,6 @@ func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
-
 	e := RecipeStatusEvent{}
 
 	err := r.RecipeInstalled(status, e)
@@ -63,16 +60,28 @@ func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
 }
 
+func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
+	c := NewMockNerdStorageClient()
+	r := NewNerdStorageStatusReporter(c)
+	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID("testGuid")
+	status.withEntityGUID("testGuid2")
+	e := RecipeStatusEvent{}
+
+	err := r.RecipeInstalled(status, e)
+	require.NoError(t, err)
+	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 2, c.writeDocumentWithEntityScopeCallCount)
+}
+
 func TestRecipeInstalled_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
 
 	err := r.RecipeInstalled(status, e)
 	require.Error(t, err)
@@ -82,12 +91,10 @@ func TestRecipeInstalled_EntityScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	c.WriteDocumentWithEntityScopeErr = errors.New("error")
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
 
 	err := r.RecipeInstalled(status, e)
 	require.Error(t, err)
@@ -97,10 +104,8 @@ func TestRecipeFailed_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	err := r.RecipeFailed(status, e)
 	require.NoError(t, err)
@@ -125,12 +130,10 @@ func TestRecipeFailed_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
 
 	err := r.RecipeFailed(status, e)
 	require.Error(t, err)
@@ -140,12 +143,10 @@ func TestRecipeFailed_EntityScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus([]StatusSubscriber{r})
+	status.withEntityGUID("testGuid")
+	e := RecipeStatusEvent{}
 
 	c.WriteDocumentWithEntityScopeErr = errors.New("error")
-
-	e := RecipeStatusEvent{
-		EntityGUID: "testGuid",
-	}
 
 	err := r.RecipeFailed(status, e)
 	require.Error(t, err)

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -45,7 +45,7 @@ func NewRecipeInstaller(ic InstallerContext, nrClient *newrelic.NewRelic) *Recip
 	re := execution.NewGoTaskRecipeExecutor()
 	v := validation.NewPollingRecipeValidator(&nrClient.Nrdb)
 	p := ux.NewPromptUIPrompter()
-	s := ux.NewPlainProgress()
+	pi := ux.NewPlainProgress()
 
 	i := RecipeInstaller{
 		discoverer:        d,
@@ -56,7 +56,7 @@ func NewRecipeInstaller(ic InstallerContext, nrClient *newrelic.NewRelic) *Recip
 		recipeFileFetcher: ff,
 		status:            statusRollup,
 		prompter:          p,
-		progressIndicator: s,
+		progressIndicator: pi,
 	}
 
 	i.InstallerContext = ic
@@ -191,7 +191,8 @@ func (i *RecipeInstaller) executeAndValidate(m *types.DiscoveryManifest, r *type
 }
 
 func (i *RecipeInstaller) executeAndValidateWithProgress(m *types.DiscoveryManifest, r *types.Recipe) (string, error) {
-	i.progressIndicator.Start(*r)
+	msg := fmt.Sprintf("Installing %s", r.Name)
+	i.progressIndicator.Start(msg)
 	defer func() { i.progressIndicator.Stop() }()
 
 	if r.PreInstallMessage() != "" {
@@ -207,7 +208,7 @@ func (i *RecipeInstaller) executeAndValidateWithProgress(m *types.DiscoveryManif
 
 	entityGUID, err := i.executeAndValidate(m, r, vars)
 	if err != nil {
-		i.progressIndicator.Fail(*r)
+		i.progressIndicator.Fail(msg)
 		return "", err
 	}
 
@@ -215,7 +216,7 @@ func (i *RecipeInstaller) executeAndValidateWithProgress(m *types.DiscoveryManif
 		fmt.Println(r.PostInstallMessage())
 	}
 
-	i.progressIndicator.Success(*r)
+	i.progressIndicator.Success(msg)
 	return entityGUID, nil
 }
 

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -34,7 +34,7 @@ var (
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status          = execution.NewInstallStatus(statusReporters)
 	p               = ux.NewMockPrompter()
-	s               = ux.NewMockProgressIndicator()
+	pi              = ux.NewMockProgressIndicator()
 )
 
 func TestInstall(t *testing.T) {
@@ -50,7 +50,7 @@ func TestNewRecipeInstaller_InstallerContextFields(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 
 	require.True(t, reflect.DeepEqual(ic, i.InstallerContext))
 }
@@ -59,7 +59,7 @@ func TestShouldGetRecipeFromURL(t *testing.T) {
 	ic := InstallerContext{}
 	ff = recipes.NewMockRecipeFileFetcher()
 	ff.FetchRecipeFileFunc = fetchRecipeFileFunc
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 
 	recipe, err := i.recipeFromPath("http://recipe/URL")
 	require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestShouldGetRecipeFromFile(t *testing.T) {
 	ic := InstallerContext{}
 	ff = recipes.NewMockRecipeFileFetcher()
 	ff.LoadRecipeFileFunc = loadRecipeFileFunc
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 
 	recipe, err := i.recipeFromPath("file.txt")
 	require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestInstall_Basic(t *testing.T) {
 		{Name: infraAgentRecipeName},
 		{Name: loggingRecipeName},
 	}
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, f.FetchRecipeNameCount[infraAgentRecipeName], 1)
@@ -115,7 +115,7 @@ func TestInstall_RecipesAvailable(t *testing.T) {
 		},
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).RecipesAvailableCallCount)
@@ -151,7 +151,7 @@ func TestInstall_RecipeInstalled(t *testing.T) {
 
 	v = validation.NewMockRecipeValidator()
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 3, statusReporters[0].(*execution.MockStatusReporter).RecipeInstalledCallCount)
@@ -190,7 +190,7 @@ func TestInstall_RecipeFailed(t *testing.T) {
 	v = validation.NewMockRecipeValidator()
 	v.ValidateErr = errors.New("validationErr")
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.Error(t, err)
 	require.Equal(t, 1, v.ValidateCallCount)
@@ -215,7 +215,7 @@ func TestInstall_InstallComplete(t *testing.T) {
 
 	v = validation.NewMockRecipeValidator()
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).InstallCompleteCallCount)
@@ -244,7 +244,7 @@ func TestInstall_InstallCompleteError(t *testing.T) {
 	v = validation.NewMockRecipeValidator()
 	v.ValidateErr = errors.New("test error")
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.Error(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).InstallCompleteCallCount)
@@ -280,7 +280,7 @@ func TestInstall_RecipeSkipped(t *testing.T) {
 		PromptMultiSelectAll: true,
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).RecipeSkippedCallCount)
@@ -317,7 +317,7 @@ func TestInstall_RecipeSkipped_SkipAll(t *testing.T) {
 		PromptMultiSelectVal: []string{},
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 3, statusReporters[0].(*execution.MockStatusReporter).RecipeSkippedCallCount)
@@ -353,7 +353,7 @@ func TestInstall_RecipeSkipped_MultiSelect(t *testing.T) {
 		PromptMultiSelectVal: []string{testRecipeName},
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 1, statusReporters[0].(*execution.MockStatusReporter).RecipeSkippedCallCount)
@@ -406,7 +406,7 @@ func TestInstall_RecipeRecommended(t *testing.T) {
 		PromptMultiSelectVal: []string{testRecipeName},
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 2, statusReporters[0].(*execution.MockStatusReporter).RecipeSkippedCallCount)
@@ -449,7 +449,7 @@ func TestInstall_RecipeSkipped_AssumeYes(t *testing.T) {
 		// PromptMultiSelectAll: true,
 	}
 
-	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, s}
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
 	err := i.Install()
 	require.NoError(t, err)
 	require.Equal(t, 0, statusReporters[0].(*execution.MockStatusReporter).RecipeSkippedCallCount)

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -7,6 +7,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-cli/internal/install/ux"
 	"github.com/newrelic/newrelic-cli/internal/install/validation"
+	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
 )
 
 type TestScenario string
@@ -24,6 +25,16 @@ var (
 		LogMatches,
 		Fail,
 		StitchedPath,
+	}
+	emptyResults = []nrdb.NRDBResult{
+		map[string]interface{}{
+			"count": 0.0,
+		},
+	}
+	nonEmptyResults = []nrdb.NRDBResult{
+		map[string]interface{}{
+			"count": 1.0,
+		},
 	}
 )
 
@@ -72,7 +83,9 @@ func (b *ScenarioBuilder) Basic() *RecipeInstaller {
 		execution.NewTerminalStatusReporter(),
 	}
 	statusRollup := execution.NewInstallStatus(ers)
-	v := validation.NewMockRecipeValidator()
+	c := validation.NewMockNRDBClient()
+	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
+	v := validation.NewPollingRecipeValidator(c)
 
 	pf := discovery.NewRegexProcessFilterer(rf)
 	ff := recipes.NewRecipeFileFetcher()
@@ -80,7 +93,7 @@ func (b *ScenarioBuilder) Basic() *RecipeInstaller {
 	gff := discovery.NewGlobFileFilterer()
 	re := execution.NewGoTaskRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
-	s := ux.NewSpinner()
+	s := ux.NewPlainProgress()
 
 	i := RecipeInstaller{
 		discoverer:        d,
@@ -108,7 +121,9 @@ func (b *ScenarioBuilder) Fail() *RecipeInstaller {
 		execution.NewTerminalStatusReporter(),
 	}
 	statusRollup := execution.NewInstallStatus(ers)
-	v := validation.NewMockRecipeValidator()
+	c := validation.NewMockNRDBClient()
+	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
+	v := validation.NewPollingRecipeValidator(c)
 
 	pf := discovery.NewRegexProcessFilterer(rf)
 	ff := recipes.NewRecipeFileFetcher()
@@ -116,7 +131,7 @@ func (b *ScenarioBuilder) Fail() *RecipeInstaller {
 	gff := discovery.NewGlobFileFilterer()
 	re := execution.NewMockFailingRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
-	s := ux.NewSpinner()
+	pi := ux.NewPlainProgress()
 
 	i := RecipeInstaller{
 		discoverer:        d,
@@ -127,7 +142,7 @@ func (b *ScenarioBuilder) Fail() *RecipeInstaller {
 		recipeFileFetcher: ff,
 		status:            statusRollup,
 		prompter:          p,
-		progressIndicator: s,
+		progressIndicator: pi,
 	}
 
 	i.InstallerContext = b.installerContext
@@ -144,7 +159,9 @@ func (b *ScenarioBuilder) LogMatches() *RecipeInstaller {
 		execution.NewTerminalStatusReporter(),
 	}
 	statusRollup := execution.NewInstallStatus(ers)
-	v := validation.NewMockRecipeValidator()
+	c := validation.NewMockNRDBClient()
+	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
+	v := validation.NewPollingRecipeValidator(c)
 	gff := discovery.NewMockFileFilterer()
 
 	pf := discovery.NewRegexProcessFilterer(rf)
@@ -152,7 +169,7 @@ func (b *ScenarioBuilder) LogMatches() *RecipeInstaller {
 	d := discovery.NewPSUtilDiscoverer(pf)
 	re := execution.NewGoTaskRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
-	s := ux.NewSpinner()
+	pi := ux.NewPlainProgress()
 
 	gff.FilterVal = []types.LogMatch{
 		{
@@ -170,7 +187,7 @@ func (b *ScenarioBuilder) LogMatches() *RecipeInstaller {
 		recipeFileFetcher: ff,
 		status:            statusRollup,
 		prompter:          p,
-		progressIndicator: s,
+		progressIndicator: pi,
 	}
 
 	i.InstallerContext = b.installerContext
@@ -186,7 +203,9 @@ func (b *ScenarioBuilder) StitchedPath() *RecipeInstaller {
 		execution.NewTerminalStatusReporter(),
 	}
 	statusRollup := execution.NewInstallStatus(ers)
-	v := validation.NewMockRecipeValidator()
+	c := validation.NewMockNRDBClient()
+	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
+	v := validation.NewPollingRecipeValidator(c)
 
 	pf := discovery.NewRegexProcessFilterer(rf)
 	ff := recipes.NewRecipeFileFetcher()
@@ -194,7 +213,7 @@ func (b *ScenarioBuilder) StitchedPath() *RecipeInstaller {
 	gff := discovery.NewGlobFileFilterer()
 	re := execution.NewGoTaskRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
-	s := ux.NewSpinner()
+	pi := ux.NewPlainProgress()
 
 	i := RecipeInstaller{
 		discoverer:        d,
@@ -205,7 +224,7 @@ func (b *ScenarioBuilder) StitchedPath() *RecipeInstaller {
 		recipeFileFetcher: ff,
 		status:            statusRollup,
 		prompter:          p,
-		progressIndicator: s,
+		progressIndicator: pi,
 	}
 
 	i.InstallerContext = b.installerContext

--- a/internal/install/ux/mock_progress_indicator.go
+++ b/internal/install/ux/mock_progress_indicator.go
@@ -1,20 +1,18 @@
 package ux
 
-import "github.com/newrelic/newrelic-cli/internal/install/types"
-
 type MockProgressIndicator struct{}
 
 func NewMockProgressIndicator() *MockProgressIndicator {
 	return &MockProgressIndicator{}
 }
 
-func (s *MockProgressIndicator) Fail(types.Recipe) {
+func (s *MockProgressIndicator) Fail(string) {
 }
 
-func (s MockProgressIndicator) Success(types.Recipe) {
+func (s MockProgressIndicator) Success(string) {
 }
 
-func (s *MockProgressIndicator) Start(types.Recipe) {
+func (s *MockProgressIndicator) Start(string) {
 }
 
 func (s MockProgressIndicator) Stop() {

--- a/internal/install/ux/plain_progress_indicator.go
+++ b/internal/install/ux/plain_progress_indicator.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 
 	"github.com/fatih/color"
-
-	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 type PlainProgress struct {
@@ -17,9 +15,7 @@ func NewPlainProgress() *PlainProgress {
 	return &p
 }
 
-func (p *PlainProgress) Start(recipe types.Recipe) {
-	msg := fmt.Sprintf("Installing %s", recipe.Name)
-
+func (p *PlainProgress) Start(msg string) {
 	c := color.New(color.FgCyan)
 	c.Printf("==>")
 	x := color.New(color.Bold)
@@ -28,26 +24,22 @@ func (p *PlainProgress) Start(recipe types.Recipe) {
 	fmt.Printf("...\n")
 }
 
-func (p *PlainProgress) Success(recipe types.Recipe) {
-	msg := fmt.Sprintf("Installing %s", recipe.Name)
-
+func (p *PlainProgress) Success(msg string) {
 	c := color.New(color.FgCyan)
 	c.Printf("==>")
 	x := color.New(color.Bold)
 	x.Printf(" %s", msg)
 
-	fmt.Printf("...success.\n")
+	fmt.Printf("...success.\n\n")
 }
 
-func (p *PlainProgress) Fail(recipe types.Recipe) {
-	msg := fmt.Sprintf("Installing %s", recipe.Name)
-
+func (p *PlainProgress) Fail(msg string) {
 	c := color.New(color.FgCyan)
 	c.Printf("==>")
 	x := color.New(color.Bold)
 	x.Printf(" %s", msg)
 
-	fmt.Printf("...failed.\n")
+	fmt.Printf("...failed.\n\n")
 }
 
 func (p *PlainProgress) Stop() {}

--- a/internal/install/ux/progress_indicator.go
+++ b/internal/install/ux/progress_indicator.go
@@ -1,10 +1,8 @@
 package ux
 
-import "github.com/newrelic/newrelic-cli/internal/install/types"
-
 type ProgressIndicator interface {
-	Fail(types.Recipe)
-	Success(types.Recipe)
-	Start(types.Recipe)
+	Fail(string)
+	Success(string)
+	Start(string)
 	Stop()
 }

--- a/internal/install/ux/spinner.go
+++ b/internal/install/ux/spinner.go
@@ -6,14 +6,13 @@ import (
 
 	spinnerLib "github.com/briandowns/spinner"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 const (
-	interval  = 100 * time.Millisecond
-	checkmark = "\u2705"
-	crossmark = "\u274C"
+	interval    = 100 * time.Millisecond
+	checkmark   = "\u2705"
+	crossmark   = "\u274C"
+	indentation = "    "
 )
 
 var (
@@ -31,14 +30,13 @@ func NewSpinner() *Spinner {
 	return &s
 }
 
-func (s *Spinner) Start(recipe types.Recipe) {
-	msg := fmt.Sprintf("Installing %s", recipe.Name)
-
+func (s *Spinner) Start(msg string) {
 	// Only start the spinner of the log level is info or below.
 	if log.IsLevelEnabled(log.DebugLevel) {
 		log.Debug(msg)
 	} else {
 		s.Spinner = spinnerLib.New(charSet, interval)
+		s.Prefix = indentation
 		s.Suffix = fmt.Sprintf(" %s", msg)
 		s.Spinner.Start()
 	}
@@ -52,10 +50,12 @@ func (s *Spinner) Stop() {
 	}
 }
 
-func (s *Spinner) Fail(recipe types.Recipe) {
-	s.FinalMSG = crossmark
+func (s *Spinner) Fail(msg string) {
+	s.FinalMSG = indentation + crossmark
+	s.Suffix = s.Suffix + "failed."
 }
 
-func (s *Spinner) Success(recipe types.Recipe) {
-	s.FinalMSG = checkmark
+func (s *Spinner) Success(msg string) {
+	s.FinalMSG = indentation + checkmark
+	s.Suffix = s.Suffix + "success."
 }

--- a/internal/install/validation/polling_recipe_validator_test.go
+++ b/internal/install/validation/polling_recipe_validator_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
+	"github.com/newrelic/newrelic-cli/internal/install/ux"
 	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
 )
 
@@ -33,7 +34,9 @@ func TestValidate(t *testing.T) {
 
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 1)
 
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 
 	r := types.Recipe{}
 	m := types.DiscoveryManifest{}
@@ -46,7 +49,9 @@ func TestValidate(t *testing.T) {
 func TestValidate_PassAfterNAttempts(t *testing.T) {
 	credentials.SetDefaultProfile(credentials.Profile{AccountID: 12345})
 	c := NewMockNRDBClient()
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 	v.maxAttempts = 5
 	v.interval = 10 * time.Millisecond
 
@@ -64,7 +69,9 @@ func TestValidate_PassAfterNAttempts(t *testing.T) {
 func TestValidate_FailAfterNAttempts(t *testing.T) {
 	credentials.SetDefaultProfile(credentials.Profile{AccountID: 12345})
 	c := NewMockNRDBClient()
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 	v.maxAttempts = 3
 	v.interval = 10 * time.Millisecond
 
@@ -83,7 +90,9 @@ func TestValidate_FailAfterMaxAttempts(t *testing.T) {
 
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 	v.maxAttempts = 1
 	v.interval = 10 * time.Millisecond
 
@@ -101,7 +110,9 @@ func TestValidate_FailIfContextDone(t *testing.T) {
 
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 	v.interval = 1 * time.Second
 
 	r := types.Recipe{}
@@ -121,7 +132,9 @@ func TestValidate_QueryError(t *testing.T) {
 
 	c.ThrowError("test error")
 
+	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
+	v.progressIndicator = pi
 
 	r := types.Recipe{}
 	m := types.DiscoveryManifest{}


### PR DESCRIPTION
This PR resolves both VIRTUOSO-380 (introduce a spinner during validation) and VIRTUOSO-381 (report entity-scoped data for all known entities during guided install).  The changes are staged across two separate commits for ease of review.

### Testing:
- For VIRTUOSO-380, `./bin/darwin/newrelic installTest` can be used to validate a mock scenario.  Next, running the installer on an actual VM should yield the same UX updates with a spinner included.
- For VIRTUOSO-381, a successful redis OHI install should no longer report redis as an available integration on the entity overview page after a successful installation.