### PR TITLE
Chore/assert platform supported

### DIFF
--- a/internal/install/discovery/mock_discoverer.go
+++ b/internal/install/discovery/mock_discoverer.go
@@ -11,11 +11,17 @@ type MockDiscoverer struct {
 }
 
 func NewMockDiscoverer() *MockDiscoverer {
-	m := &types.DiscoveryManifest{}
+	m := &types.DiscoveryManifest{
+		OS: "linux",
+	}
 
 	return &MockDiscoverer{
 		DiscoveryManifest: m,
 	}
+}
+
+func (d *MockDiscoverer) Os(os string) {
+	d.DiscoveryManifest.OS = os
 }
 
 func (d *MockDiscoverer) Discover(context.Context) (*types.DiscoveryManifest, error) {

--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -175,19 +175,8 @@ func (s *InstallStatus) RecipeSkipped(event RecipeStatusEvent) {
 	}
 }
 
-func (s *InstallStatus) InstallError(err error) {
-	statusError := StatusError{
-		Message: "unknown error",
-	}
-	if err != nil {
-		statusError.Message = err.Error()
-	}
-	s.Error = statusError
-	s.InstallComplete()
-}
-
-func (s *InstallStatus) InstallComplete() {
-	s.completed()
+func (s *InstallStatus) InstallComplete(err error) {
+	s.completed(err)
 
 	for _, r := range s.statusSubscriber {
 		if err := r.InstallComplete(s); err != nil {
@@ -355,9 +344,16 @@ func (s *InstallStatus) withRecipeEvent(e RecipeStatusEvent, rs RecipeStatusType
 	s.Timestamp = utils.GetTimestamp()
 }
 
-func (s *InstallStatus) completed() {
+func (s *InstallStatus) completed(err error) {
 	s.Complete = true
 	s.Timestamp = utils.GetTimestamp()
+
+	if err != nil {
+		statusError := StatusError{
+			Message: err.Error(),
+		}
+		s.Error = statusError
+	}
 
 	log.WithFields(log.Fields{
 		"timestamp": s.Timestamp,

--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -175,6 +175,17 @@ func (s *InstallStatus) RecipeSkipped(event RecipeStatusEvent) {
 	}
 }
 
+func (s *InstallStatus) InstallError(err error) {
+	statusError := StatusError{
+		Message: "unknown error",
+	}
+	if err != nil {
+		statusError.Message = err.Error()
+	}
+	s.Error = statusError
+	s.InstallComplete()
+}
+
 func (s *InstallStatus) InstallComplete() {
 	s.completed()
 

--- a/internal/install/execution/install_status_test.go
+++ b/internal/install/execution/install_status_test.go
@@ -148,7 +148,7 @@ func TestInstallStatus_statusUpdateMethods(t *testing.T) {
 	require.Equal(t, result.Status, RecipeStatusTypes.SKIPPED)
 	require.False(t, s.hasFailed())
 
-	s.InstallComplete()
+	s.InstallComplete(nil)
 	require.True(t, s.Complete)
 	require.NotNil(t, s.Timestamp)
 }
@@ -159,7 +159,7 @@ func TestInstallStatus_failAvailableOnComplete(t *testing.T) {
 
 	s.RecipesAvailable([]types.Recipe{r})
 
-	s.InstallComplete()
+	s.InstallComplete(nil)
 	require.Equal(t, RecipeStatusTypes.FAILED, s.Statuses[0].Status)
 }
 

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -115,7 +115,7 @@ func (i *RecipeInstaller) Install() error {
 			return err
 		}
 
-		i.status.InstallError(err)
+		i.status.InstallComplete(err)
 
 		return err
 	}

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -117,6 +117,90 @@ func TestInstall_DiscoveryComplete(t *testing.T) {
 	require.Equal(t, 1, statusReporter.DiscoveryCompleteCallCount)
 }
 
+func TestInstall_FailsOnInvalidOs(t *testing.T) {
+	ic := InstallerContext{}
+	discover := discovery.NewMockDiscoverer()
+	discover.Os("darwin")
+	statusReporter := execution.NewMockStatusReporter()
+	statusReporters = []execution.StatusSubscriber{statusReporter}
+	status = execution.NewInstallStatus(statusReporters)
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
+
+	i := RecipeInstaller{ic, discover, l, f, e, v, ff, status, p, pi, lkf}
+
+	err := i.Install()
+	require.Error(t, err)
+}
+
+func TestInstall_FailsOnNoOs(t *testing.T) {
+	ic := InstallerContext{}
+	discover := discovery.NewMockDiscoverer()
+	discover.Os("")
+	statusReporter := execution.NewMockStatusReporter()
+	statusReporters = []execution.StatusSubscriber{statusReporter}
+	status = execution.NewInstallStatus(statusReporters)
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
+
+	i := RecipeInstaller{ic, discover, l, f, e, v, ff, status, p, pi, lkf}
+
+	err := i.Install()
+	require.Error(t, err)
+}
+
+func TestInstall_DoesntFailForWindowsOs(t *testing.T) {
+	ic := InstallerContext{}
+	discover := discovery.NewMockDiscoverer()
+	discover.Os("windows")
+	statusReporter := execution.NewMockStatusReporter()
+	statusReporters = []execution.StatusSubscriber{statusReporter}
+	status = execution.NewInstallStatus(statusReporters)
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
+
+	i := RecipeInstaller{ic, discover, l, f, e, v, ff, status, p, pi, lkf}
+
+	err := i.Install()
+	require.NoError(t, err)
+}
+
+func TestInstall_DoesntFailForLinuxOs(t *testing.T) {
+	ic := InstallerContext{}
+	discover := discovery.NewMockDiscoverer()
+	discover.Os("linux")
+	statusReporter := execution.NewMockStatusReporter()
+	statusReporters = []execution.StatusSubscriber{statusReporter}
+	status = execution.NewInstallStatus(statusReporters)
+	f.FetchRecipeVals = []types.Recipe{
+		{
+			Name:           infraAgentRecipeName,
+			DisplayName:    infraAgentRecipeName,
+			ValidationNRQL: "testNrql",
+		},
+	}
+
+	i := RecipeInstaller{ic, discover, l, f, e, v, ff, status, p, pi, lkf}
+
+	err := i.Install()
+	require.NoError(t, err)
+}
+
 func TestInstall_RecipesAvailable(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}

--- a/internal/install/validation/polling_recipe_validator.go
+++ b/internal/install/validation/polling_recipe_validator.go
@@ -53,7 +53,7 @@ func (m *PollingRecipeValidator) waitForData(ctx context.Context, dm types.Disco
 	ticker := time.NewTicker(m.interval)
 	defer ticker.Stop()
 
-	progressMsg := "Checking for data in New Relic..."
+	progressMsg := "Checking for data in New Relic (this may take a few minutes)..."
 	m.progressIndicator.Start(progressMsg)
 	defer m.progressIndicator.Stop()
 


### PR DESCRIPTION
We've validated the correct error message when running a darwin machine.
We also see an event INSTALL_GuidedInstall_completeInstall in Tessen, with the os column of darwin, however we don't see any error message. There might be something else to do in the UI to wire through the error message