### PR TITLE
fix: init the file logger only for the install command

### DIFF
--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -29,21 +29,6 @@ func initLogger(logLevel string) {
 		EnvironmentOverrideColors: true,
 	})
 
-	_, err := os.Stat(DefaultConfigDirectory)
-
-	if os.IsNotExist(err) {
-		errDir := os.MkdirAll(DefaultConfigDirectory, 0750)
-		if errDir != nil {
-			log.Warnf("Could not create log file folder: %s", err)
-		}
-	}
-
-	fileHook, err := NewLogrusFileHook(DefaultConfigDirectory+"/"+DefaultLogFile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
-	if err == nil && !fileHookConfigured {
-		l.Hooks.Add(fileHook)
-		fileHookConfigured = true
-	}
-
 	switch level := strings.ToUpper(logLevel); level {
 	case "TRACE":
 		l.SetLevel(log.TraceLevel)
@@ -55,6 +40,29 @@ func initLogger(logLevel string) {
 		l.SetLevel(log.ErrorLevel)
 	default:
 		l.SetLevel(log.InfoLevel)
+	}
+}
+
+func InitFileLogger() {
+	if fileHookConfigured {
+		log.Debug("file logger already configured")
+		return
+	}
+
+	_, err := os.Stat(DefaultConfigDirectory)
+
+	if os.IsNotExist(err) {
+		errDir := os.MkdirAll(DefaultConfigDirectory, 0750)
+		if errDir != nil {
+			log.Warnf("Could not create log file folder: %s", err)
+		}
+	}
+
+	fileHook, err := NewLogrusFileHook(DefaultConfigDirectory+"/"+DefaultLogFile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0640)
+	if err == nil && !fileHookConfigured {
+		l := log.StandardLogger()
+		l.Hooks.Add(fileHook)
+		fileHookConfigured = true
 	}
 }
 

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-client-go/newrelic"
@@ -37,6 +38,8 @@ var Command = &cobra.Command{
 			SkipIntegrations:   skipIntegrations,
 			SkipLoggingInstall: skipLoggingInstall,
 		}
+
+		config.InitFileLogger()
 
 		client.WithClientAndProfile(func(nrClient *newrelic.NewRelic, profile *credentials.Profile) {
 			if trace {


### PR DESCRIPTION
fixes: #803

Without this change, we initialize the file logger even when we might not intend
to.  Here we ensure that the file logger is only initialized during execution of
the install command.