### PR TITLE
chore(install): use generated types for installation recipes

### DIFF
--- a/.tutone.yml
+++ b/.tutone.yml
@@ -47,13 +47,29 @@ packages:
       - typegen
     types:
       - name: OpenInstallationRecipe
+        struct_tags: [json, yaml]
       - name: ID
         field_type_override: string
         skip_type_create: true
+      - name: OpenInstallationRecipeInputVariable
+        struct_tags: [json, yaml]
+      - name: OpenInstallationRecipeInstallTarget
+        struct_tags: [json, yaml]
+      - name: OpenInstallationSuccessLinkConfig
+        struct_tags: [json, yaml]
+      - name: OpenInstallationQuickstartsFilter
+        struct_tags: [json, yaml]
+      - name: OpenInstallationAttributes
+        struct_tags: [json, yaml]
+      - name: OpenInstallationLogMatch
+        struct_tags: [json, yaml]
+      - name: OpenInstallationPostInstallConfiguration
+        struct_tags: [json, yaml]
+      - name: OpenInstallationPreInstallConfiguration
+        struct_tags: [json, yaml]
+      - name: OpenInstallationQuickstartEntityType
+        struct_tags: [json, yaml]
 
 generators:
-  - name: command
-    templateName: 'command.go.tmpl'
-    templateDir: templates
   - name: typegen
     fileName: 'types.go'

--- a/internal/install/discovery/file_filterer.go
+++ b/internal/install/discovery/file_filterer.go
@@ -8,5 +8,5 @@ import (
 
 // FileFilterer determines the existence of files on the underlying filesystem.
 type FileFilterer interface {
-	Filter(context.Context, []types.Recipe) ([]types.LogMatch, error)
+	Filter(context.Context, []types.OpenInstallationRecipe) ([]types.OpenInstallationLogMatch, error)
 }

--- a/internal/install/discovery/glob_file_filterer.go
+++ b/internal/install/discovery/glob_file_filterer.go
@@ -22,8 +22,9 @@ func NewGlobFileFilterer() *GlobFileFilterer {
 
 // Filter uses the patterns provided in the passed recipe to return matches based
 // on which files exist in the underlying file system.
-func (f *GlobFileFilterer) Filter(ctx context.Context, recipes []types.Recipe) ([]types.LogMatch, error) {
-	fileMatches := []types.LogMatch{}
+func (f *GlobFileFilterer) Filter(ctx context.Context, recipes []types.OpenInstallationRecipe) ([]types.OpenInstallationLogMatch, error) {
+	fileMatches := []types.OpenInstallationLogMatch{}
+
 	for _, r := range recipes {
 		for _, l := range r.LogMatch {
 			match, _ := matchLogFilesFromRecipe(l)
@@ -36,7 +37,7 @@ func (f *GlobFileFilterer) Filter(ctx context.Context, recipes []types.Recipe) (
 	return fileMatches, nil
 }
 
-func matchLogFilesFromRecipe(matcher types.LogMatch) (bool, []string) {
+func matchLogFilesFromRecipe(matcher types.OpenInstallationLogMatch) (bool, []string) {
 	matches, err := filepath.Glob(matcher.File)
 	if err != nil {
 		log.Errorf("error matching logfiles: %s", err)

--- a/internal/install/discovery/glob_file_filterer_test.go
+++ b/internal/install/discovery/glob_file_filterer_test.go
@@ -33,10 +33,10 @@ func TestGlobFileFilter(t *testing.T) {
 	require.NoError(t, err)
 	defer f3.Close()
 
-	recipes := []types.Recipe{
+	recipes := []types.OpenInstallationRecipe{
 		{
 			ID: "test",
-			LogMatch: []types.LogMatch{
+			LogMatch: []types.OpenInstallationLogMatch{
 				{
 					File: filepath.Join(tmpDir, "*.log"),
 				},
@@ -44,7 +44,7 @@ func TestGlobFileFilter(t *testing.T) {
 		},
 		{
 			ID: "nginx",
-			LogMatch: []types.LogMatch{
+			LogMatch: []types.OpenInstallationLogMatch{
 				{
 					File: "/var/log/nope/*.log",
 				},
@@ -81,10 +81,10 @@ func TestMatchLogFilesFromRecipe(t *testing.T) {
 	require.NoError(t, err)
 	defer f3.Close()
 
-	recipes := []types.Recipe{
+	recipes := []types.OpenInstallationRecipe{
 		{
 			ID: "test",
-			LogMatch: []types.LogMatch{
+			LogMatch: []types.OpenInstallationLogMatch{
 				{
 					File: filepath.Join(tmpDir, "*.log"),
 				},

--- a/internal/install/discovery/mock_file_filterer.go
+++ b/internal/install/discovery/mock_file_filterer.go
@@ -11,7 +11,7 @@ import (
 type MockFileFilterer struct {
 	FilterCallCount int
 	FilterErr       error
-	FilterVal       []types.LogMatch
+	FilterVal       []types.OpenInstallationLogMatch
 }
 
 // NewMockFileFilterer creates a new instance of MockFileFilterer.
@@ -19,7 +19,7 @@ func NewMockFileFilterer() *MockFileFilterer {
 	return &MockFileFilterer{}
 }
 
-func (m *MockFileFilterer) Filter(ctx context.Context, recipes []types.Recipe) ([]types.LogMatch, error) {
+func (m *MockFileFilterer) Filter(ctx context.Context, recipes []types.OpenInstallationRecipe) ([]types.OpenInstallationLogMatch, error) {
 	m.FilterCallCount++
 	return m.FilterVal, m.FilterErr
 }

--- a/internal/install/discovery/psutil_discoverer_integration_test.go
+++ b/internal/install/discovery/psutil_discoverer_integration_test.go
@@ -21,7 +21,7 @@ func TestDiscovery(t *testing.T) {
 	}
 
 	mockRecipeFetcher := recipes.NewMockRecipeFetcher()
-	mockRecipeFetcher.FetchRecipesVal = []types.Recipe{
+	mockRecipeFetcher.FetchRecipesVal = []types.OpenInstallationRecipe{
 		{
 			ID:           "test",
 			Name:         "java",

--- a/internal/install/discovery/regex_process_filterer.go
+++ b/internal/install/discovery/regex_process_filterer.go
@@ -50,7 +50,7 @@ func (f *RegexProcessFilterer) filter(ctx context.Context, processes []types.Gen
 	return matches, nil
 }
 
-func match(r types.Recipe, matchedProcess *types.MatchedProcess) bool {
+func match(r types.OpenInstallationRecipe, matchedProcess *types.MatchedProcess) bool {
 	for _, pattern := range r.ProcessMatch {
 		matched, err := regexp.Match(pattern, []byte(matchedProcess.Command))
 		if err != nil {

--- a/internal/install/discovery/regex_process_filterer_test.go
+++ b/internal/install/discovery/regex_process_filterer_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestShouldFilterWithCmdLineInsteadOfName(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "test-cassandra-ohi",
@@ -45,7 +45,7 @@ func TestShouldFilterWithCmdLineInsteadOfName(t *testing.T) {
 }
 
 func TestFilter_NoMatchingProcess(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "java-agent",
@@ -81,7 +81,7 @@ func TestFilter_NoMatchingProcess(t *testing.T) {
 }
 
 func TestFilter_SingleMatchingProcess_SingleOHIRecipe(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "cassandra-open-source-integration",
@@ -113,7 +113,7 @@ func TestFilter_SingleMatchingProcess_SingleOHIRecipe(t *testing.T) {
 }
 
 func TestFilter_SingleMatchingProcess_SingleAPMRecipe(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "java-agent",
@@ -145,7 +145,7 @@ func TestFilter_SingleMatchingProcess_SingleAPMRecipe(t *testing.T) {
 }
 
 func TestFilter_SingleMatchingProcess_MultipleRecipes(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "java-agent",
@@ -183,7 +183,7 @@ func TestFilter_SingleMatchingProcess_MultipleRecipes(t *testing.T) {
 }
 
 func TestFilter_MultipleMatchingProcesses_SingleRecipe(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "test-java-agent",
@@ -220,7 +220,7 @@ func TestFilter_MultipleMatchingProcesses_SingleRecipe(t *testing.T) {
 }
 
 func TestFilter_MultipleMatchingProcesses_MultipleRecipes(t *testing.T) {
-	r := []types.Recipe{
+	r := []types.OpenInstallationRecipe{
 		{
 			ID:           "1",
 			Name:         "test-java-agent",

--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -92,7 +92,7 @@ func (s *InstallStatus) DiscoveryComplete(dm types.DiscoveryManifest) {
 	}
 }
 
-func (s *InstallStatus) RecipeAvailable(recipe types.Recipe) {
+func (s *InstallStatus) RecipeAvailable(recipe types.OpenInstallationRecipe) {
 	s.withAvailableRecipe(recipe)
 
 	for _, r := range s.statusSubscriber {
@@ -102,7 +102,7 @@ func (s *InstallStatus) RecipeAvailable(recipe types.Recipe) {
 	}
 }
 
-func (s *InstallStatus) RecipesAvailable(recipes []types.Recipe) {
+func (s *InstallStatus) RecipesAvailable(recipes []types.OpenInstallationRecipe) {
 	s.withAvailableRecipes(recipes)
 
 	for _, r := range s.statusSubscriber {
@@ -112,7 +112,7 @@ func (s *InstallStatus) RecipesAvailable(recipes []types.Recipe) {
 	}
 }
 
-func (s *InstallStatus) RecipesSelected(recipes []types.Recipe) {
+func (s *InstallStatus) RecipesSelected(recipes []types.OpenInstallationRecipe) {
 	for _, r := range s.statusSubscriber {
 		if err := r.RecipesSelected(s, recipes); err != nil {
 			log.Errorf("Could not report recipe execution status: %s", err)
@@ -240,13 +240,13 @@ func (s *InstallStatus) HostEntityGUID() string {
 	return guid
 }
 
-func (s *InstallStatus) withAvailableRecipes(recipes []types.Recipe) {
+func (s *InstallStatus) withAvailableRecipes(recipes []types.OpenInstallationRecipe) {
 	for _, r := range recipes {
 		s.withAvailableRecipe(r)
 	}
 }
 
-func (s *InstallStatus) withAvailableRecipe(r types.Recipe) {
+func (s *InstallStatus) withAvailableRecipe(r types.OpenInstallationRecipe) {
 	e := RecipeStatusEvent{Recipe: r}
 	s.withRecipeEvent(e, RecipeStatusTypes.AVAILABLE)
 }
@@ -362,7 +362,7 @@ func (s *InstallStatus) canceled() {
 	s.updateFinalInstallationStatuses(true)
 }
 
-func (s *InstallStatus) getStatus(r types.Recipe) *RecipeStatus {
+func (s *InstallStatus) getStatus(r types.OpenInstallationRecipe) *RecipeStatus {
 	for _, recipe := range s.Statuses {
 		if recipe.Name == r.Name {
 			return recipe

--- a/internal/install/execution/install_status_test.go
+++ b/internal/install/execution/install_status_test.go
@@ -18,7 +18,7 @@ func TestNewInstallStatus(t *testing.T) {
 
 func TestStatusWithAvailableRecipes_Basic(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := []types.Recipe{{
+	r := []types.OpenInstallationRecipe{{
 		Name: "testRecipe1",
 	}, {
 		Name: "testRecipe2",
@@ -35,7 +35,7 @@ func TestStatusWithAvailableRecipes_Basic(t *testing.T) {
 
 func TestStatusWithRecipeEvent_Basic(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r}
 
 	s.Timestamp = 0
@@ -49,7 +49,7 @@ func TestStatusWithRecipeEvent_Basic(t *testing.T) {
 
 func TestStatusWithRecipeEvent_ErrorMessages(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{
 		Recipe: r,
 		Msg:    "thing failed for a reason",
@@ -68,7 +68,7 @@ func TestStatusWithRecipeEvent_ErrorMessages(t *testing.T) {
 
 func TestExecutionStatusWithRecipeEvent_RecipeExists(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r}
 
 	s.Timestamp = 0
@@ -90,7 +90,7 @@ func TestExecutionStatusWithRecipeEvent_RecipeExists(t *testing.T) {
 
 func TestStatusWithRecipeEvent_EntityGUID(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
 
 	s.Timestamp = 0
@@ -104,7 +104,7 @@ func TestStatusWithRecipeEvent_EntityGUID(t *testing.T) {
 func TestStatusWithRecipeEvent_EntityGUIDExists(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
 	s.withEntityGUID("testGUID")
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
 
 	s.Timestamp = 0
@@ -117,10 +117,10 @@ func TestStatusWithRecipeEvent_EntityGUIDExists(t *testing.T) {
 
 func TestInstallStatus_statusUpdateMethods(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
 
-	s.RecipesAvailable([]types.Recipe{r})
+	s.RecipesAvailable([]types.OpenInstallationRecipe{r})
 
 	result := s.getStatus(r)
 	require.NotNil(t, result)
@@ -155,9 +155,9 @@ func TestInstallStatus_statusUpdateMethods(t *testing.T) {
 
 func TestInstallStatus_failAvailableOnComplete(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 
-	s.RecipesAvailable([]types.Recipe{r})
+	s.RecipesAvailable([]types.OpenInstallationRecipe{r})
 
 	s.InstallComplete(nil)
 	require.Equal(t, RecipeStatusTypes.FAILED, s.Statuses[0].Status)
@@ -165,9 +165,9 @@ func TestInstallStatus_failAvailableOnComplete(t *testing.T) {
 
 func TestInstallStatus_cancelAvailable(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{})
-	r := types.Recipe{Name: "testRecipe"}
+	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 
-	s.RecipesAvailable([]types.Recipe{r})
+	s.RecipesAvailable([]types.OpenInstallationRecipe{r})
 
 	s.InstallCanceled()
 	require.Equal(t, RecipeStatusTypes.CANCELED, s.Statuses[0].Status)
@@ -175,18 +175,18 @@ func TestInstallStatus_cancelAvailable(t *testing.T) {
 
 func TestInstallStatus_multipleRecipeStatuses(t *testing.T) {
 	s := NewInstallStatus([]StatusSubscriber{NewMockStatusReporter()})
-	recipeInstalled := types.Recipe{Name: "installed"}
+	recipeInstalled := types.OpenInstallationRecipe{Name: "installed"}
 	installedRecipeEvent := RecipeStatusEvent{Recipe: recipeInstalled, EntityGUID: "installedGUID"}
 
-	recipeSkipped := types.Recipe{Name: "skipped"}
+	recipeSkipped := types.OpenInstallationRecipe{Name: "skipped"}
 	skippedRecipeEvent := RecipeStatusEvent{Recipe: recipeSkipped, EntityGUID: "skippedGUID"}
 
-	recipeErrored := types.Recipe{Name: "errored"}
+	recipeErrored := types.OpenInstallationRecipe{Name: "errored"}
 	erroredRecipeEvent := RecipeStatusEvent{Recipe: recipeErrored, EntityGUID: "erroredGUID"}
 
-	recipeCanceled := types.Recipe{Name: "canceled"}
+	recipeCanceled := types.OpenInstallationRecipe{Name: "canceled"}
 
-	s.RecipesAvailable([]types.Recipe{
+	s.RecipesAvailable([]types.OpenInstallationRecipe{
 		recipeInstalled,
 		recipeCanceled,
 	})

--- a/internal/install/execution/mock_failing_recipe_executor.go
+++ b/internal/install/execution/mock_failing_recipe_executor.go
@@ -17,10 +17,10 @@ func NewMockFailingRecipeExecutor() *MockFailingRecipeExecutor {
 	}
 }
 
-func (m *MockFailingRecipeExecutor) Prepare(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe, y bool, z string) (types.RecipeVars, error) {
+func (m *MockFailingRecipeExecutor) Prepare(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, y bool, z string) (types.RecipeVars, error) {
 	return types.RecipeVars{}, nil
 }
 
-func (m *MockFailingRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe, v types.RecipeVars) error {
+func (m *MockFailingRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, v types.RecipeVars) error {
 	return fmt.Errorf("something went wrong")
 }

--- a/internal/install/execution/mock_recipe_executor.go
+++ b/internal/install/execution/mock_recipe_executor.go
@@ -16,10 +16,10 @@ func NewMockRecipeExecutor() *MockRecipeExecutor {
 	}
 }
 
-func (m *MockRecipeExecutor) Prepare(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe, y bool, z string) (types.RecipeVars, error) {
+func (m *MockRecipeExecutor) Prepare(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, y bool, z string) (types.RecipeVars, error) {
 	return types.RecipeVars{}, nil
 }
 
-func (m *MockRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe, v types.RecipeVars) error {
+func (m *MockRecipeExecutor) Execute(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, v types.RecipeVars) error {
 	return nil
 }

--- a/internal/install/execution/mock_status_reporter.go
+++ b/internal/install/execution/mock_status_reporter.go
@@ -107,7 +107,7 @@ func (r *MockStatusReporter) RecipeSkipped(status *InstallStatus, event RecipeSt
 	return r.RecipeSkippedErr
 }
 
-func (r *MockStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.Recipe) error {
+func (r *MockStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.OpenInstallationRecipe) error {
 	r.RecipeAvailableCallCount++
 	if len(r.ReportAvailable) == 0 {
 		r.ReportAvailable = make(map[string]int)
@@ -116,12 +116,12 @@ func (r *MockStatusReporter) RecipeAvailable(status *InstallStatus, recipe types
 	return r.RecipeAvailableErr
 }
 
-func (r *MockStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.Recipe) error {
+func (r *MockStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	r.RecipesAvailableCallCount++
 	return r.RecipesAvailableErr
 }
 
-func (r *MockStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.Recipe) error {
+func (r *MockStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	r.RecipesSelectedCallCount++
 	return r.RecipesSelectedErr
 }

--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -29,17 +29,17 @@ func NewNerdStorageStatusReporter(client NerdStorageClient) *NerdstorageStatusRe
 
 // RecipesAvailable reports that recipes are available for installation on
 // the underlying host.
-func (r NerdstorageStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.Recipe) error {
+func (r NerdstorageStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	return r.writeStatus(status)
 }
 
-func (r NerdstorageStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.Recipe) error {
+func (r NerdstorageStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	return nil
 }
 
 // RecipeAvailable reports that a recipe is available for installation on
 // the underlying host.
-func (r NerdstorageStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.Recipe) error {
+func (r NerdstorageStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.OpenInstallationRecipe) error {
 	return r.writeStatus(status)
 }
 

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -47,7 +47,7 @@ func TestReportRecipeSucceeded_Basic(t *testing.T) {
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
 
-	rec := types.Recipe{Name: "testName"}
+	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
 		Recipe:     rec,
 		EntityGUID: entityGUID,
@@ -95,7 +95,7 @@ func TestReportRecipeSucceeded_UserScopeOnly(t *testing.T) {
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
 
-	rec := types.Recipe{Name: "testName"}
+	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
 		Recipe: rec,
 	}

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -16,7 +16,7 @@ func TestRecipesAvailable_Basic(t *testing.T) {
 	r := NewNerdStorageStatusReporter(c)
 	status := NewInstallStatus(nil)
 
-	recipes := []types.Recipe{{}}
+	recipes := []types.OpenInstallationRecipe{{}}
 
 	err := r.RecipesAvailable(status, recipes)
 	require.NoError(t, err)
@@ -29,7 +29,7 @@ func TestRecipesAvailable_UserScopeError(t *testing.T) {
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
 
-	recipes := []types.Recipe{{}}
+	recipes := []types.OpenInstallationRecipe{{}}
 
 	err := r.RecipesAvailable(status, recipes)
 	require.Error(t, err)

--- a/internal/install/execution/recipe_executor.go
+++ b/internal/install/execution/recipe_executor.go
@@ -9,6 +9,6 @@ import (
 // RecipeExecutor is responsible for execution of the task steps defined in a
 // recipe.
 type RecipeExecutor interface {
-	Prepare(context.Context, types.DiscoveryManifest, types.Recipe, bool, string) (types.RecipeVars, error)
-	Execute(context.Context, types.DiscoveryManifest, types.Recipe, types.RecipeVars) error
+	Prepare(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe, bool, string) (types.RecipeVars, error)
+	Execute(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe, types.RecipeVars) error
 }

--- a/internal/install/execution/status_subscriber.go
+++ b/internal/install/execution/status_subscriber.go
@@ -7,19 +7,19 @@ type StatusSubscriber interface {
 	InstallCanceled(status *InstallStatus) error
 	InstallComplete(status *InstallStatus) error
 	DiscoveryComplete(status *InstallStatus, dm types.DiscoveryManifest) error
-	RecipeAvailable(status *InstallStatus, recipe types.Recipe) error
+	RecipeAvailable(status *InstallStatus, recipe types.OpenInstallationRecipe) error
 	RecipeFailed(status *InstallStatus, event RecipeStatusEvent) error
 	RecipeInstalled(status *InstallStatus, event RecipeStatusEvent) error
 	RecipeInstalling(status *InstallStatus, event RecipeStatusEvent) error
 	RecipeRecommended(status *InstallStatus, event RecipeStatusEvent) error
 	RecipeSkipped(status *InstallStatus, event RecipeStatusEvent) error
-	RecipesAvailable(status *InstallStatus, recipes []types.Recipe) error
-	RecipesSelected(status *InstallStatus, recipes []types.Recipe) error
+	RecipesAvailable(status *InstallStatus, recipes []types.OpenInstallationRecipe) error
+	RecipesSelected(status *InstallStatus, recipes []types.OpenInstallationRecipe) error
 }
 
 // RecipeStatusEvent represents an event in a recipe's execution.
 type RecipeStatusEvent struct {
-	Recipe                         types.Recipe
+	Recipe                         types.OpenInstallationRecipe
 	Msg                            string
 	EntityGUID                     string
 	ValidationDurationMilliseconds int64

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -42,11 +42,11 @@ func (r TerminalStatusReporter) RecipeRecommended(status *InstallStatus, event R
 	return nil
 }
 
-func (r TerminalStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.Recipe) error {
+func (r TerminalStatusReporter) RecipesAvailable(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	return nil
 }
 
-func (r TerminalStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.Recipe) error {
+func (r TerminalStatusReporter) RecipesSelected(status *InstallStatus, recipes []types.OpenInstallationRecipe) error {
 	if len(recipes) > 0 {
 		fmt.Println("The following will be installed:")
 	}
@@ -68,7 +68,7 @@ func (r TerminalStatusReporter) RecipesSelected(status *InstallStatus, recipes [
 	return nil
 }
 
-func (r TerminalStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.Recipe) error {
+func (r TerminalStatusReporter) RecipeAvailable(status *InstallStatus, recipe types.OpenInstallationRecipe) error {
 	return nil
 }
 

--- a/internal/install/recipe_file_test.go
+++ b/internal/install/recipe_file_test.go
@@ -14,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/newrelic/newrelic-cli/internal/install/recipes"
+	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 var (
@@ -102,39 +103,11 @@ func TestFetchRecipeFile_FailedStatusCode(t *testing.T) {
 }
 
 func TestNewRecipeFile(t *testing.T) {
-	var expected recipes.RecipeFile
+	var expected types.OpenInstallationRecipe
 	err := yaml.Unmarshal([]byte(testRecipeFileString), &expected)
 	require.NoError(t, err)
 
 	actual, err := recipes.NewRecipeFile(testRecipeFileString)
 	require.NoError(t, err)
 	require.True(t, reflect.DeepEqual(&expected, actual))
-}
-
-func TestString(t *testing.T) {
-	var f recipes.RecipeFile
-	err := yaml.Unmarshal([]byte(testRecipeFileString), &f)
-	require.NoError(t, err)
-
-	s, err := f.String()
-	require.NoError(t, err)
-	require.NotEmpty(t, s)
-}
-
-func TestToRecipe(t *testing.T) {
-	var f recipes.RecipeFile
-	err := yaml.Unmarshal([]byte(testRecipeFileString), &f)
-	require.NoError(t, err)
-
-	r, err := f.ToRecipe()
-	require.NoError(t, err)
-	require.NotEmpty(t, r)
-	require.NotEmpty(t, r.File)
-	require.Equal(t, f.Name, r.Name)
-	require.Equal(t, f.Description, r.Description)
-	require.Equal(t, f.Repository, r.Repository)
-	require.Equal(t, f.ValidationNRQL, r.ValidationNRQL)
-
-	require.NotEmpty(t, f.Keywords, r.Keywords)
-	require.NotEmpty(t, f.ProcessMatch, r.ProcessMatch)
 }

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -167,7 +167,7 @@ func (i *RecipeInstaller) assertDiscoveryValid(ctx context.Context, m *types.Dis
 	return nil
 }
 
-func (i *RecipeInstaller) installRecipes(ctx context.Context, m *types.DiscoveryManifest, recipes []types.Recipe) error {
+func (i *RecipeInstaller) installRecipes(ctx context.Context, m *types.DiscoveryManifest, recipes []types.OpenInstallationRecipe) error {
 	log.WithFields(log.Fields{
 		"recipe_count": len(recipes),
 	}).Debug("installing recipes")
@@ -210,7 +210,7 @@ func (i *RecipeInstaller) discover(ctx context.Context) (*types.DiscoveryManifes
 	return m, nil
 }
 
-func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.Recipe, vars types.RecipeVars) (string, error) {
+func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, vars types.RecipeVars) (string, error) {
 	i.status.RecipeInstalling(execution.RecipeStatusEvent{Recipe: *r})
 
 	// Execute the recipe steps.
@@ -257,7 +257,7 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 	return entityGUID, nil
 }
 
-func (i *RecipeInstaller) executeAndValidateWithProgress(ctx context.Context, m *types.DiscoveryManifest, r *types.Recipe) (string, error) {
+func (i *RecipeInstaller) executeAndValidateWithProgress(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe) (string, error) {
 	msg := fmt.Sprintf("Installing %s", r.Name)
 	i.progressIndicator.Start(msg)
 	defer func() { i.progressIndicator.Stop() }()
@@ -296,7 +296,7 @@ func (i *RecipeInstaller) failMessage(componentName string) error {
 	return fmt.Errorf("execution of %s failed, please see the following link for clues on how to resolve the issue: %s", componentName, searchURL)
 }
 
-func (i *RecipeInstaller) fetchRecipeAndReportAvailable(ctx context.Context, m *types.DiscoveryManifest, recipeName string) (*types.Recipe, error) {
+func (i *RecipeInstaller) fetchRecipeAndReportAvailable(ctx context.Context, m *types.DiscoveryManifest, recipeName string) (*types.OpenInstallationRecipe, error) {
 	log.WithFields(log.Fields{
 		"name": recipeName,
 	}).Debug("fetching recipe for install")
@@ -311,7 +311,7 @@ func (i *RecipeInstaller) fetchRecipeAndReportAvailable(ctx context.Context, m *
 	return r, nil
 }
 
-func (i *RecipeInstaller) fetch(ctx context.Context, m *types.DiscoveryManifest, recipeName string) (*types.Recipe, error) {
+func (i *RecipeInstaller) fetch(ctx context.Context, m *types.DiscoveryManifest, recipeName string) (*types.OpenInstallationRecipe, error) {
 	r, err := i.recipeFetcher.FetchRecipe(ctx, m, recipeName)
 	if err != nil {
 		log.Errorf("error retrieving recipe %s: %s", recipeName, err)

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -24,7 +24,7 @@ import (
 var (
 	testRecipeName        = "Test Recipe"
 	anotherTestRecipeName = "Another Test Recipe"
-	testRecipeFile        = &recipes.RecipeFile{
+	testRecipeFile        = &types.OpenInstallationRecipe{
 		Name: testRecipeName,
 	}
 
@@ -88,7 +88,7 @@ func TestShouldGetRecipeFromFile(t *testing.T) {
 func TestInstall_Basic(t *testing.T) {
 	ic := InstallerContext{}
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{Name: types.InfraAgentRecipeName},
 		{Name: types.LoggingRecipeName},
 	}
@@ -104,7 +104,7 @@ func TestInstall_DiscoveryComplete(t *testing.T) {
 	statusReporter := execution.NewMockStatusReporter()
 	statusReporters = []execution.StatusSubscriber{statusReporter}
 	status = execution.NewInstallStatus(statusReporters)
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -127,7 +127,7 @@ func TestInstall_FailsOnInvalidOs(t *testing.T) {
 	statusReporter := execution.NewMockStatusReporter()
 	statusReporters = []execution.StatusSubscriber{statusReporter}
 	status = execution.NewInstallStatus(statusReporters)
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -145,12 +145,12 @@ func TestInstall_RecipesAvailable(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -174,12 +174,12 @@ func TestInstall_RecipeInstalled(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f2 := recipes.NewMockRecipeFetcher()
-	f2.FetchRecommendationsVal = []types.Recipe{{
+	f2.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f2.FetchRecipeVals = []types.Recipe{
+	f2.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -189,7 +189,7 @@ func TestInstall_RecipeInstalled(t *testing.T) {
 			Name:           types.LoggingRecipeName,
 			DisplayName:    types.LoggingRecipeName,
 			ValidationNRQL: "testNrql",
-			LogMatch: []types.LogMatch{
+			LogMatch: []types.OpenInstallationLogMatch{
 				{
 					Name: "docker log",
 					File: "/var/lib/docker/containers/*/*.log",
@@ -218,12 +218,12 @@ func TestInstall_RecipeFailed(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -259,8 +259,8 @@ func TestInstall_InstallComplete(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -302,8 +302,8 @@ func TestInstall_InstallCompleteError(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -336,11 +336,11 @@ func TestInstall_InstallCompleteError_guidedRecipeFail(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           "badRecipe",
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -372,12 +372,12 @@ func TestInstall_RecipeSkipped(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    "test displayName",
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:        types.InfraAgentRecipeName,
 			DisplayName: "Infra Recipe",
@@ -409,13 +409,13 @@ func TestInstall_RecipeSkippedApm(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    "test displayName",
 		ValidationNRQL: "testNrql",
 		Keywords:       []string{"apm"},
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:        types.InfraAgentRecipeName,
 			DisplayName: "Infra Recipe",
@@ -447,13 +447,13 @@ func TestInstall_RecipeSkippedApmAnyKeyword(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    "test displayName",
 		ValidationNRQL: "testNrql",
 		Keywords:       []string{"xy", "apm", "z"},
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:        types.InfraAgentRecipeName,
 			DisplayName: "Infra Recipe",
@@ -486,11 +486,11 @@ func TestInstall_RecipeSkipped_SkipAll(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           "test-recipe",
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -521,12 +521,12 @@ func TestInstall_RecipeSkipped_MultiSelect(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -558,7 +558,7 @@ func TestInstall_RecipeRecommended(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{
 		{
 			Name:           testRecipeName,
 			DisplayName:    testRecipeName,
@@ -589,7 +589,7 @@ func TestInstall_RecipeRecommended(t *testing.T) {
 			},
 		},
 	}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -627,12 +627,12 @@ func TestInstall_RecipeSkipped_AssumeYes(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    "test displayName",
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:        types.InfraAgentRecipeName,
 			DisplayName: "Infra Recipe",
@@ -664,8 +664,8 @@ func TestInstall_TargetedInstall_InstallsInfraAgent(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -689,8 +689,8 @@ func TestInstall_TargetedInstall_InstallsInfraAgentDependency(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           "testRecipe",
 			ValidationNRQL: "testNrql",
@@ -719,8 +719,8 @@ func TestInstall_TargetedInstallInfraAgent_NoInfraAgentDuplicate(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -745,8 +745,8 @@ func TestInstall_TargetedInstall_SkipInfra(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			ValidationNRQL: "testNrql",
@@ -771,8 +771,8 @@ func TestInstall_TargetedInstall_SkipInfraDependency(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           "testRecipe",
 			ValidationNRQL: "testNrql",
@@ -801,12 +801,12 @@ func TestInstall_GuidReport(t *testing.T) {
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
 	status = execution.NewInstallStatus(statusReporters)
 	f = recipes.NewMockRecipeFetcher()
-	f.FetchRecommendationsVal = []types.Recipe{{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
 		ValidationNRQL: "testNrql",
 	}}
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
 			DisplayName:    types.InfraAgentRecipeName,
@@ -848,10 +848,10 @@ func TestInstall_GuidReport(t *testing.T) {
 	}
 }
 
-func fetchRecipeFileFunc(recipeURL *url.URL) (*recipes.RecipeFile, error) {
+func fetchRecipeFileFunc(recipeURL *url.URL) (*types.OpenInstallationRecipe, error) {
 	return testRecipeFile, nil
 }
 
-func loadRecipeFileFunc(filename string) (*recipes.RecipeFile, error) {
+func loadRecipeFileFunc(filename string) (*types.OpenInstallationRecipe, error) {
 	return testRecipeFile, nil
 }

--- a/internal/install/recipes/local_recipe_fetcher.go
+++ b/internal/install/recipes/local_recipe_fetcher.go
@@ -17,7 +17,7 @@ type LocalRecipeFetcher struct {
 	Path string
 }
 
-func (f *LocalRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.DiscoveryManifest, friendlyName string) (*types.Recipe, error) {
+func (f *LocalRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.DiscoveryManifest, friendlyName string) (*types.OpenInstallationRecipe, error) {
 	recipes, err := f.FetchRecommendations(ctx, manifest)
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func (f *LocalRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.Di
 	return nil, fmt.Errorf("%s: %w", friendlyName, ErrRecipeNotFound)
 }
 
-func (f *LocalRecipeFetcher) FetchRecommendations(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.Recipe, error) {
+func (f *LocalRecipeFetcher) FetchRecommendations(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error) {
 	recipes, err := f.FetchRecipes(ctx, manifest)
 	if err != nil {
 		return nil, err
@@ -41,8 +41,8 @@ func (f *LocalRecipeFetcher) FetchRecommendations(ctx context.Context, manifest 
 	return manifest.ConstrainRecipes(recipes), nil
 }
 
-func (f *LocalRecipeFetcher) FetchRecipes(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.Recipe, error) {
-	var recipes []types.Recipe
+func (f *LocalRecipeFetcher) FetchRecipes(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error) {
+	var recipes []types.OpenInstallationRecipe
 	var err error
 
 	if f.Path == "" {
@@ -57,7 +57,7 @@ func (f *LocalRecipeFetcher) FetchRecipes(ctx context.Context, manifest *types.D
 	return recipes, nil
 }
 
-func loadRecipesFromDir(ctx context.Context, path string) ([]types.Recipe, error) {
+func loadRecipesFromDir(ctx context.Context, path string) ([]types.OpenInstallationRecipe, error) {
 	recipePaths := []string{}
 
 	log.WithFields(log.Fields{
@@ -80,10 +80,10 @@ func loadRecipesFromDir(ctx context.Context, path string) ([]types.Recipe, error
 		return nil, err
 	}
 
-	recipes := []types.Recipe{}
+	recipes := []types.OpenInstallationRecipe{}
 
 	for _, path := range recipePaths {
-		var r RecipeFile
+		var r types.OpenInstallationRecipe
 
 		content, err := ioutil.ReadFile(path)
 		if err != nil {
@@ -97,15 +97,7 @@ func loadRecipesFromDir(ctx context.Context, path string) ([]types.Recipe, error
 			continue
 		}
 
-		rec, err := r.ToRecipe()
-		if err != nil {
-			log.Error(err)
-			continue
-		}
-
-		if rec != nil {
-			recipes = append(recipes, *rec)
-		}
+		recipes = append(recipes, r)
 	}
 
 	return recipes, nil

--- a/internal/install/recipes/mock_recipe_fetcher.go
+++ b/internal/install/recipes/mock_recipe_fetcher.go
@@ -14,22 +14,22 @@ type MockRecipeFetcher struct {
 	FetchRecipeCallCount          int
 	FetchRecipesCallCount         int
 	FetchRecommendationsCallCount int
-	FetchRecipeVals               []types.Recipe
-	FetchRecipeVal                *types.Recipe
-	FetchRecipesVal               []types.Recipe
-	FetchRecommendationsVal       []types.Recipe
+	FetchRecipeVals               []types.OpenInstallationRecipe
+	FetchRecipeVal                *types.OpenInstallationRecipe
+	FetchRecipesVal               []types.OpenInstallationRecipe
+	FetchRecommendationsVal       []types.OpenInstallationRecipe
 	FetchRecipeNameCount          map[string]int
 }
 
 func NewMockRecipeFetcher() *MockRecipeFetcher {
 	f := MockRecipeFetcher{}
-	f.FetchRecipesVal = []types.Recipe{}
-	f.FetchRecommendationsVal = []types.Recipe{}
+	f.FetchRecipesVal = []types.OpenInstallationRecipe{}
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeNameCount = make(map[string]int)
 	return &f
 }
 
-func (f *MockRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.DiscoveryManifest, friendlyName string) (*types.Recipe, error) {
+func (f *MockRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.DiscoveryManifest, friendlyName string) (*types.OpenInstallationRecipe, error) {
 	f.FetchRecipeCallCount++
 	f.FetchRecipeNameCount[friendlyName]++
 
@@ -41,12 +41,12 @@ func (f *MockRecipeFetcher) FetchRecipe(ctx context.Context, manifest *types.Dis
 	return f.FetchRecipeVal, f.FetchRecipeErr
 }
 
-func (f *MockRecipeFetcher) FetchRecipes(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.Recipe, error) {
+func (f *MockRecipeFetcher) FetchRecipes(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error) {
 	f.FetchRecipesCallCount++
 	return f.FetchRecipesVal, f.FetchRecipesErr
 }
 
-func (f *MockRecipeFetcher) FetchRecommendations(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.Recipe, error) {
+func (f *MockRecipeFetcher) FetchRecommendations(ctx context.Context, manifest *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error) {
 	f.FetchRecommendationsCallCount++
 	return f.FetchRecommendationsVal, f.FetchRecommendationsErr
 }

--- a/internal/install/recipes/mock_recipe_file_fetcher.go
+++ b/internal/install/recipes/mock_recipe_file_fetcher.go
@@ -2,11 +2,13 @@ package recipes
 
 import (
 	"net/url"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 type MockRecipeFileFetcher struct {
-	FetchRecipeFileFunc func(*url.URL) (*RecipeFile, error)
-	LoadRecipeFileFunc  func(string) (*RecipeFile, error)
+	FetchRecipeFileFunc func(*url.URL) (*types.OpenInstallationRecipe, error)
+	LoadRecipeFileFunc  func(string) (*types.OpenInstallationRecipe, error)
 }
 
 func NewMockRecipeFileFetcher() *MockRecipeFileFetcher {
@@ -16,18 +18,18 @@ func NewMockRecipeFileFetcher() *MockRecipeFileFetcher {
 	return &f
 }
 
-func (f *MockRecipeFileFetcher) FetchRecipeFile(url *url.URL) (*RecipeFile, error) {
+func (f *MockRecipeFileFetcher) FetchRecipeFile(url *url.URL) (*types.OpenInstallationRecipe, error) {
 	return f.FetchRecipeFileFunc(url)
 }
 
-func (f *MockRecipeFileFetcher) LoadRecipeFile(filename string) (*RecipeFile, error) {
+func (f *MockRecipeFileFetcher) LoadRecipeFile(filename string) (*types.OpenInstallationRecipe, error) {
 	return f.LoadRecipeFileFunc(filename)
 }
 
-func defaultFetchRecipeFileFunc(recipeURL *url.URL) (*RecipeFile, error) {
-	return &RecipeFile{}, nil
+func defaultFetchRecipeFileFunc(recipeURL *url.URL) (*types.OpenInstallationRecipe, error) {
+	return &types.OpenInstallationRecipe{}, nil
 }
 
-func defaultLoadRecipeFileFunc(filename string) (*RecipeFile, error) {
-	return &RecipeFile{}, nil
+func defaultLoadRecipeFileFunc(filename string) (*types.OpenInstallationRecipe, error) {
+	return &types.OpenInstallationRecipe{}, nil
 }

--- a/internal/install/recipes/recipe_fetcher.go
+++ b/internal/install/recipes/recipe_fetcher.go
@@ -8,7 +8,7 @@ import (
 
 // RecipeFetcher is responsible for retrieving recipe information.
 type RecipeFetcher interface {
-	FetchRecipe(context.Context, *types.DiscoveryManifest, string) (*types.Recipe, error)
-	FetchRecommendations(context.Context, *types.DiscoveryManifest) ([]types.Recipe, error)
-	FetchRecipes(context.Context, *types.DiscoveryManifest) ([]types.Recipe, error)
+	FetchRecipe(context.Context, *types.DiscoveryManifest, string) (*types.OpenInstallationRecipe, error)
+	FetchRecommendations(context.Context, *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error)
+	FetchRecipes(context.Context, *types.DiscoveryManifest) ([]types.OpenInstallationRecipe, error)
 }

--- a/internal/install/recipes/recipe_file_fetcher.go
+++ b/internal/install/recipes/recipe_file_fetcher.go
@@ -2,9 +2,11 @@ package recipes
 
 import (
 	"net/url"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 type RecipeFileFetcher interface {
-	FetchRecipeFile(recipeURL *url.URL) (*RecipeFile, error)
-	LoadRecipeFile(filename string) (*RecipeFile, error)
+	FetchRecipeFile(recipeURL *url.URL) (*types.OpenInstallationRecipe, error)
+	LoadRecipeFile(filename string) (*types.OpenInstallationRecipe, error)
 }

--- a/internal/install/recipes/service_recipe_fetcher_test.go
+++ b/internal/install/recipes/service_recipe_fetcher_test.go
@@ -49,7 +49,7 @@ func TestFetchFilters(t *testing.T) {
 	require.NotEmpty(t, recipes)
 	// The duplicate name should still be included when we perform the FetchRecipes() call.
 	require.Equal(t, 3, len(recipes))
-	require.True(t, reflect.DeepEqual(createRecipes(r), recipes))
+	require.True(t, reflect.DeepEqual(r, recipes))
 }
 
 func TestFetchRecommendations(t *testing.T) {
@@ -57,29 +57,14 @@ func TestFetchRecommendations(t *testing.T) {
 		{
 			ID:   "MAo=",
 			Name: "testing1",
-			File: `
----
-name: Test recipe file
-description: test description
-`,
 		},
 		{
 			ID:   "non-zero",
 			Name: "testing1",
-			File: `
----
-name: Test recipe file2
-description: test description
-`,
 		},
 		{
 			ID:   "non-zero2",
 			Name: "testing2",
-			File: `
----
-name: Test recipe file3
-description: test description
-`,
 		},
 	}
 

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -182,7 +182,7 @@ func (b *ScenarioBuilder) LogMatches() *RecipeInstaller {
 	p := ux.NewPromptUIPrompter()
 	pi := ux.NewPlainProgress()
 
-	gff.FilterVal = []types.LogMatch{
+	gff.FilterVal = []types.OpenInstallationLogMatch{
 		{
 			Name: "asdf",
 			File: "asdf",
@@ -321,7 +321,7 @@ func (b *ScenarioBuilder) DisplayExplorerLink() *RecipeInstaller {
 
 func setupRecipeFetcherGuidedInstall() recipes.RecipeFetcher {
 	f := recipes.NewMockRecipeFetcher()
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:        "infrastructure-agent-installer",
 			DisplayName: "Infrastructure Agent",
@@ -338,45 +338,24 @@ It is made up of a multi line string.
 				`,
 			},
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: infra-agent
-displayName: Infrastructure Agent
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 		{
 			Name:           "logs-integration",
 			DisplayName:    "Logs integration",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: logs-integration
-displayName: Logs integration
-install:
-  version: "3"
-  tasks:
-    default:
-`,
+			LogMatch: []types.OpenInstallationLogMatch{
+				{
+					Name: "docker log",
+					File: "/var/lib/docker/containers/*/*.log",
+				},
+			},
 		},
 	}
-	f.FetchRecommendationsVal = []types.Recipe{
+	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{
 		{
 			Name:           "recommended-recipe",
 			DisplayName:    "Recommended recipe",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: recommended-recipe
-displayName: Recommended recipe
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 	}
 
@@ -385,34 +364,16 @@ install:
 
 func setupRecipeFetcherStitchedPath() recipes.RecipeFetcher {
 	f := recipes.NewMockRecipeFetcher()
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           "recommended-recipe",
 			DisplayName:    "Recommended recipe",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: recommended-recipe
-displayName: Recommended recipe
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 		{
 			Name:           "another-recommended-recipe",
 			DisplayName:    "Another Recommended recipe",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: another-recommended-recipe
-displayName: Another Recommended recipe
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 	}
 
@@ -421,48 +382,16 @@ install:
 
 func setupRecipeCanceledInstall() recipes.RecipeFetcher {
 	f := recipes.NewMockRecipeFetcher()
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           "infrastructure-agent-installer",
 			DisplayName:    "Infrastructure Agent",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: infra-agent
-displayName: Infrastructure Agent
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 		{
 			Name:           "test-canceled-installation",
 			DisplayName:    "Test Canceled Installation",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: test-canceled-installation
-displayName: Test Canceled Installation
-description: Scenario to test when a user cancels installation via ctl+c
-
-processMatch: []
-
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
-
-install:
-  version: "3"
-  silent: true
-  tasks:
-    default:
-      cmds:
-        - task: run
-    run:
-      cmds:
-        - |
-          echo "sleeping 10 seconds"
-          sleep 10
-`,
 		},
 	}
 
@@ -471,7 +400,7 @@ install:
 
 func setupDisplayExplorerLink() recipes.RecipeFetcher {
 	f := recipes.NewMockRecipeFetcher()
-	f.FetchRecipeVals = []types.Recipe{
+	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           "test-display-explorer-link",
 			DisplayName:    "Test Display Explorer Link",
@@ -480,46 +409,11 @@ func setupDisplayExplorerLink() recipes.RecipeFetcher {
 				Type:   "explorer",
 				Filter: "\"`tags.language` = 'java'\"",
 			},
-			File: `
----
-name: test-display-explorer-link
-displayName: Test Display Explorer Link
-description: Scenario to test when a recipe designates a filtered explorer link
-
-processMatch: []
-
-validationNrql: "SELECT count(*) from SystemSample where hostname like '{{.HOSTNAME}}' FACET entityGuid SINCE 10 minutes ago"
-
-successLinkConfig:
-  type: explorer
-  filter: "` + "`tags.language`" + ` = 'java'"
-
-install:
-  version: "3"
-  silent: true
-  tasks:
-    default:
-      cmds:
-        - task: run
-    run:
-      cmds:
-        - |
-          echo "executing recipe steps"
-`,
 		},
 		{
 			Name:           "infrastructure-agent-installer",
 			DisplayName:    "Infrastructure Agent",
 			ValidationNRQL: "test NRQL",
-			File: `
----
-name: infra-agent
-displayName: Infrastructure Agent
-install:
-  version: "3"
-  tasks:
-    default:
-`,
 		},
 	}
 

--- a/internal/install/types/discovery_manifest.go
+++ b/internal/install/types/discovery_manifest.go
@@ -36,8 +36,8 @@ func (d *DiscoveryManifest) AddMatchedProcess(p MatchedProcess) {
 	d.Processes = append(d.Processes, p)
 }
 
-func (d *DiscoveryManifest) ConstrainRecipes(allRecipes []Recipe) []Recipe {
-	var recipes []Recipe
+func (d *DiscoveryManifest) ConstrainRecipes(allRecipes []OpenInstallationRecipe) []OpenInstallationRecipe {
+	var recipes []OpenInstallationRecipe
 
 	for _, recipe := range allRecipes {
 		if len(recipe.InstallTargets) == 0 {

--- a/internal/install/types/discovery_manifest_test.go
+++ b/internal/install/types/discovery_manifest_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDiscoveryManifest_ConstrainRecipes(t *testing.T) {
 
-	recipes := []Recipe{
+	recipes := []OpenInstallationRecipe{
 		{
 			Name: "unknown",
 			InstallTargets: []OpenInstallationRecipeInstallTarget{

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -1,34 +1,324 @@
 package types
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
 
 const (
 	InfraAgentRecipeName = "infrastructure-agent-installer"
 	LoggingRecipeName    = "logs-integration"
 )
 
-type Recipe struct {
-	ID                string                                   `json:"id" yaml:"id"`
-	Description       string                                   `json:"description" yaml:"description"`
-	DisplayName       string                                   `json:"displayName" yaml:"displayName"`
-	Dependencies      []string                                 `json:"dependencies" yaml:"dependencies"`
-	Stability         OpenInstallationStability                `json:"stability" yaml:"stability"`
-	Quickstarts       OpenInstallationQuickstartsFilter        `json:"quickstarts,omitempty" yaml:"quickstarts"`
-	File              string                                   `json:"file" yaml:"file"`
-	InstallTargets    []OpenInstallationRecipeInstallTarget    `json:"installTargets" yaml:"installTargets"`
-	Keywords          []string                                 `json:"keywords" yaml:"keywords"`
-	LogMatch          []LogMatch                               `json:"logMatch" yaml:"logMatch"`
-	Name              string                                   `json:"name" yaml:"name"`
-	PreInstall        OpenInstallationPreInstallConfiguration  `json:"preInstall" yaml:"preInstall"`
-	PostInstall       OpenInstallationPostInstallConfiguration `json:"postInstall" yaml:"postInstall"`
-	ProcessMatch      []string                                 `json:"processMatch" yaml:"processMatch"`
-	Repository        string                                   `json:"repository" yaml:"repository"`
-	SuccessLinkConfig OpenInstallationSuccessLinkConfig        `json:"successLinkConfig" yaml:"successLinkConfig"`
-	ValidationNRQL    string                                   `json:"validationNrql" yaml:"validationNrql"`
-	Vars              map[string]interface{}
+var (
+	RecipeVariables = map[string]string{}
+)
+
+// The API response returns OpenInstallationRecipe.Install as a string.
+// When specifying a recipe path, OpenInstallationRecipe.Install is a map[interface{}]interface{}.
+// For this reason we need a custom unmarshal method for YAML.
+func (r *OpenInstallationRecipe) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var recipe map[string]interface{}
+	err := unmarshal(&recipe)
+	if err != nil {
+		return err
+	}
+
+	if v, ok := recipe["dependencies"]; ok {
+		r.Dependencies = interfaceSliceToStringSlice(v.([]interface{}))
+	}
+
+	r.Description = toStringByFieldName("description", recipe)
+	r.DisplayName = toStringByFieldName("displayName", recipe)
+	r.File = toStringByFieldName("file", recipe)
+	r.ID = toStringByFieldName("id", recipe)
+	r.InputVars = expandInputVars(recipe)
+
+	installAsString, err := expandInstalllMapToString(recipe)
+	if err != nil {
+		return err
+	}
+	r.Install = installAsString
+
+	r.InstallTargets = expandInstallTargets(recipe)
+
+	if v, ok := recipe["keywords"]; ok {
+		r.Keywords = interfaceSliceToStringSlice(v.([]interface{}))
+	}
+
+	r.LogMatch = expandLogMatch(recipe)
+	r.Name = toStringByFieldName("name", recipe)
+	r.PostInstall = expandPostInstall(recipe)
+	r.PreInstall = expandPreInstall(recipe)
+
+	if v, ok := recipe["processMatch"]; ok {
+		r.ProcessMatch = interfaceSliceToStringSlice(v.([]interface{}))
+	}
+
+	// Quickstarts are not quite ready in the API yet.
+	// The Nerdgraph type are incorrect and will get getting
+	// updated when the Quickstarts feature is worked on.
+	// r.Quickstarts = expandQuickStarts(recipe)
+
+	r.Repository = toStringByFieldName("repository", recipe)
+
+	if v, ok := recipe["stability"]; ok {
+		r.Stability = OpenInstallationStability(v.(string))
+	}
+
+	r.SuccessLinkConfig = expandSuccessLinkConfig(recipe)
+
+	if v, ok := recipe["validationNrql"]; ok {
+		r.ValidationNRQL = NRQL(v.(string))
+	}
+
+	return err
 }
 
-func (r *Recipe) PostInstallMessage() string {
+func expandSuccessLinkConfig(recipe map[string]interface{}) OpenInstallationSuccessLinkConfig {
+	v, ok := recipe["successLinkConfig"]
+	if !ok {
+		return OpenInstallationSuccessLinkConfig{}
+	}
+
+	dataIn := v.(map[interface{}]interface{})
+	reData := map[string]interface{}{}
+	for k, v := range dataIn {
+		reData[k.(string)] = v
+	}
+
+	dataOut := OpenInstallationSuccessLinkConfig{
+		Filter: toStringByFieldName("filter", reData),
+	}
+
+	if v, ok := reData["type"]; ok {
+		dataOut.Type = OpenInstallationSuccessLinkType(v.(string))
+	}
+
+	return dataOut
+}
+
+func expandInstallTargets(recipe map[string]interface{}) []OpenInstallationRecipeInstallTarget {
+	v, ok := recipe["installTargets"]
+	if !ok {
+		return []OpenInstallationRecipeInstallTarget{}
+	}
+
+	dataIn := v.([]interface{})
+	dataOut := make([]OpenInstallationRecipeInstallTarget, len(dataIn))
+	dataz := make([]map[string]interface{}, len(dataIn))
+	for i, vv := range dataIn {
+		vvv := vv.(map[interface{}]interface{})
+		varr := map[string]interface{}{}
+
+		for k, v := range vvv {
+			varr[k.(string)] = v
+			dataz[i] = varr
+		}
+	}
+
+	for i, v := range dataz {
+		vOut := OpenInstallationRecipeInstallTarget{
+			KernelArch:      toStringByFieldName("kernelArch", v),
+			KernelVersion:   toStringByFieldName("kernelVersion", v),
+			PlatformVersion: toStringByFieldName("platformVersion", v),
+		}
+
+		if v, ok := v["os"]; ok {
+			vOut.Os = OpenInstallationOperatingSystem(v.(string))
+		}
+
+		if v, ok := v["platform"]; ok {
+			vOut.Platform = OpenInstallationPlatform(v.(string))
+		}
+
+		if v, ok := v["platformFamily"]; ok {
+			vOut.PlatformFamily = OpenInstallationPlatformFamily(v.(string))
+		}
+
+		if v, ok := v["type"]; ok {
+			vOut.Type = OpenInstallationTargetType(v.(string))
+		}
+
+		dataOut[i] = vOut
+	}
+
+	return dataOut
+}
+
+func expandPreInstall(recipe map[string]interface{}) OpenInstallationPreInstallConfiguration {
+	v, ok := recipe["preInstall"]
+	if !ok {
+		return OpenInstallationPreInstallConfiguration{}
+	}
+
+	vv := v.(map[interface{}]interface{})
+	infoOut := map[string]interface{}{}
+	for k, v := range vv {
+		infoOut[k.(string)] = v
+	}
+
+	return OpenInstallationPreInstallConfiguration{
+		Info:   toStringByFieldName("info", infoOut),
+		Prompt: toStringByFieldName("prompt", infoOut),
+	}
+}
+
+func expandPostInstall(recipe map[string]interface{}) OpenInstallationPostInstallConfiguration {
+	v, ok := recipe["postInstall"]
+	if !ok {
+		return OpenInstallationPostInstallConfiguration{}
+	}
+
+	vv := v.(map[interface{}]interface{})
+	infoOut := map[string]interface{}{}
+	for k, v := range vv {
+		infoOut[k.(string)] = v
+	}
+
+	return OpenInstallationPostInstallConfiguration{
+		Info: toStringByFieldName("info", infoOut),
+	}
+}
+
+func expandInputVars(recipe map[string]interface{}) []OpenInstallationRecipeInputVariable {
+	v, ok := recipe["inputVars"]
+	if !ok {
+		return []OpenInstallationRecipeInputVariable{}
+	}
+
+	vars := v.([]interface{})
+	varsOut := make([]OpenInstallationRecipeInputVariable, len(vars))
+
+	varz := make([]map[string]interface{}, len(vars))
+	for i, vv := range vars {
+		vvv := vv.(map[interface{}]interface{})
+		varr := map[string]interface{}{}
+
+		for k, v := range vvv {
+			varr[k.(string)] = v
+			varz[i] = varr
+		}
+	}
+
+	for i, v := range varz {
+		vOut := OpenInstallationRecipeInputVariable{
+			Default: toStringByFieldName("default", v),
+			Name:    toStringByFieldName("name", v),
+			Prompt:  toStringByFieldName("prompt", v),
+			Secret:  toBoolByFieldName("secret", v),
+		}
+
+		varsOut[i] = vOut
+	}
+
+	return varsOut
+}
+
+func expandLogMatch(recipe map[string]interface{}) []OpenInstallationLogMatch {
+	v, ok := recipe["logMatch"]
+	if !ok {
+		return []OpenInstallationLogMatch{}
+	}
+
+	dataIn := v.([]interface{})
+	dataOut := make([]OpenInstallationLogMatch, len(dataIn))
+	dataz := make([]map[string]interface{}, len(dataIn))
+	for i, vv := range dataIn {
+		vvv := vv.(map[interface{}]interface{})
+		varr := map[string]interface{}{}
+
+		for k, v := range vvv {
+			varr[k.(string)] = v
+			dataz[i] = varr
+		}
+	}
+
+	for i, v := range dataz {
+		vOut := OpenInstallationLogMatch{
+			Attributes: expandLogAttributes(v),
+			File:       toStringByFieldName("file", v),
+			Name:       toStringByFieldName("name", v),
+			Pattern:    toStringByFieldName("pattern", v),
+			Systemd:    toStringByFieldName("systemd", v),
+		}
+
+		dataOut[i] = vOut
+	}
+
+	return dataOut
+}
+
+func expandLogAttributes(data map[string]interface{}) OpenInstallationAttributes {
+	attributesOut := OpenInstallationAttributes{}
+
+	v, ok := data["attributes"]
+	if !ok {
+		return attributesOut
+	}
+
+	attrs := v.(map[interface{}]interface{})
+	attrsOut := map[string]string{}
+	for k, v := range attrs {
+		attrsOut[k.(string)] = v.(string)
+	}
+
+	if v, ok := attrsOut["logtype"]; ok {
+		attributesOut.Logtype = v
+	}
+
+	return attributesOut
+}
+
+func toBoolByFieldName(fieldName string, data map[string]interface{}) bool {
+	if v, ok := data[fieldName]; ok {
+		return v.(bool)
+	}
+
+	return false
+}
+
+func toStringByFieldName(fieldName string, data map[string]interface{}) string {
+	if v, ok := data[fieldName]; ok {
+		return v.(string)
+	}
+
+	return ""
+}
+
+func expandInstalllMapToString(recipeIn map[string]interface{}) (string, error) {
+	installIn, ok := recipeIn["install"]
+	if !ok {
+		return "", nil
+	}
+
+	installOut := map[string]interface{}{}
+	installMap := installIn.(map[interface{}]interface{})
+	for k, v := range installMap {
+		installOut[k.(string)] = v
+	}
+
+	installAsString, err := yaml.Marshal(installOut)
+	if err != nil {
+		return "", fmt.Errorf("error unmarshaling recipe.install to string: %s", err)
+	}
+
+	return string(installAsString), nil
+}
+
+func interfaceSliceToStringSlice(slice []interface{}) []string {
+	out := make([]string, len(slice))
+
+	for i, v := range slice {
+		out[i] = v.(string)
+	}
+
+	return out
+}
+
+func (r *OpenInstallationRecipe) PostInstallMessage() string {
 	if r.PostInstall.Info != "" {
 		return r.PostInstall.Info
 	}
@@ -36,7 +326,7 @@ func (r *Recipe) PostInstallMessage() string {
 	return ""
 }
 
-func (r *Recipe) PreInstallMessage() string {
+func (r *OpenInstallationRecipe) PreInstallMessage() string {
 	if r.PreInstall.Info != "" {
 		return r.PreInstall.Info
 	}
@@ -44,45 +334,35 @@ func (r *Recipe) PreInstallMessage() string {
 	return ""
 }
 
-// LogMatch represents a pattern that may match one or more logs on the underlying host.
-type LogMatch struct {
-	Name       string             `yaml:"name"`
-	File       string             `yaml:"file"`
-	Attributes LogMatchAttributes `yaml:"attributes,omitempty"`
-	Pattern    string             `yaml:"pattern,omitempty"`
-	Systemd    string             `yaml:"systemd,omitempty"`
-}
-
-// LogMatchAttributes contains metadata about its parent LogMatch.
-type LogMatchAttributes struct {
-	LogType string `yaml:"logtype"`
-}
-
 type RecipeVars map[string]string
 
 // AddVar is responsible for including a new variable on the recipe Vars
 // struct, which is used by go-task executor.
-func (r *Recipe) AddVar(key string, value interface{}) {
-	if len(r.Vars) == 0 {
-		r.Vars = make(map[string]interface{})
-	}
+func (r *OpenInstallationRecipe) AddVar(key string, value interface{}) {
+	// if len(r.Vars) == 0 {
+	// 	r.Vars = make(map[string]interface{})
+	// }
 
-	r.Vars[key] = value
+	// r.Vars[key] = value
 }
 
-func (r *Recipe) IsApm() bool {
+func (r *OpenInstallationRecipe) SetRecipeVar(key string, value string) {
+	RecipeVariables[key] = value
+}
+
+func (r *OpenInstallationRecipe) IsApm() bool {
 	return r.HasKeyword("apm")
 }
 
-func (r *Recipe) HasHostTargetType() bool {
+func (r *OpenInstallationRecipe) HasHostTargetType() bool {
 	return r.HasTargetType(OpenInstallationTargetTypeTypes.HOST)
 }
 
-func (r *Recipe) HasApplicationTargetType() bool {
+func (r *OpenInstallationRecipe) HasApplicationTargetType() bool {
 	return r.HasTargetType(OpenInstallationTargetTypeTypes.APPLICATION)
 }
 
-func (r *Recipe) HasKeyword(keyword string) bool {
+func (r *OpenInstallationRecipe) HasKeyword(keyword string) bool {
 	if len(r.Keywords) == 0 {
 		return false
 	}
@@ -96,7 +376,7 @@ func (r *Recipe) HasKeyword(keyword string) bool {
 	return false
 }
 
-func (r *Recipe) HasTargetType(t OpenInstallationTargetType) bool {
+func (r *OpenInstallationRecipe) HasTargetType(t OpenInstallationTargetType) bool {
 	if len(r.InstallTargets) == 0 {
 		return false
 	}

--- a/internal/install/types/types.go
+++ b/internal/install/types/types.go
@@ -153,134 +153,134 @@ var OpenInstallationTargetTypeTypes = struct {
 // OpenInstallationAttributes - Custom event data attributes
 type OpenInstallationAttributes struct {
 	// Built-in parsing rulesets
-	Logtype string `json:"logtype,omitempty"`
+	Logtype string `json:"logtype,omitempty" yaml:"logtype,omitempty"`
 }
 
 // OpenInstallationLogMatch - Matches partial list of the Log forwarding parameters
 type OpenInstallationLogMatch struct {
 	// List of custom attributes, as key-value pairs, that can be used to send additional data with the logs which you can then query.
-	Attributes OpenInstallationAttributes `json:"attributes,omitempty"`
+	Attributes OpenInstallationAttributes `json:"attributes,omitempty" yaml:"attributes,omitempty"`
 	// Path to the log file or files.
-	File string `json:"file,omitempty"`
+	File string `json:"file,omitempty" yaml:"file,omitempty"`
 	// Name of the log or logs.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Regular expression for filtering records.
-	Pattern string `json:"pattern,omitempty"`
+	Pattern string `json:"pattern,omitempty" yaml:"pattern,omitempty"`
 	// Service name (Linux Only).
-	Systemd string `json:"systemd,omitempty"`
+	Systemd string `json:"systemd,omitempty" yaml:"systemd,omitempty"`
 }
 
 // OpenInstallationPostInstallConfiguration - Optional post-install configuration items
 type OpenInstallationPostInstallConfiguration struct {
 	// Message/Docs notice displayed to user after running the recipe
-	Info string `json:"info,omitempty"`
+	Info string `json:"info,omitempty" yaml:"info,omitempty"`
 }
 
 // OpenInstallationPreInstallConfiguration - Optional pre-install configuration items
 type OpenInstallationPreInstallConfiguration struct {
 	// Message/Docs notice displayed to user prior to running recipe
-	Info string `json:"info,omitempty"`
+	Info string `json:"info,omitempty" yaml:"info,omitempty"`
 	// Message/Docs notice displayed to user prior to running recipe
-	Prompt string `json:"prompt,omitempty"`
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
 }
 
 // OpenInstallationQuickstartEntityType - Entity type relation for Quickstart
 type OpenInstallationQuickstartEntityType struct {
 	// Domain of Entity
-	Domain string `json:"domain"`
+	Domain string `json:"domain" yaml:"domain"`
 	// Type of Entity
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 }
 
 // OpenInstallationQuickstartsFilter - Metadata used to filter for Quickstarts
 type OpenInstallationQuickstartsFilter struct {
 	// Categorization of Quickstart
-	Category OpenInstallationCategory `json:"category,omitempty"`
+	Category OpenInstallationCategory `json:"category,omitempty" yaml:"category,omitempty"`
 	// Entity relationship for Quickstart
-	EntityType OpenInstallationQuickstartEntityType `json:"entityType,omitempty"`
+	EntityType OpenInstallationQuickstartEntityType `json:"entityType,omitempty" yaml:"entityType,omitempty"`
 	// Name of the Quickstart
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // OpenInstallationRecipe - Installation instructions and definition of an instrumentation integration
 type OpenInstallationRecipe struct {
 	// Named list of dependencies for this recipe
-	Dependencies []string `json:"dependencies"`
+	Dependencies []string `json:"dependencies" yaml:"dependencies"`
 	// Description of the recipe
-	Description string `json:"description"`
+	Description string `json:"description" yaml:"description"`
 	// Friendly name of the integration
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	// The full contents of the recipe file (yaml)
-	File string `json:"file"`
+	File string `json:"file" yaml:"file"`
 	// The ID
-	ID string `json:"id,omitempty"`
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
 	// List of variables to prompt for input from the user
-	InputVars []OpenInstallationRecipeInputVariable `json:"inputVars"`
-	// Go-task's taskfile definition (see https://taskfile.dev/#/usage)
-	Install string `json:"install"`
+	InputVars []OpenInstallationRecipeInputVariable `json:"inputVars" yaml:"inputVars"`
+	// Go-task's taskfile definiton (see https://taskfile.dev/#/usage)
+	Install string `json:"install" yaml:"install"`
 	// Object representing the intended install target
-	InstallTargets []OpenInstallationRecipeInstallTarget `json:"installTargets"`
+	InstallTargets []OpenInstallationRecipeInstallTarget `json:"installTargets" yaml:"installTargets"`
 	// Tags
-	Keywords []string `json:"keywords"`
+	Keywords []string `json:"keywords" yaml:"keywords"`
 	// # Partial list of possible Log forwarding parameters
-	LogMatch []OpenInstallationLogMatch `json:"logMatch"`
+	LogMatch []OpenInstallationLogMatch `json:"logMatch" yaml:"logMatch"`
 	// Short unique handle for the name of the integration
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Object representing optional post-install configuration items
-	PostInstall OpenInstallationPostInstallConfiguration `json:"postInstall,omitempty"`
+	PostInstall OpenInstallationPostInstallConfiguration `json:"postInstall,omitempty" yaml:"postInstall,omitempty"`
 	// Object representing optional pre-install configuration items
-	PreInstall OpenInstallationPreInstallConfiguration `json:"preInstall,omitempty"`
+	PreInstall OpenInstallationPreInstallConfiguration `json:"preInstall,omitempty" yaml:"preInstall,omitempty"`
 	// List of process definitions used to match CLI process detection
-	ProcessMatch []string `json:"processMatch"`
+	ProcessMatch []string `json:"processMatch" yaml:"processMatch"`
 	// Metadata used to recommend and install Quickstarts
-	Quickstarts OpenInstallationQuickstartsFilter `json:"quickstarts,omitempty"`
+	Quickstarts OpenInstallationQuickstartsFilter `json:"quickstarts,omitempty" yaml:"quickstarts,omitempty"`
 	// Github repository url
-	Repository string `json:"repository"`
+	Repository string `json:"repository" yaml:"repository"`
 	// Indicates stability level of recipe
-	Stability OpenInstallationStability `json:"stability,omitempty"`
+	Stability OpenInstallationStability `json:"stability,omitempty" yaml:"stability,omitempty"`
 	// Metadata to support generating a URL after installation success
-	SuccessLinkConfig OpenInstallationSuccessLinkConfig `json:"successLinkConfig,omitempty"`
+	SuccessLinkConfig OpenInstallationSuccessLinkConfig `json:"successLinkConfig,omitempty" yaml:"successLinkConfig,omitempty"`
 	// NRQL the newrelic-cli uses to validate this recipe
 	// is successfully sending data to New Relic
-	ValidationNRQL NRQL `json:"validationNrql,omitempty"`
+	ValidationNRQL NRQL `json:"validationNrql,omitempty" yaml:"validationNrql,omitempty"`
 }
 
 // OpenInstallationRecipeInputVariable - Recipe input variable prompts displayed to the user prior to execution
 type OpenInstallationRecipeInputVariable struct {
 	// Default value of variable
-	Default string `json:"default,omitempty"`
+	Default string `json:"default,omitempty" yaml:"default,omitempty"`
 	// Name of the variable
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Message to present to the user
-	Prompt string `json:"prompt,omitempty"`
+	Prompt string `json:"prompt,omitempty" yaml:"prompt,omitempty"`
 	// Indicates a password field
-	Secret bool `json:"secret,omitempty"`
+	Secret bool `json:"secret,omitempty" yaml:"secret,omitempty"`
 }
 
 // OpenInstallationRecipeInstallTarget - Matrix of supported installation criteria for this recipe
 type OpenInstallationRecipeInstallTarget struct {
 	// OS kernel architecture
-	KernelArch string `json:"kernelArch,omitempty"`
+	KernelArch string `json:"kernelArch,omitempty" yaml:"kernelArch,omitempty"`
 	// OS kernel version
-	KernelVersion string `json:"kernelVersion,omitempty"`
+	KernelVersion string `json:"kernelVersion,omitempty" yaml:"kernelVersion,omitempty"`
 	// Operating system
-	Os OpenInstallationOperatingSystem `json:"os,omitempty"`
+	Os OpenInstallationOperatingSystem `json:"os,omitempty" yaml:"os,omitempty"`
 	// Operating System distribution
-	Platform OpenInstallationPlatform `json:"platform,omitempty"`
+	Platform OpenInstallationPlatform `json:"platform,omitempty" yaml:"platform,omitempty"`
 	// Operating System distribution family
-	PlatformFamily OpenInstallationPlatformFamily `json:"platformFamily,omitempty"`
+	PlatformFamily OpenInstallationPlatformFamily `json:"platformFamily,omitempty" yaml:"platformFamily,omitempty"`
 	// OS distribution version
-	PlatformVersion string `json:"platformVersion,omitempty"`
+	PlatformVersion string `json:"platformVersion,omitempty" yaml:"platformVersion,omitempty"`
 	// Target type
-	Type OpenInstallationTargetType `json:"type,omitempty"`
+	Type OpenInstallationTargetType `json:"type,omitempty" yaml:"type,omitempty"`
 }
 
 // OpenInstallationSuccessLinkConfig - Metadata to support generating a URL after installation success
 type OpenInstallationSuccessLinkConfig struct {
 	// An optional filter for appending to the URL
-	Filter string `json:"filter,omitempty"`
+	Filter string `json:"filter,omitempty" yaml:"filter,omitempty"`
 	// The type of the link to generate
-	Type OpenInstallationSuccessLinkType `json:"type"`
+	Type OpenInstallationSuccessLinkType `json:"type" yaml:"type"`
 }
 
 // NRQL - This scalar represents a NRQL query string.

--- a/internal/install/validation/mock_recipe_validator.go
+++ b/internal/install/validation/mock_recipe_validator.go
@@ -20,7 +20,7 @@ func NewMockRecipeValidator() *MockRecipeValidator {
 	return &MockRecipeValidator{}
 }
 
-func (m *MockRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) (string, error) {
+func (m *MockRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
 	m.ValidateCallCount++
 
 	var err error

--- a/internal/install/validation/polling_recipe_validator.go
+++ b/internal/install/validation/polling_recipe_validator.go
@@ -44,11 +44,11 @@ func NewPollingRecipeValidator(c nrdbClient) *PollingRecipeValidator {
 }
 
 // Validate polls NRDB to assert data is being reported for the given recipe.
-func (m *PollingRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) (string, error) {
+func (m *PollingRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
 	return m.waitForData(ctx, dm, r)
 }
 
-func (m *PollingRecipeValidator) waitForData(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) (string, error) {
+func (m *PollingRecipeValidator) waitForData(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
 	count := 0
 	ticker := time.NewTicker(m.interval)
 	defer ticker.Stop()
@@ -87,7 +87,7 @@ func (m *PollingRecipeValidator) waitForData(ctx context.Context, dm types.Disco
 	}
 }
 
-func (m *PollingRecipeValidator) tryValidate(ctx context.Context, dm types.DiscoveryManifest, r types.Recipe) (bool, string, error) {
+func (m *PollingRecipeValidator) tryValidate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (bool, string, error) {
 	query, err := substituteHostname(dm, r)
 	if err != nil {
 		return false, "", err
@@ -126,8 +126,8 @@ func (m *PollingRecipeValidator) tryValidate(ctx context.Context, dm types.Disco
 	return false, "", nil
 }
 
-func substituteHostname(dm types.DiscoveryManifest, r types.Recipe) (string, error) {
-	tmpl, err := template.New("validationNRQL").Parse(r.ValidationNRQL)
+func substituteHostname(dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
+	tmpl, err := template.New("validationNRQL").Parse(string(r.ValidationNRQL))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/install/validation/polling_recipe_validator_test.go
+++ b/internal/install/validation/polling_recipe_validator_test.go
@@ -38,7 +38,7 @@ func TestValidate(t *testing.T) {
 	v := NewPollingRecipeValidator(c)
 	v.progressIndicator = pi
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	_, err := v.Validate(getTestContext(), m, r)
@@ -57,7 +57,7 @@ func TestValidate_PassAfterNAttempts(t *testing.T) {
 
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 5)
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	_, err := v.Validate(getTestContext(), m, r)
@@ -75,7 +75,7 @@ func TestValidate_FailAfterNAttempts(t *testing.T) {
 	v.maxAttempts = 3
 	v.interval = 10 * time.Millisecond
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	_, err := v.Validate(getTestContext(), m, r)
@@ -96,7 +96,7 @@ func TestValidate_FailAfterMaxAttempts(t *testing.T) {
 	v.maxAttempts = 1
 	v.interval = 10 * time.Millisecond
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	_, err := v.Validate(getTestContext(), m, r)
@@ -115,7 +115,7 @@ func TestValidate_FailIfContextDone(t *testing.T) {
 	v.progressIndicator = pi
 	v.interval = 1 * time.Second
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	ctx, cancel := context.WithCancel(getTestContext())
@@ -136,7 +136,7 @@ func TestValidate_QueryError(t *testing.T) {
 	v := NewPollingRecipeValidator(c)
 	v.progressIndicator = pi
 
-	r := types.Recipe{}
+	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
 	_, err := v.Validate(getTestContext(), m, r)

--- a/internal/install/validation/recipe_validator.go
+++ b/internal/install/validation/recipe_validator.go
@@ -8,5 +8,5 @@ import (
 
 // RecipeValidator validates installation of a recipe.
 type RecipeValidator interface {
-	Validate(context.Context, types.DiscoveryManifest, types.Recipe) (entityGUID string, err error)
+	Validate(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe) (entityGUID string, err error)
 }


### PR DESCRIPTION
**Checklist**
- [ ] ~Remove recipe_file.go? (yes, please 🦙 )~  Can't quite do this just yet. Next PR
- [x] Need a custom `UnmashalYAML()` method for `OpenInstallationRecipe` due to the `Install` field
- [x] How to handle the `Vars` thing for recipes variable injection
    - update `AddVar()` to use `InputVars` since it that field already exists on `OpenInstallationRecipe`
- [x] Remove `file` from the NerdGraph query
- [x] Remove usage of `OpenInstallationRecipe.File` (deprecated and no longer needed)
- [x] Add note to the custom unmarshal method for the recipe struct for added context 