### PR TITLE
chore(install): add host discovery info to nerstorage payloads

### DIFF
--- a/internal/install/execution/mock_status_reporter.go
+++ b/internal/install/execution/mock_status_reporter.go
@@ -16,6 +16,7 @@ type MockStatusReporter struct {
 	RecipeRecommendedErr       error
 	RecipeSkippedErr           error
 	InstallCompleteErr         error
+	DiscoveryCompleteErr       error
 	RecipeAvailableCallCount   int
 	RecipesAvailableCallCount  int
 	RecipesSelectedCallCount   int
@@ -25,6 +26,7 @@ type MockStatusReporter struct {
 	RecipeRecommendedCallCount int
 	RecipeSkippedCallCount     int
 	InstallCompleteCallCount   int
+	DiscoveryCompleteCallCount int
 
 	ReportSkipped     map[string]int
 	ReportInstalled   map[string]int
@@ -106,4 +108,9 @@ func (r *MockStatusReporter) RecipesSelected(status *InstallStatus, recipes []ty
 func (r *MockStatusReporter) InstallComplete(status *InstallStatus) error {
 	r.InstallCompleteCallCount++
 	return r.InstallCompleteErr
+}
+
+func (r *MockStatusReporter) DiscoveryComplete(status *InstallStatus, dm types.DiscoveryManifest) error {
+	r.DiscoveryCompleteCallCount++
+	return r.DiscoveryCompleteErr
 }

--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -30,11 +30,7 @@ func NewNerdStorageStatusReporter(client NerdStorageClient) *NerdstorageStatusRe
 // RecipesAvailable reports that recipes are available for installation on
 // the underlying host.
 func (r NerdstorageStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.Recipe) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.Recipe) error {
@@ -44,54 +40,34 @@ func (r NerdstorageStatusReporter) RecipesSelected(status *InstallStatus, recipe
 // RecipeAvailable reports that a recipe is available for installation on
 // the underlying host.
 func (r NerdstorageStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.Recipe) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipeFailed(status *InstallStatus, event RecipeStatusEvent) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipeInstalling(status *InstallStatus, event RecipeStatusEvent) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipeInstalled(status *InstallStatus, event RecipeStatusEvent) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipeRecommended(status *InstallStatus, event RecipeStatusEvent) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) RecipeSkipped(status *InstallStatus, event RecipeStatusEvent) error {
-	if err := r.writeStatus(status); err != nil {
-		return err
-	}
-
-	return nil
+	return r.writeStatus(status)
 }
 
 func (r NerdstorageStatusReporter) InstallComplete(status *InstallStatus) error {
+	return r.writeStatus(status)
+}
+
+func (r NerdstorageStatusReporter) DiscoveryComplete(status *InstallStatus, dm types.DiscoveryManifest) error {
 	if err := r.writeStatus(status); err != nil {
 		return err
 	}

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -173,3 +173,25 @@ func TestInstallComplete_UserScopeError(t *testing.T) {
 	err := r.InstallComplete(status)
 	require.Error(t, err)
 }
+
+func TestDiscoveryComplete_Basic(t *testing.T) {
+	c := NewMockNerdStorageClient()
+	r := NewNerdStorageStatusReporter(c)
+	status := NewInstallStatus([]StatusSubscriber{r})
+
+	err := r.DiscoveryComplete(status, types.DiscoveryManifest{})
+	require.NoError(t, err)
+	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+}
+
+func TestDiscoveryComplete_UserScopeError(t *testing.T) {
+	c := NewMockNerdStorageClient()
+	r := NewNerdStorageStatusReporter(c)
+	status := NewInstallStatus([]StatusSubscriber{r})
+
+	c.WriteDocumentWithUserScopeErr = errors.New("error")
+
+	err := r.DiscoveryComplete(status, types.DiscoveryManifest{})
+	require.Error(t, err)
+}

--- a/internal/install/execution/status_subscriber.go
+++ b/internal/install/execution/status_subscriber.go
@@ -5,6 +5,7 @@ import "github.com/newrelic/newrelic-cli/internal/install/types"
 // StatusSubscriber is notified during the lifecycle of the recipe execution status.
 type StatusSubscriber interface {
 	InstallComplete(status *InstallStatus) error
+	DiscoveryComplete(status *InstallStatus, dm types.DiscoveryManifest) error
 	RecipeAvailable(status *InstallStatus, recipe types.Recipe) error
 	RecipeFailed(status *InstallStatus, event RecipeStatusEvent) error
 	RecipeInstalled(status *InstallStatus, event RecipeStatusEvent) error

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -99,3 +99,7 @@ func (r TerminalStatusReporter) InstallComplete(status *InstallStatus) error {
 
 	return nil
 }
+
+func (r TerminalStatusReporter) DiscoveryComplete(status *InstallStatus, dm types.DiscoveryManifest) error {
+	return nil
+}

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -91,13 +91,15 @@ func (i *RecipeInstaller) Install() error {
 		"RecipeNamesProvided":       i.RecipeNamesProvided(),
 	}).Debug("context summary")
 
+	defer i.status.InstallComplete()
+
 	// Execute the discovery process, exiting on failure.
 	m, err := i.discover()
 	if err != nil {
 		return err
 	}
 
-	defer i.status.InstallComplete()
+	i.status.DiscoveryComplete(*m)
 
 	if i.RecipesProvided() {
 		// Run the targeted (AKA stitched path) installer.

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -94,6 +94,26 @@ func TestInstall_Basic(t *testing.T) {
 	require.Equal(t, f.FetchRecipeNameCount[loggingRecipeName], 1)
 }
 
+func TestInstall_DiscoveryComplete(t *testing.T) {
+	ic := InstallerContext{}
+	statusReporter := execution.NewMockStatusReporter()
+	statusReporters = []execution.StatusSubscriber{statusReporter}
+	status = execution.NewInstallStatus(statusReporters)
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
+
+	i := RecipeInstaller{ic, d, l, f, e, v, ff, status, p, pi}
+
+	err := i.Install()
+	require.NoError(t, err)
+	require.Equal(t, 1, statusReporter.DiscoveryCompleteCallCount)
+}
+
 func TestInstall_RecipesAvailable(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}

--- a/internal/install/types/discovery_manifest.go
+++ b/internal/install/types/discovery_manifest.go
@@ -20,7 +20,7 @@ type GenericProcess interface {
 }
 
 type MatchedProcess struct {
-	Command         string
+	Command         string `json:"command"`
 	Process         GenericProcess
 	MatchingPattern string
 }


### PR DESCRIPTION
This PR introduces host discovery info to nerdstorage payloads during the install process.

cc @devfreddy @jbeveland27 

### Testing
An end-to-end flow should show no regressions, and retrieving the Nerdstorage documents for user and entity scope post-install should show the new information.