### PR TITLE
chore(query): include postInstall when fetching from service

### DIFF
--- a/internal/install/recipes/recipe_file.go
+++ b/internal/install/recipes/recipe_file.go
@@ -12,19 +12,19 @@ import (
 
 // RecipeFile represents a recipe file as defined in the Open Installation Library.
 type RecipeFile struct {
-	Description    string                                        `yaml:"description"`
-	InputVars      []VariableConfig                              `yaml:"inputVars"`
-	Install        map[string]interface{}                        `yaml:"install"`
-	InstallTargets []RecipeInstallTarget                         `yaml:"installTargets"`
-	Keywords       []string                                      `yaml:"keywords"`
-	LogMatch       []types.LogMatch                              `yaml:"logMatch"`
-	Name           string                                        `yaml:"name"`
-	DisplayName    string                                        `yaml:"displayName"`
-	PreInstall     types.OpenInstallationPreInstallConfiguration `yaml:"preInstall"`
-	PostInstall    types.RecipePostInstall                       `yaml:"postInstall"`
-	ProcessMatch   []string                                      `yaml:"processMatch"`
-	Repository     string                                        `yaml:"repository"`
-	ValidationNRQL string                                        `yaml:"validationNrql"`
+	Description    string                                         `yaml:"description"`
+	InputVars      []VariableConfig                               `yaml:"inputVars"`
+	Install        map[string]interface{}                         `yaml:"install"`
+	InstallTargets []RecipeInstallTarget                          `yaml:"installTargets"`
+	Keywords       []string                                       `yaml:"keywords"`
+	LogMatch       []types.LogMatch                               `yaml:"logMatch"`
+	Name           string                                         `yaml:"name"`
+	DisplayName    string                                         `yaml:"displayName"`
+	PreInstall     types.OpenInstallationPreInstallConfiguration  `yaml:"preInstall"`
+	PostInstall    types.OpenInstallationPostInstallConfiguration `yaml:"postInstall"`
+	ProcessMatch   []string                                       `yaml:"processMatch"`
+	Repository     string                                         `yaml:"repository"`
+	ValidationNRQL string                                         `yaml:"validationNrql"`
 }
 
 type VariableConfig struct {

--- a/internal/install/recipes/service_recipe_fetcher.go
+++ b/internal/install/recipes/service_recipe_fetcher.go
@@ -249,6 +249,7 @@ func createRecipe(result types.OpenInstallationRecipe) types.Recipe {
 		Repository:     result.Repository,
 		ValidationNRQL: string(result.ValidationNRQL),
 		PreInstall:     result.PreInstall,
+		PostInstall:    result.PostInstall,
 	}
 }
 
@@ -312,6 +313,9 @@ const (
 		}
 		validationNrql
 		preInstall {
+			info
+		}
+		postInstall {
 			info
 		}
 		file

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -244,7 +244,7 @@ This is the Infrastructure Agent Installer preinstall message.
 It is made up of a multi line string.
 				`,
 			},
-			PostInstall: types.RecipePostInstall{
+			PostInstall: types.OpenInstallationPostInstallConfiguration{
 				Info: `
 This is the Infrastructure Agent Installer postinstall message.
 It is made up of a multi line string.

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -1,25 +1,20 @@
 package types
 
 type Recipe struct {
-	ID             string                                  `json:"id"`
-	Description    string                                  `json:"description"`
-	DisplayName    string                                  `json:"displayName"`
-	File           string                                  `json:"file"`
-	InstallTargets []OpenInstallationRecipeInstallTarget   `json:"installTargets"`
-	Keywords       []string                                `json:"keywords"`
-	LogMatch       []LogMatch                              `json:"logMatch"`
-	Name           string                                  `json:"name"`
-	PreInstall     OpenInstallationPreInstallConfiguration `json:"preInstall"`
-	PostInstall    RecipePostInstall                       `json:"postInstall"`
-	ProcessMatch   []string                                `json:"processMatch"`
-	Repository     string                                  `json:"repository"`
-	ValidationNRQL string                                  `json:"validationNrql"`
+	ID             string                                   `json:"id"`
+	Description    string                                   `json:"description"`
+	DisplayName    string                                   `json:"displayName"`
+	File           string                                   `json:"file"`
+	InstallTargets []OpenInstallationRecipeInstallTarget    `json:"installTargets"`
+	Keywords       []string                                 `json:"keywords"`
+	LogMatch       []LogMatch                               `json:"logMatch"`
+	Name           string                                   `json:"name"`
+	PreInstall     OpenInstallationPreInstallConfiguration  `json:"preInstall"`
+	PostInstall    OpenInstallationPostInstallConfiguration `json:"postInstall"`
+	ProcessMatch   []string                                 `json:"processMatch"`
+	Repository     string                                   `json:"repository"`
+	ValidationNRQL string                                   `json:"validationNrql"`
 	Vars           map[string]interface{}
-}
-
-// RecipePostInstall represents the information used after recipe execution has completed.
-type RecipePostInstall struct {
-	Info string `yaml:"info"`
 }
 
 func (r *Recipe) PostInstallMessage() string {

--- a/internal/install/types/types.go
+++ b/internal/install/types/types.go
@@ -129,6 +129,12 @@ type OpenInstallationPreInstallConfiguration struct {
 	Info string `json:"info,omitempty"`
 }
 
+// OpenInstallationPostInstallConfiguration - Optional post-install configuration items
+type OpenInstallationPostInstallConfiguration struct {
+	// Message/Docs notice displayed to user after running the recipe
+	Info string `json:"info,omitempty"`
+}
+
 // OpenInstallationRecipe - Installation instructions and definition of an instrumentation integration
 type OpenInstallationRecipe struct {
 	// Description of the recipe
@@ -153,6 +159,8 @@ type OpenInstallationRecipe struct {
 	Name string `json:"name,omitempty"`
 	// Object representing optional pre-install configuration items
 	PreInstall OpenInstallationPreInstallConfiguration `json:"preInstall,omitempty"`
+	// Object representing optional post-install configuration items
+	PostInstall OpenInstallationPostInstallConfiguration `json:"postInstall,omitempty"`
 	// List of process definitions used to match CLI process detection
 	ProcessMatch []string `json:"processMatch"`
 	// Github repository url


### PR DESCRIPTION
Prior to this change, `postInstall` only showed when using the `-c` flag (maybe `-n` too?). Now it'll work for guided install as well.

Tested result on Linux 2 instance:

```
[ec2-user@ip-172-31-17-251 ~]$ sudo NEW_RELIC_API_KEY=... NEW_RELIC_ACCOUNT_ID=... /usr/local/bin/newrelic install

   _   _                 ____      _ _
  | \ | | _____      __ |  _ \ ___| (_) ___
  |  \| |/ _ \ \ /\ / / | |_) / _ | | |/ __|
  | |\  |  __/\ V  V /  |  _ |  __| | | (__
  |_| \_|\___| \_/\_/   |_| \_\___|_|_|\___|

  Welcome to New Relic. Let's install some instrumentation.

  Questions? Read more about our installation process at
  https://docs.newrelic.com/


The guided installation will begin by installing the New Relic Infrastructure agent, which is required for additional instrumentation.

? Please choose from the additional recommended instrumentation to be installed: Logs integration, NGINX Open Source Integration

The following will be installed:
  Infrastructure Agent
  NGINX Open Source Integration

==> Installing infrastructure-agent-installer...
Package newrelic-infra-1.15.2-1.el7.x86_64 already installed and latest version
    ✅ Checking for data in New Relic...success.
  ⚙️  The Infrastructure Agent configuration file can be found in /etc/newrelic-infra.yml
  Edit this file to make changes or configure advanced features for the agent. See the docs for options:
  https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings

==> Installing infrastructure-agent-installer...success.
Files have been found at the following pattern: /var/log/nginx/error.log* Do you want to watch them? Y
==> Installing logs-integration...
  - Which log files would you like to tail? /var/log/messages,/var/log/cloud-init.log,/var/log/secure
    ✅ Checking for data in New Relic...success.
  ⚙️  The Logs configuration file (base configuration) can be found in /etc/newrelic-infra/logging.d/logging.yml
  ⚙️  The Logs configuration file for discovered processes can be found in /etc/newrelic-infra/logging.d/discovered.yml
  Edit these files to make changes or configure advanced features for the Logs integration. See the docs for options:
  https://docs.newrelic.com/docs/logs/enable-log-management-new-relic/enable-log-monitoring-new-relic/forward-your-logs-using-infrastructure-agent#parameters

==> Installing logs-integration...success.

==> Installing nginx-open-source-integration...
  To capture data from the NGINX integration, you'll first need to enable
  and configure the applicable extension module:
  - For NGINX Open Source: HTTP stub status module
  - For NGINX Plus: HTTP status module and HTTP API module

  - NGINX status URL (default: http://127.0.0.1/status) http://127.0.0.1/status
Package nri-nginx-3.0.1-1.x86_64 already installed and latest version
    ✅ Checking for data in New Relic...success.
  ⚙️  The Nginx configuration file can be found in /etc/newrelic-infra/integrations.d/nginx-config.yml
  Edit this file to make changes or configure advanced features for this integration. See the docs for options:
  https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/nginx-monitoring-integration#config

==> Installing nginx-open-source-integration...success.

  New Relic installation complete!
```