### PR TITLE
chore(install): make go-task errors nicer

### DIFF
--- a/internal/install/execution/go_task_recipe_executor.go
+++ b/internal/install/execution/go_task_recipe_executor.go
@@ -131,7 +131,7 @@ func (re *GoTaskRecipeExecutor) Execute(ctx context.Context, m types.DiscoveryMa
 		if strings.Contains(err.Error(), "exit status") {
 			lastStderr := stderrCapture.LastFullLine
 
-			return types.NewNonZeroExitCode(types.GoTaskGeneralError{}, lastStderr)
+			return types.NewNonZeroExitCode(goTaskError, lastStderr)
 		}
 
 		return goTaskError

--- a/internal/install/execution/line_capture_buffer.go
+++ b/internal/install/execution/line_capture_buffer.go
@@ -1,0 +1,39 @@
+package execution
+
+import (
+	"io"
+)
+
+type LineCaptureBuffer struct {
+	LastFullLine string
+	current      []byte
+	writer       io.Writer
+}
+
+func NewLineCaptureBuffer(w io.Writer) *LineCaptureBuffer {
+	b := &LineCaptureBuffer{
+		writer: w,
+	}
+
+	return b
+}
+
+func (c *LineCaptureBuffer) Write(p []byte) (n int, err error) {
+	for _, b := range p {
+		if b == '\n' {
+			s := string(c.current)
+			if s != "" {
+				c.LastFullLine = s
+			}
+			c.current = []byte{}
+		} else {
+			c.current = append(c.current, b)
+		}
+	}
+
+	return c.writer.Write(p)
+}
+
+func (c *LineCaptureBuffer) Current() string {
+	return string(c.current)
+}

--- a/internal/install/execution/line_capture_buffer_test.go
+++ b/internal/install/execution/line_capture_buffer_test.go
@@ -1,0 +1,18 @@
+package execution
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLineCaptureBuffer(t *testing.T) {
+	w := bytes.NewBufferString("")
+	b := NewLineCaptureBuffer(w)
+	b.Write([]byte("abc\n123\ndef"))
+
+	require.Equal(t, "123", b.LastFullLine)
+	require.Equal(t, "def", b.Current())
+	require.Equal(t, "abc\n123\ndef", string(w.Bytes()))
+}

--- a/internal/install/execution/line_capture_buffer_test.go
+++ b/internal/install/execution/line_capture_buffer_test.go
@@ -4,15 +4,17 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestLineCaptureBuffer(t *testing.T) {
 	w := bytes.NewBufferString("")
 	b := NewLineCaptureBuffer(w)
-	b.Write([]byte("abc\n123\ndef"))
+	_, err := b.Write([]byte("abc\n123\ndef"))
+	assert.NoError(t, err)
 
 	require.Equal(t, "123", b.LastFullLine)
 	require.Equal(t, "def", b.Current())
-	require.Equal(t, "abc\n123\ndef", string(w.Bytes()))
+	require.Equal(t, "abc\n123\ndef", w.String())
 }

--- a/internal/install/execution/status_subscriber.go
+++ b/internal/install/execution/status_subscriber.go
@@ -21,6 +21,7 @@ type StatusSubscriber interface {
 type RecipeStatusEvent struct {
 	Recipe                         types.OpenInstallationRecipe
 	Msg                            string
+	Tasks                          []string
 	EntityGUID                     string
 	ValidationDurationMilliseconds int64
 }

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -229,18 +229,22 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 			return "", err
 		}
 
-		msg := fmt.Sprintf("encountered an error while executing %s: %s", r.Name, err)
+		msg := fmt.Sprintf("execution failed for %s: %s", r.Name, err)
+
 		se := execution.RecipeStatusEvent{
 			Recipe: *r,
 			Msg:    msg,
 		}
 
 		if e, ok := err.(types.GoTaskError); ok {
+			e.SetError(msg)
 			se.Tasks = e.Tasks()
+		} else {
+			err = errors.New(msg)
 		}
 
 		i.status.RecipeFailed(se)
-		return "", errors.New(msg)
+		return "", err
 	}
 
 	var entityGUID string

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -230,10 +230,16 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 		}
 
 		msg := fmt.Sprintf("encountered an error while executing %s: %s", r.Name, err)
-		i.status.RecipeFailed(execution.RecipeStatusEvent{
+		se := execution.RecipeStatusEvent{
 			Recipe: *r,
 			Msg:    msg,
-		})
+		}
+
+		if e, ok := err.(types.GoTaskError); ok {
+			se.Tasks = e.Tasks()
+		}
+
+		i.status.RecipeFailed(se)
 		return "", errors.New(msg)
 	}
 

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -91,6 +91,8 @@ func (b *ScenarioBuilder) Basic() *RecipeInstaller {
 	re := execution.NewGoTaskRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
 	s := ux.NewPlainProgress()
+	mv := discovery.NewEmptyManifestValidator()
+	lkf := NewMockLicenseKeyFetcher()
 
 	i := RecipeInstaller{
 		discoverer:        d,

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -91,8 +91,6 @@ func (b *ScenarioBuilder) Basic() *RecipeInstaller {
 	re := execution.NewGoTaskRecipeExecutor()
 	p := ux.NewPromptUIPrompter()
 	s := ux.NewPlainProgress()
-	mv := discovery.NewEmptyManifestValidator()
-	lkf := NewMockLicenseKeyFetcher()
 
 	i := RecipeInstaller{
 		discoverer:        d,

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -12,6 +12,7 @@ var ErrInterrupt = errors.New("operation canceled")
 type GoTaskError interface {
 	error
 	Tasks() []string
+	SetError(msg string)
 }
 
 // GoTaskError represents a task failure reported by go-task.
@@ -22,6 +23,10 @@ type GoTaskGeneralError struct {
 
 func (e GoTaskGeneralError) Error() string {
 	return e.error.Error()
+}
+
+func (e GoTaskGeneralError) SetError(msg string) {
+	e.error = errors.New(msg)
 }
 
 func (e GoTaskGeneralError) Tasks() []string {
@@ -52,7 +57,7 @@ type ErrNonZeroExitCode struct {
 	additionalContext string
 }
 
-func NewNonZeroExitCode(originalError GoTaskGeneralError, additionalContext string) ErrNonZeroExitCode {
+func NewNonZeroExitCode(originalError GoTaskError, additionalContext string) ErrNonZeroExitCode {
 	return ErrNonZeroExitCode{
 		GoTaskError:       originalError,
 		additionalContext: additionalContext,
@@ -60,7 +65,11 @@ func NewNonZeroExitCode(originalError GoTaskGeneralError, additionalContext stri
 }
 
 func (e ErrNonZeroExitCode) Error() string {
-	return fmt.Sprintf("%s: %s", e.GoTaskError.Error(), e.additionalContext)
+	if e.additionalContext != "" {
+		return fmt.Sprintf("%s: %s", e.GoTaskError.Error(), e.additionalContext)
+	}
+
+	return e.GoTaskError.Error()
 }
 
 // nolint: golint

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -7,6 +7,21 @@ import (
 // ErrInterrupt represents a context cancellation.
 var ErrInterrupt = errors.New("operation canceled")
 
+// ErrNonZeroExitCode represents a non-zero exit code bieing returned from a child process.
+type ErrNonZeroExitCode struct {
+	err string
+}
+
+func NewNonZeroExitCode(err string) ErrNonZeroExitCode {
+	return ErrNonZeroExitCode{
+		err: err,
+	}
+}
+
+func (e ErrNonZeroExitCode) Error() string {
+	return e.err
+}
+
 // nolint: golint
 var ErrorFetchingLicenseKey = errors.New("Oops, we're having some difficulties fetching your license key. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic")
 var ErrorFetchingInsightsInsertKey = errors.New("error retrieving Insights insert key")

--- a/test/recipes/testError.yaml
+++ b/test/recipes/testError.yaml
@@ -1,0 +1,18 @@
+name: test-error
+displayName: Test error
+
+install:
+  version: '3'
+  silent: true
+
+  tasks:
+    default:
+      cmds:
+        - task: execute
+
+    execute:
+      label: 'Testing errors...'
+      cmds:
+        - |
+          echo -e "asdf" >&2
+          exit 123


### PR DESCRIPTION
This PR has a few effects:
1. Removes a bunch of the noise from go-task errors
2. Appends the final line of stderr to the go-task error so that it will appear in the final FATAL message presented to the user

### Testing
```
newrelic installTest -c test/recipes/testError.yaml
```

The `testError.yaml` file can be updated as desired to try various recipe invocation scenarios.


### Notes

1. Removing the "noise" in the error also loses some of the context about which sub-task in the recipe the error originated from. (e.g. `task: Failed to run task "default": task: Failed to run task "execute":`) Is this acceptable?
1. Errors will show up in the `FATAL` message if:
   1. The convention `echo -e "error message" >&2` is used directly in the recipe.  (`echo -e "eror message" > /dev/null` **will not** work since that routes output around our capture buffer and directly to the system level stderr file handler.  This new convention will likely require existing recipes to be updated to make use of the new feature.)
   1. A child process invoked by the recipe fails, *and* provides an error message as the last line of its stderr output.  This can sometimes be confusing if the error from the child process is split across multiple lines.  To demonstrate this, you can pass a malformed option to `jq` (I used `jq -asdf`) and watch what happens:


```
==> Installing test-error...
jq: Unknown option -asdf
Use jq --help for help with command-line options,
or see the jq manpage, or online docs  at https://stedolan.github.io/jq
==> Installing test-error...failed.

WARNING encountered an error while executing test-error: exit status 2: or see the jq manpage, or online docs  at https://stedolan.github.io/jq 
WARNING execution of Test error failed, please see the following link for clues on how to resolve the issue: https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/not-seeing-data/ 
  One or more installations failed.  Check the install log for more details: /Users/ctrombley/.newrelic/newrelic-cli.log
  New Relic installation complete!


FATAL test failed: encountered an error while executing test-error: exit status 2: or see the jq manpage, or online docs  at https://stedolan.github.io/jq 
```

I'm not sure what do do about this, but my thinking is that more information is better than none.  I am curious to know if the team feels that this caveat invalidates the approach.  Suggestions are invited.

