### PR TITLE
chore(install): provide redirect URL on nerdstorage doc for frontend to use

### DIFF
--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -14,27 +14,28 @@ import (
 
 // nolint: maligned
 type InstallStatus struct {
-	Complete            bool                    `json:"complete"`
-	DiscoveryManifest   types.DiscoveryManifest `json:"discoveryManifest"`
-	EntityGUIDs         []string                `json:"entityGuids"`
-	Error               StatusError             `json:"error"`
-	LogFilePath         string                  `json:"logFilePath"`
-	Statuses            []*RecipeStatus         `json:"recipes"`
-	Timestamp           int64                   `json:"timestamp"`
-	CLIVersion          string                  `json:"cliVersion"`
-	HasInstalledRecipes bool                    `json:"hasInstalledRecipes"`
-	HasCanceledRecipes  bool                    `json:"hasCanceledRecipes"`
-	HasSkippedRecipes   bool                    `json:"hasSkippedRecipes"`
-	HasFailedRecipes    bool                    `json:"hasFailedRecipes"`
-	RecipesSkipped      []*RecipeStatus         `json:"recipesSkipped"`
-	RecipesCanceled     []*RecipeStatus         `json:"recipesCanceled"`
-	RecipesFailed       []*RecipeStatus         `json:"recipesFailed"`
-	RecipesInstalled    []*RecipeStatus         `json:"recipesInstalled"`
-	RedirectURL         string                  `json:"redirectUrl"`
-	DocumentID          string
-	targetedInstall     bool
-	statusSubscriber    []StatusSubscriber
-	successLinkConfig   types.OpenInstallationSuccessLinkConfig
+	Complete             bool                    `json:"complete"`
+	DiscoveryManifest    types.DiscoveryManifest `json:"discoveryManifest"`
+	EntityGUIDs          []string                `json:"entityGuids"`
+	Error                StatusError             `json:"error"`
+	LogFilePath          string                  `json:"logFilePath"`
+	Statuses             []*RecipeStatus         `json:"recipes"`
+	Timestamp            int64                   `json:"timestamp"`
+	CLIVersion           string                  `json:"cliVersion"`
+	HasInstalledRecipes  bool                    `json:"hasInstalledRecipes"`
+	HasCanceledRecipes   bool                    `json:"hasCanceledRecipes"`
+	HasSkippedRecipes    bool                    `json:"hasSkippedRecipes"`
+	HasFailedRecipes     bool                    `json:"hasFailedRecipes"`
+	RecipesSkipped       []*RecipeStatus         `json:"recipesSkipped"`
+	RecipesCanceled      []*RecipeStatus         `json:"recipesCanceled"`
+	RecipesFailed        []*RecipeStatus         `json:"recipesFailed"`
+	RecipesInstalled     []*RecipeStatus         `json:"recipesInstalled"`
+	RedirectURL          string                  `json:"redirectUrl"`
+	DocumentID           string
+	targetedInstall      bool
+	statusSubscriber     []StatusSubscriber
+	successLinkConfig    types.OpenInstallationSuccessLinkConfig
+	successLinkGenerator SuccessLinkGenerator
 }
 
 type RecipeStatus struct {
@@ -72,12 +73,13 @@ type StatusError struct {
 	Details string `json:"details"`
 }
 
-func NewInstallStatus(reporters []StatusSubscriber) *InstallStatus {
+func NewInstallStatus(reporters []StatusSubscriber, successLinkGenerator SuccessLinkGenerator) *InstallStatus {
 	s := InstallStatus{
-		DocumentID:       uuid.New().String(),
-		Timestamp:        utils.GetTimestamp(),
-		LogFilePath:      config.DefaultConfigDirectory + "/" + config.DefaultLogFile,
-		statusSubscriber: reporters,
+		DocumentID:           uuid.New().String(),
+		Timestamp:            utils.GetTimestamp(),
+		LogFilePath:          config.DefaultConfigDirectory + "/" + config.DefaultLogFile,
+		statusSubscriber:     reporters,
+		successLinkGenerator: successLinkGenerator,
 	}
 
 	return &s
@@ -242,7 +244,7 @@ func (s *InstallStatus) HostEntityGUID() string {
 }
 
 func (s *InstallStatus) setRedirectURL() {
-	s.RedirectURL = generateSuccessURL(*s)
+	s.RedirectURL = s.successLinkGenerator.GenerateRedirectURL(*s)
 }
 
 func (s *InstallStatus) withAvailableRecipes(recipes []types.OpenInstallationRecipe) {

--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -30,6 +30,7 @@ type InstallStatus struct {
 	RecipesCanceled     []*RecipeStatus         `json:"recipesCanceled"`
 	RecipesFailed       []*RecipeStatus         `json:"recipesFailed"`
 	RecipesInstalled    []*RecipeStatus         `json:"recipesInstalled"`
+	RedirectURL         string                  `json:"redirectUrl"`
 	DocumentID          string
 	targetedInstall     bool
 	statusSubscriber    []StatusSubscriber
@@ -240,6 +241,10 @@ func (s *InstallStatus) HostEntityGUID() string {
 	return guid
 }
 
+func (s *InstallStatus) setRedirectURL() {
+	s.RedirectURL = generateSuccessURL(*s)
+}
+
 func (s *InstallStatus) withAvailableRecipes(recipes []types.OpenInstallationRecipe) {
 	for _, r := range recipes {
 		s.withAvailableRecipe(r)
@@ -350,6 +355,7 @@ func (s *InstallStatus) completed(err error) {
 	}).Debug("completed")
 
 	s.updateFinalInstallationStatuses(false)
+	s.setRedirectURL()
 }
 
 func (s *InstallStatus) canceled() {

--- a/internal/install/execution/install_status_test.go
+++ b/internal/install/execution/install_status_test.go
@@ -11,13 +11,15 @@ import (
 )
 
 func TestNewInstallStatus(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	require.NotEmpty(t, s.Timestamp)
 	require.NotEmpty(t, s.DocumentID)
 }
 
 func TestStatusWithAvailableRecipes_Basic(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := []types.OpenInstallationRecipe{{
 		Name: "testRecipe1",
 	}, {
@@ -34,7 +36,8 @@ func TestStatusWithAvailableRecipes_Basic(t *testing.T) {
 }
 
 func TestStatusWithRecipeEvent_Basic(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r}
 
@@ -48,7 +51,8 @@ func TestStatusWithRecipeEvent_Basic(t *testing.T) {
 }
 
 func TestStatusWithRecipeEvent_ErrorMessages(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{
 		Recipe: r,
@@ -67,7 +71,8 @@ func TestStatusWithRecipeEvent_ErrorMessages(t *testing.T) {
 }
 
 func TestExecutionStatusWithRecipeEvent_RecipeExists(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r}
 
@@ -89,7 +94,8 @@ func TestExecutionStatusWithRecipeEvent_RecipeExists(t *testing.T) {
 }
 
 func TestStatusWithRecipeEvent_EntityGUID(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
 
@@ -102,7 +108,8 @@ func TestStatusWithRecipeEvent_EntityGUID(t *testing.T) {
 }
 
 func TestStatusWithRecipeEvent_EntityGUIDExists(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	s.withEntityGUID("testGUID")
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
@@ -116,7 +123,8 @@ func TestStatusWithRecipeEvent_EntityGUIDExists(t *testing.T) {
 }
 
 func TestInstallStatus_statusUpdateMethods(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 	e := RecipeStatusEvent{Recipe: r, EntityGUID: "testGUID"}
 
@@ -154,7 +162,8 @@ func TestInstallStatus_statusUpdateMethods(t *testing.T) {
 }
 
 func TestInstallStatus_failAvailableOnComplete(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 
 	s.RecipesAvailable([]types.OpenInstallationRecipe{r})
@@ -164,7 +173,8 @@ func TestInstallStatus_failAvailableOnComplete(t *testing.T) {
 }
 
 func TestInstallStatus_cancelAvailable(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{}, slg)
 	r := types.OpenInstallationRecipe{Name: "testRecipe"}
 
 	s.RecipesAvailable([]types.OpenInstallationRecipe{r})
@@ -174,7 +184,8 @@ func TestInstallStatus_cancelAvailable(t *testing.T) {
 }
 
 func TestInstallStatus_multipleRecipeStatuses(t *testing.T) {
-	s := NewInstallStatus([]StatusSubscriber{NewMockStatusReporter()})
+	slg := NewConcreteSuccessLinkGenerator()
+	s := NewInstallStatus([]StatusSubscriber{NewMockStatusReporter()}, slg)
 	recipeInstalled := types.OpenInstallationRecipe{Name: "installed"}
 	installedRecipeEvent := RecipeStatusEvent{Recipe: recipeInstalled, EntityGUID: "installedGUID"}
 

--- a/internal/install/execution/mock_success_link_generator.go
+++ b/internal/install/execution/mock_success_link_generator.go
@@ -1,5 +1,7 @@
 package execution
 
+import "strings"
+
 type MockSuccessLinkGenerator struct {
 	GenerateExplorerLinkCallCount int
 	GenerateEntityLinkCallCount   int
@@ -19,4 +21,17 @@ func (g *MockSuccessLinkGenerator) GenerateExplorerLink(filter string) string {
 func (g *MockSuccessLinkGenerator) GenerateEntityLink(entityGUID string) string {
 	g.GenerateEntityLinkCallCount++
 	return g.GenerateEntityLinkVal
+}
+
+func (g *MockSuccessLinkGenerator) GenerateRedirectURL(status InstallStatus) string {
+	if status.hasAnyRecipeStatus(RecipeStatusTypes.INSTALLED) {
+		switch t := status.successLinkConfig.Type; {
+		case strings.EqualFold(string(t), "explorer"):
+			return g.GenerateExplorerLink(status.successLinkConfig.Filter)
+		default:
+			return g.GenerateEntityLink(status.HostEntityGUID())
+		}
+	}
+
+	return ""
 }

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -40,7 +40,7 @@ func TestReportRecipeSucceeded_Basic(t *testing.T) {
 	entityGUID := createEntity(t, a, c)
 
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	status := NewInstallStatus([]StatusSubscriber{r}, NewConcreteSuccessLinkGenerator())
 	status.withEntityGUID(entityGUID)
 
 	defer deleteUserStatusCollection(t, c.NerdStorage)
@@ -89,7 +89,7 @@ func TestReportRecipeSucceeded_UserScopeOnly(t *testing.T) {
 	entityGUID := createEntity(t, a, c)
 
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	status := NewInstallStatus([]StatusSubscriber{r}, NewConcreteSuccessLinkGenerator())
 
 	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -14,7 +14,8 @@ import (
 func TestRecipesAvailable_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus(nil)
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	recipes := []types.OpenInstallationRecipe{{}}
 
@@ -25,7 +26,8 @@ func TestRecipesAvailable_Basic(t *testing.T) {
 func TestRecipesAvailable_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
 
@@ -38,7 +40,8 @@ func TestRecipesAvailable_UserScopeError(t *testing.T) {
 func TestRecipeInstalled_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -51,7 +54,8 @@ func TestRecipeInstalled_Basic(t *testing.T) {
 func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	e := RecipeStatusEvent{}
 
 	err := r.RecipeInstalled(status, e)
@@ -63,7 +67,8 @@ func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	status.withEntityGUID("testGuid2")
 	e := RecipeStatusEvent{}
@@ -77,7 +82,8 @@ func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
 func TestRecipeInstalled_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -90,7 +96,8 @@ func TestRecipeInstalled_UserScopeError(t *testing.T) {
 func TestRecipeInstalled_EntityScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -103,7 +110,8 @@ func TestRecipeInstalled_EntityScopeError(t *testing.T) {
 func TestRecipeFailed_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -116,7 +124,8 @@ func TestRecipeFailed_Basic(t *testing.T) {
 func TestRecipeFailed_UserScopeOnly(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	e := RecipeStatusEvent{}
 
@@ -129,7 +138,8 @@ func TestRecipeFailed_UserScopeOnly(t *testing.T) {
 func TestRecipeFailed_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -142,7 +152,8 @@ func TestRecipeFailed_UserScopeError(t *testing.T) {
 func TestRecipeFailed_EntityScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 	status.withEntityGUID("testGuid")
 	e := RecipeStatusEvent{}
 
@@ -155,7 +166,8 @@ func TestRecipeFailed_EntityScopeError(t *testing.T) {
 func TestInstallComplete_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	err := r.InstallComplete(status)
 	require.NoError(t, err)
@@ -166,7 +178,8 @@ func TestInstallComplete_Basic(t *testing.T) {
 func TestInstallComplete_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
 
@@ -177,7 +190,8 @@ func TestInstallComplete_UserScopeError(t *testing.T) {
 func TestInstallCanceled_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	err := r.InstallCanceled(status)
 	require.NoError(t, err)
@@ -188,7 +202,8 @@ func TestInstallCanceled_Basic(t *testing.T) {
 func TestInstallCanceled_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
 
@@ -199,7 +214,8 @@ func TestInstallCanceled_UserScopeError(t *testing.T) {
 func TestDiscoveryComplete_Basic(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	err := r.DiscoveryComplete(status, types.DiscoveryManifest{})
 	require.NoError(t, err)
@@ -210,7 +226,8 @@ func TestDiscoveryComplete_Basic(t *testing.T) {
 func TestDiscoveryComplete_UserScopeError(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
-	status := NewInstallStatus([]StatusSubscriber{r})
+	slg := NewConcreteSuccessLinkGenerator()
+	status := NewInstallStatus([]StatusSubscriber{}, slg)
 
 	c.WriteDocumentWithUserScopeErr = errors.New("error")
 

--- a/internal/install/execution/success_link_generator.go
+++ b/internal/install/execution/success_link_generator.go
@@ -16,29 +16,67 @@ type SuccessLinkGenerator interface {
 
 type ConcreteSuccessLinkGenerator struct{}
 
+var nrPlatformHostnames = struct {
+	Staging string
+	US      string
+	EU      string
+}{
+	Staging: "staging-one.newrelic.com",
+	US:      "one.newrelic.com",
+	EU:      "one.eu.newrelic.com",
+}
+
 func NewConcreteSuccessLinkGenerator() *ConcreteSuccessLinkGenerator {
 	return &ConcreteSuccessLinkGenerator{}
 }
 
 func (g *ConcreteSuccessLinkGenerator) GenerateExplorerLink(filter string) string {
-	return fmt.Sprintf("https://%s/launcher/nr1-core.explorer?platform[filters]=%s&platform[accountId]=%d",
-		nrPlatformHostname(),
-		utils.Base64Encode(filter),
-		credentials.DefaultProfile().AccountID)
+	return generateExplorerLink(filter)
 }
 
 func (g *ConcreteSuccessLinkGenerator) GenerateEntityLink(entityGUID string) string {
+	return generateEntityLink(entityGUID)
+}
+
+func generateSuccessURL(status InstallStatus) string {
+	if status.hasAnyRecipeStatus(RecipeStatusTypes.INSTALLED) {
+		switch t := status.successLinkConfig.Type; {
+		case strings.EqualFold(string(t), "explorer"):
+			return generateExplorerLink(status.successLinkConfig.Filter)
+		default:
+			return generateEntityLink(status.HostEntityGUID())
+		}
+	}
+
+	return ""
+}
+
+func generateExplorerLink(filter string) string {
+	return fmt.Sprintf("https://%s/launcher/nr1-core.explorer?platform[filters]=%s&platform[accountId]=%d",
+		nrPlatformHostname(),
+		utils.Base64Encode(filter),
+		credentials.DefaultProfile().AccountID,
+	)
+}
+
+func generateEntityLink(entityGUID string) string {
 	return fmt.Sprintf("https://%s/redirect/entity/%s", nrPlatformHostname(), entityGUID)
 }
 
 // nrPlatformHostname returns the host for the platform based on the region set.
 func nrPlatformHostname() string {
-	switch defaultProfile := credentials.DefaultProfile(); {
-	case strings.EqualFold(defaultProfile.Region, region.Staging.String()):
-		return "staging-one.newrelic.com"
-	case strings.EqualFold(defaultProfile.Region, region.EU.String()):
-		return "one.eu.newrelic.com"
-	default:
-		return "one.newrelic.com"
+	defaultProfile := credentials.DefaultProfile()
+	if defaultProfile == nil {
+		return nrPlatformHostnames.US
 	}
+
+	if strings.EqualFold(defaultProfile.Region, region.Staging.String()) {
+		return nrPlatformHostnames.Staging
+	}
+
+	if strings.EqualFold(defaultProfile.Region, region.EU.String()) {
+		return nrPlatformHostnames.EU
+	}
+
+	return nrPlatformHostnames.US
 }

--- a/internal/install/execution/success_link_generator.go
+++ b/internal/install/execution/success_link_generator.go
@@ -12,6 +12,7 @@ import (
 type SuccessLinkGenerator interface {
 	GenerateExplorerLink(filter string) string
 	GenerateEntityLink(entityGUID string) string
+	GenerateRedirectURL(status InstallStatus) string
 }
 
 type ConcreteSuccessLinkGenerator struct{}
@@ -38,13 +39,17 @@ func (g *ConcreteSuccessLinkGenerator) GenerateEntityLink(entityGUID string) str
 	return generateEntityLink(entityGUID)
 }
 
-func generateSuccessURL(status InstallStatus) string {
+// GenerateRedirectURL creates a URL for the user to navigate to after running
+// through an installation. The URL is displayed in the CLI out as well and is
+// also provided in the nerdstorage document. This provides the user two options
+// to see their data - click from the CLI output or from the frontend.
+func (g *ConcreteSuccessLinkGenerator) GenerateRedirectURL(status InstallStatus) string {
 	if status.hasAnyRecipeStatus(RecipeStatusTypes.INSTALLED) {
 		switch t := status.successLinkConfig.Type; {
 		case strings.EqualFold(string(t), "explorer"):
-			return generateExplorerLink(status.successLinkConfig.Filter)
+			return g.GenerateExplorerLink(status.successLinkConfig.Filter)
 		default:
-			return generateEntityLink(status.HostEntityGUID())
+			return g.GenerateEntityLink(status.HostEntityGUID())
 		}
 	}
 

--- a/internal/install/execution/terminal_reporter_test.go
+++ b/internal/install/execution/terminal_reporter_test.go
@@ -18,9 +18,9 @@ func TestTerminalStatusReporter_interface(t *testing.T) {
 func Test_ShouldGenerateEntityLink(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
-
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 	recipeStatus := &RecipeStatus{
 		Status: RecipeStatusTypes.INSTALLED,
 	}
@@ -35,9 +35,10 @@ func Test_ShouldGenerateEntityLink(t *testing.T) {
 func Test_ShouldNotGenerateEntityLink(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
 
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 	recipeStatus := &RecipeStatus{
 		Status: RecipeStatusTypes.FAILED,
 	}
@@ -52,9 +53,10 @@ func Test_ShouldNotGenerateEntityLink(t *testing.T) {
 func Test_ShouldNotGenerateEntityLinkWhenNoRecipes(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
 
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 
 	err := r.InstallComplete(status)
 	require.NoError(t, err)
@@ -65,9 +67,10 @@ func Test_ShouldNotGenerateEntityLinkWhenNoRecipes(t *testing.T) {
 func Test_ShouldGenerateExplorerLink(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
 
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 	recipeStatus := &RecipeStatus{
 		Status: RecipeStatusTypes.INSTALLED,
 	}
@@ -86,9 +89,10 @@ func Test_ShouldGenerateExplorerLink(t *testing.T) {
 func Test_ShouldNotGenerateExplorerLink(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
 
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 	recipeStatus := &RecipeStatus{
 		Status: RecipeStatusTypes.FAILED,
 	}
@@ -107,9 +111,10 @@ func Test_ShouldNotGenerateExplorerLink(t *testing.T) {
 func Test_ShouldNotGenerateExplorerLinkWhenNoRecipes(t *testing.T) {
 	r := NewTerminalStatusReporter()
 	g := NewMockSuccessLinkGenerator()
-	r.successLinkGenerator = g
 
-	status := &InstallStatus{}
+	status := &InstallStatus{
+		successLinkGenerator: g,
+	}
 	status.successLinkConfig = types.OpenInstallationSuccessLinkConfig{
 		Type:   "explorer",
 		Filter: "\"`tags.language` = 'java'\"",

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -54,7 +54,8 @@ func NewRecipeInstaller(ic InstallerContext, nrClient *newrelic.NewRelic) *Recip
 		execution.NewTerminalStatusReporter(),
 	}
 	lkf := NewServiceLicenseKeyFetcher(&nrClient.NerdGraph)
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 
 	d := discovery.NewPSUtilDiscoverer(pf)
 	gff := discovery.NewGlobFileFilterer()

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -36,7 +36,7 @@ var (
 	v               = validation.NewMockRecipeValidator()
 	ff              = recipes.NewMockRecipeFileFetcher()
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status          = execution.NewInstallStatus(statusReporters)
+	status          = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	p               = ux.NewMockPrompter()
 	pi              = ux.NewMockProgressIndicator()
 	lkf             = NewMockLicenseKeyFetcher()
@@ -103,7 +103,7 @@ func TestInstall_DiscoveryComplete(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporter := execution.NewMockStatusReporter()
 	statusReporters = []execution.StatusSubscriber{statusReporter}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
@@ -126,7 +126,7 @@ func TestInstall_FailsOnInvalidOs(t *testing.T) {
 	mv = discovery.NewManifestValidator()
 	statusReporter := execution.NewMockStatusReporter()
 	statusReporters = []execution.StatusSubscriber{statusReporter}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
 		{
 			Name:           types.InfraAgentRecipeName,
@@ -144,7 +144,7 @@ func TestInstall_FailsOnInvalidOs(t *testing.T) {
 func TestInstall_RecipesAvailable(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
 		DisplayName:    testRecipeName,
@@ -172,7 +172,7 @@ func TestInstall_RecipesAvailable(t *testing.T) {
 func TestInstall_RecipeInstalled(t *testing.T) {
 	ic := InstallerContext{}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f2 := recipes.NewMockRecipeFetcher()
 	f2.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -216,7 +216,7 @@ func TestInstall_RecipeFailed(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -257,7 +257,7 @@ func TestInstall_InstallComplete(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -282,7 +282,7 @@ func TestInstall_InstallCanceled(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecipeErr = types.ErrInterrupt
 
@@ -300,7 +300,7 @@ func TestInstall_InstallCompleteError(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -334,7 +334,7 @@ func TestInstall_InstallCompleteError_guidedRecipeFail(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           "badRecipe",
@@ -370,7 +370,7 @@ func TestInstall_RecipeSkipped(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -407,7 +407,7 @@ func TestInstall_RecipeSkippedApm(t *testing.T) {
 		SkipApm: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -445,7 +445,7 @@ func TestInstall_RecipeSkippedApmAnyKeyword(t *testing.T) {
 		SkipApm: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -484,7 +484,7 @@ func TestInstall_RecipeSkipped_SkipAll(t *testing.T) {
 		SkipIntegrations:   true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           "test-recipe",
@@ -519,7 +519,7 @@ func TestInstall_RecipeSkipped_MultiSelect(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -556,7 +556,7 @@ func TestInstall_RecipeRecommended(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{
 		{
@@ -625,7 +625,7 @@ func TestInstall_RecipeSkipped_AssumeYes(t *testing.T) {
 	}
 
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,
@@ -662,7 +662,7 @@ func TestInstall_TargetedInstall_InstallsInfraAgent(t *testing.T) {
 		RecipeNames: []string{types.InfraAgentRecipeName},
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -687,7 +687,7 @@ func TestInstall_TargetedInstall_InstallsInfraAgentDependency(t *testing.T) {
 		RecipeNames: []string{"testRecipe"},
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -717,7 +717,7 @@ func TestInstall_TargetedInstallInfraAgent_NoInfraAgentDuplicate(t *testing.T) {
 		RecipeNames: []string{types.InfraAgentRecipeName},
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -743,7 +743,7 @@ func TestInstall_TargetedInstall_SkipInfra(t *testing.T) {
 		SkipInfra:   true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -769,7 +769,7 @@ func TestInstall_TargetedInstall_SkipInfraDependency(t *testing.T) {
 		SkipInfra:   true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{}
 	f.FetchRecipeVals = []types.OpenInstallationRecipe{
@@ -799,7 +799,7 @@ func TestInstall_GuidReport(t *testing.T) {
 		SkipLoggingInstall: true,
 	}
 	statusReporters = []execution.StatusSubscriber{execution.NewMockStatusReporter()}
-	status = execution.NewInstallStatus(statusReporters)
+	status = execution.NewInstallStatus(statusReporters, execution.NewConcreteSuccessLinkGenerator())
 	f = recipes.NewMockRecipeFetcher()
 	f.FetchRecommendationsVal = []types.OpenInstallationRecipe{{
 		Name:           testRecipeName,

--- a/internal/install/recipes/service_recipe_fetcher.go
+++ b/internal/install/recipes/service_recipe_fetcher.go
@@ -230,6 +230,7 @@ const (
 		dependencies
 		stability
 		repository
+		install
 		installTargets {
 			type
 			os

--- a/internal/install/scenario_builder.go
+++ b/internal/install/scenario_builder.go
@@ -93,7 +93,8 @@ func (b *ScenarioBuilder) Basic() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)
@@ -131,7 +132,8 @@ func (b *ScenarioBuilder) Fail() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)
@@ -169,7 +171,8 @@ func (b *ScenarioBuilder) LogMatches() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)
@@ -213,7 +216,8 @@ func (b *ScenarioBuilder) StitchedPath() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)
@@ -250,7 +254,8 @@ func (b *ScenarioBuilder) CanceledInstall() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)
@@ -289,7 +294,8 @@ func (b *ScenarioBuilder) DisplayExplorerLink() *RecipeInstaller {
 		execution.NewMockStatusReporter(),
 		execution.NewTerminalStatusReporter(),
 	}
-	statusRollup := execution.NewInstallStatus(ers)
+	slg := execution.NewConcreteSuccessLinkGenerator()
+	statusRollup := execution.NewInstallStatus(ers, slg)
 	c := validation.NewMockNRDBClient()
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 2)
 	v := validation.NewPollingRecipeValidator(c)


### PR DESCRIPTION
Currently we have very similar logic on the frontend as we do in the CLI. This PR ensures a backwards compatible way to provide a redirect URL for the frontend to use when generating the link used for "See Your Data" upon a successful installation.