### PR TITLE
fix(install): use machine name for arm7

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,7 +26,7 @@ if [ "$(uname -m)" == "x86_64" ]; then
     MACHINE="x86_64"
 elif [ "$(uname)" == "aarch64" ]; then
     MACHINE="aarch64"
-elif [ "$(uname)" == "armv7l" ]; then
+elif [ "$(uname -m)" == "armv7l" ]; then
     MACHINE="armv7"
 else
     echo "This machine architecture is not supported. The supported architectures are x86_64, aarch64, armv7."


### PR DESCRIPTION
Need to use `uname -m` for arm7 on raspberry pi

![image](https://user-images.githubusercontent.com/6722433/117183572-b1417c00-ada5-11eb-9dd5-22b70ab13f5b.png)
