### PR TITLE
fix(install): discovered log files needs to be a string to work within our recipe

### DIFF
--- a/internal/install/recipe_installer_guided.go
+++ b/internal/install/recipe_installer_guided.go
@@ -154,16 +154,26 @@ func (i *RecipeInstaller) installLogging(ctx context.Context, m *types.Discovery
 		"matches": acceptedLogMatches,
 	}).Debug("matches accepted")
 
+	// The struct to approximate the logging configuration file of the Infra Agent. (deprecated)
+	type loggingConfig struct {
+		Logs []types.LogMatch `yaml:"logs"`
+	}
+	// Deprecated. Will be removed in a future release and replaced by NR_DISCOVERED_LOG_FILES.
+	// We need to keep this var for backwards compatibility until recipes have been updated with the new var.
+	r.AddVar("DISCOVERED_LOG_FILES", loggingConfig{Logs: acceptedLogMatches})
+
+	// Build a comma-separated list of discovered log file paths
 	discoveredLogFiles := []string{}
 	for _, logMatch := range acceptedLogMatches {
 		discoveredLogFiles = append(discoveredLogFiles, logMatch.File)
 	}
 
+	// NR_DISCOVERED_LOG_FILES will be replacing DISCOVERED_LOG_FILES in recipes.
 	discoveredLogFilesString := strings.Join(discoveredLogFiles, ",")
-	r.AddVar("DISCOVERED_LOG_FILES", discoveredLogFilesString)
+	r.AddVar("NR_DISCOVERED_LOG_FILES", discoveredLogFilesString)
 
 	log.WithFields(log.Fields{
-		"DISCOVERED_LOG_FILES": discoveredLogFilesString,
+		"NR_DISCOVERED_LOG_FILES": discoveredLogFilesString,
 	}).Debug("discovered log files")
 
 	_, err = i.executeAndValidateWithProgress(ctx, m, r)

--- a/internal/install/recipe_installer_guided.go
+++ b/internal/install/recipe_installer_guided.go
@@ -3,6 +3,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -153,12 +154,17 @@ func (i *RecipeInstaller) installLogging(ctx context.Context, m *types.Discovery
 		"matches": acceptedLogMatches,
 	}).Debug("matches accepted")
 
-	// The struct to approximate the logging configuration file of the Infra Agent.
-	type loggingConfig struct {
-		Logs []types.LogMatch `yaml:"logs"`
+	discoveredLogFiles := []string{}
+	for _, logMatch := range acceptedLogMatches {
+		discoveredLogFiles = append(discoveredLogFiles, logMatch.File)
 	}
 
-	r.AddVar("DISCOVERED_LOG_FILES", loggingConfig{Logs: acceptedLogMatches})
+	discoveredLogFilesString := strings.Join(discoveredLogFiles, ",")
+	r.AddVar("DISCOVERED_LOG_FILES", discoveredLogFilesString)
+
+	log.WithFields(log.Fields{
+		"DISCOVERED_LOG_FILES": discoveredLogFilesString,
+	}).Debug("discovered log files")
 
 	_, err = i.executeAndValidateWithProgress(ctx, m, r)
 	return err

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -165,6 +165,12 @@ func TestInstall_RecipeInstalled(t *testing.T) {
 			Name:           loggingRecipeName,
 			DisplayName:    loggingRecipeName,
 			ValidationNRQL: "testNrql",
+			LogMatch: []types.LogMatch{
+				{
+					Name: "docker log",
+					File: "/var/lib/docker/containers/*/*.log",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Related: [newrelic/open-install-library #293](https://github.com/newrelic/open-install-library/pull/293)