### PR TITLE
(feat): validate CLI config

### DIFF
--- a/cmd/newrelic/command.go
+++ b/cmd/newrelic/command.go
@@ -177,11 +177,6 @@ func fetchLicenseKey(client *newrelic.NewRelic, accountID int) (string, error) {
 	return "", types.ErrorFetchingLicenseKey
 }
 
-type insightsKey struct {
-	ID  int    `json:"id"`
-	Key string `json:"key"`
-}
-
 func fetchInsightsInsertKey(client *newrelic.NewRelic, accountID int) (string, error) {
 	// Check for an existing key first
 	keys, err := client.APIAccess.ListInsightsInsertKeys(accountID)

--- a/cmd/newrelic/command_integration_test.go
+++ b/cmd/newrelic/command_integration_test.go
@@ -60,6 +60,8 @@ func TestInitializeProfile(t *testing.T) {
 	assert.Equal(t, apiKey, c.Profiles[defaultProfileName].APIKey)
 	assert.NotEmpty(t, c.Profiles[defaultProfileName].Region)
 	assert.NotEmpty(t, c.Profiles[defaultProfileName].AccountID)
+	assert.NotEmpty(t, c.Profiles[defaultProfileName].LicenseKey)
+	assert.NotEmpty(t, c.Profiles[defaultProfileName].InsightsInsertKey)
 
 	// Ensure that we don't Fatal out if the default profile already exists, but
 	// was not specified in the default-profile.json.

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/llorllale/go-gitlint v0.0.0-20200802191503-5984945d4b80
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/newrelic/newrelic-client-go v0.58.5
+	github.com/newrelic/newrelic-client-go v0.59.0
 	github.com/newrelic/tutone v0.6.1
 	github.com/pkg/errors v0.9.1
 	github.com/psampaz/go-mod-outdated v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -527,8 +527,8 @@ github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iP
 github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
-github.com/hashicorp/go-retryablehttp v0.6.8 h1:92lWxgpa+fF3FozM4B3UZtHZMJX8T5XT+TFdCxsPyWs=
-github.com/hashicorp/go-retryablehttp v0.6.8/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiwC1FZWkvQPQ4=
+github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -760,8 +760,8 @@ github.com/nakabonne/nestif v0.3.0/go.mod h1:dI314BppzXjJ4HsCnbo7XzrJHPszZsjnk5w
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
-github.com/newrelic/newrelic-client-go v0.58.5 h1:Bp9vzKjc/9nQXvO1q/cdRW6YppGhXAHh8GZrlevIrVM=
-github.com/newrelic/newrelic-client-go v0.58.5/go.mod h1:+wOK+2m1ClVuAqnpMAW7v924ryKW1eYylvkPJR0b3PA=
+github.com/newrelic/newrelic-client-go v0.59.0 h1:SQsZmVdE0elfioi3EoMCv0sNyKsZ4QnYOeoUfVzzkzA=
+github.com/newrelic/newrelic-client-go v0.59.0/go.mod h1:CIVFEfoZomM9/V1eowdwCv9TG6Eid5X587leQVIwCKo=
 github.com/newrelic/tutone v0.6.1 h1:hO3gumrOvTeIQjHHEB8J9oGloC0GHxbIAXU1FazSe6Q=
 github.com/newrelic/tutone v0.6.1/go.mod h1:dOSVZu/5kTucS3dxLIf6S5Ra3FPzBcT9NDBm4kfDGx0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/internal/diagnose/command_validate.go
+++ b/internal/diagnose/command_validate.go
@@ -26,10 +26,10 @@ data to the New Relic platform and verifying that it has been received.`,
 					log.Fatal("Failed to detect your system's hostname.  Please contact New Relic support.")
 				}
 				if err == ErrPostEvent {
-					log.Fatal("There was a failure posting data to New Relic.  This could be ")
+					log.Fatal("There was a failure posting data to New Relic.")
 				}
 				if err == ErrValidation {
-					log.Fatal("validation failed!")
+					log.Fatal("There was a failure locating the data that was posted to New Relic.")
 				}
 
 				log.Fatal(err)

--- a/internal/diagnose/command_validate.go
+++ b/internal/diagnose/command_validate.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 )
 
@@ -19,8 +20,18 @@ data to the New Relic platform and verifying that it has been received.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		client.WithClient(func(nrClient *newrelic.NewRelic) {
 			v := NewConfigValidator(nrClient)
-			err := v.ValidateConfig(cmd.Context())
+			err := v.ValidateConfig(utils.SignalCtx)
 			if err != nil {
+				if err == ErrDiscovery {
+					log.Fatal("Failed to detect your system's hostname.  Please contact New Relic support.")
+				}
+				if err == ErrPostEvent {
+					log.Fatal("There was a failure posting data to New Relic.  This could be ")
+				}
+				if err == ErrValidation {
+					log.Fatal("validation failed!")
+				}
+
 				log.Fatal(err)
 			}
 		})

--- a/internal/diagnose/command_validate.go
+++ b/internal/diagnose/command_validate.go
@@ -1,0 +1,32 @@
+package diagnose
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+var cmdValidate = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate your CLI configuration and connectivity",
+	Long: `Validate your CLI configuration and connectivity.
+
+Checks the configuration in the default or specified configuation profile by sending
+data to the New Relic platform and verifying that it has been received.`,
+	Example: "\tnewrelic diagnose validate",
+	Run: func(cmd *cobra.Command, args []string) {
+		client.WithClient(func(nrClient *newrelic.NewRelic) {
+			v := NewConfigValidator(nrClient)
+			err := v.ValidateConfig(cmd.Context())
+			if err != nil {
+				log.Fatal(err)
+			}
+		})
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdValidate)
+}

--- a/internal/diagnose/config_validator.go
+++ b/internal/diagnose/config_validator.go
@@ -9,10 +9,11 @@ import (
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/shirou/gopsutil/host"
+
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/utils/validation"
 	"github.com/newrelic/newrelic-client-go/newrelic"
-	"github.com/shirou/gopsutil/host"
 )
 
 const (

--- a/internal/diagnose/config_validator.go
+++ b/internal/diagnose/config_validator.go
@@ -1,0 +1,69 @@
+package diagnose
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/newrelic/newrelic-cli/internal/credentials"
+	"github.com/newrelic/newrelic-cli/internal/install/discovery"
+	"github.com/newrelic/newrelic-cli/internal/utils/validation"
+	"github.com/newrelic/newrelic-client-go/newrelic"
+)
+
+const (
+	validationEventType = "NrIntegrationError"
+)
+
+type ConfigValidator struct {
+	client *newrelic.NewRelic
+	*validation.PollingNRQLValidator
+	discovery.Discoverer
+}
+
+type ValidationTracerEvent struct {
+	EventType string `json:"eventType"`
+	Hostname  string `json:"hostname"`
+}
+
+func NewConfigValidator(client *newrelic.NewRelic) *ConfigValidator {
+	pf := discovery.NewNoOpProcessFilterer()
+
+	return &ConfigValidator{
+		client:               client,
+		PollingNRQLValidator: validation.NewPollingNRQLValidator(&client.Nrdb),
+		Discoverer:           discovery.NewPSUtilDiscoverer(pf),
+	}
+}
+
+func (c *ConfigValidator) ValidateConfig(ctx context.Context) error {
+	defaultProfile := credentials.DefaultProfile()
+	manifest, err := c.Discover(ctx)
+	if err != nil {
+		return err
+	}
+
+	evt := ValidationTracerEvent{
+		EventType: validationEventType,
+		Hostname:  manifest.Hostname,
+	}
+
+	log.Printf("Sending tracer event to New Relic.")
+
+	err = c.client.Events.CreateEvent(defaultProfile.AccountID, evt)
+	if err != nil {
+		return err
+	}
+
+	query := fmt.Sprintf(`
+	FROM %s
+	SELECT count(*)
+	WHERE hostname LIKE '%s%%'
+	SINCE 10 MINUTES AGO
+	`, validationEventType, manifest.Hostname)
+
+	_, err = c.Validate(ctx, query)
+
+	return err
+}

--- a/internal/install/discovery/noop_process_filterer.go
+++ b/internal/install/discovery/noop_process_filterer.go
@@ -1,0 +1,17 @@
+package discovery
+
+import (
+	"context"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
+)
+
+type NoOpProcessFilterer struct{}
+
+func NewNoOpProcessFilterer() *NoOpProcessFilterer {
+	return &NoOpProcessFilterer{}
+}
+
+func (f *NoOpProcessFilterer) filter(ctx context.Context, processes []types.GenericProcess, manifest types.DiscoveryManifest) ([]types.MatchedProcess, error) {
+	return []types.MatchedProcess{}, nil
+}

--- a/internal/install/execution/go_task_recipe_executor_test.go
+++ b/internal/install/execution/go_task_recipe_executor_test.go
@@ -14,9 +14,10 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/go-task/task/v3/taskfile"
+	"github.com/stretchr/testify/require"
+
 	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExecute_SystemVariableInterpolation(t *testing.T) {

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -232,7 +232,7 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 	var validationDurationMilliseconds int64
 	start := time.Now()
 	if r.ValidationNRQL != "" {
-		entityGUID, err = i.recipeValidator.Validate(ctx, *m, *r)
+		entityGUID, err = i.recipeValidator.ValidateRecipe(ctx, *m, *r)
 		if err != nil {
 			validationDurationMilliseconds = time.Since(start).Milliseconds()
 			msg := fmt.Sprintf("encountered an error while validating receipt of data for %s: %s", r.Name, err)

--- a/internal/install/recipes/recipe_file.go
+++ b/internal/install/recipes/recipe_file.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"gopkg.in/yaml.v2"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 type RecipeFileFetcherImpl struct {

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -9,3 +9,4 @@ var ErrInterrupt = errors.New("operation canceled")
 
 // nolint: golint
 var ErrorFetchingLicenseKey = errors.New("Oops, we're having some difficulties fetching your license key. Please try again later, or see our documentation for installing manually https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/install-configure/install-new-relic")
+var ErrorFetchingInsightsInsertKey = errors.New("error retrieving Insights insert key")

--- a/internal/install/validation/mock_recipe_validator.go
+++ b/internal/install/validation/mock_recipe_validator.go
@@ -20,15 +20,7 @@ func NewMockRecipeValidator() *MockRecipeValidator {
 	return &MockRecipeValidator{}
 }
 
-func (m *MockRecipeValidator) ValidateQuery(ctx context.Context, query string) (string, error) {
-	return m.validate(ctx)
-}
-
 func (m *MockRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
-	return m.validate(ctx)
-}
-
-func (m *MockRecipeValidator) validate(ctx context.Context) (string, error) {
 	m.ValidateCallCount++
 
 	var err error

--- a/internal/install/validation/mock_recipe_validator.go
+++ b/internal/install/validation/mock_recipe_validator.go
@@ -20,7 +20,15 @@ func NewMockRecipeValidator() *MockRecipeValidator {
 	return &MockRecipeValidator{}
 }
 
-func (m *MockRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
+func (m *MockRecipeValidator) ValidateQuery(ctx context.Context, query string) (string, error) {
+	return m.validate(ctx)
+}
+
+func (m *MockRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
+	return m.validate(ctx)
+}
+
+func (m *MockRecipeValidator) validate(ctx context.Context) (string, error) {
 	m.ValidateCallCount++
 
 	var err error

--- a/internal/install/validation/polling_recipe_validator.go
+++ b/internal/install/validation/polling_recipe_validator.go
@@ -3,127 +3,38 @@ package validation
 import (
 	"bytes"
 	"context"
-	"errors"
-	"fmt"
 	"html/template"
-	"time"
 
-	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
-	"github.com/newrelic/newrelic-cli/internal/install/ux"
-	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	utilsValidation "github.com/newrelic/newrelic-cli/internal/utils/validation"
 )
 
 type contextKey int
 
-const (
-	defaultMaxAttempts            = 60
-	defaultInterval               = 5 * time.Second
-	TestIdentifierKey  contextKey = iota
-)
-
 // PollingRecipeValidator is an implementation of the RecipeValidator interface
 // that polls NRDB to assert data is being reported for the given recipe.
 type PollingRecipeValidator struct {
-	maxAttempts       int
-	interval          time.Duration
-	client            nrdbClient
-	progressIndicator ux.ProgressIndicator
+	utilsValidation.PollingNRQLValidator
 }
 
 // NewPollingRecipeValidator returns a new instance of PollingRecipeValidator.
-func NewPollingRecipeValidator(c nrdbClient) *PollingRecipeValidator {
+func NewPollingRecipeValidator(c utils.NRDBClient) *PollingRecipeValidator {
 	v := PollingRecipeValidator{
-		maxAttempts:       defaultMaxAttempts,
-		interval:          defaultInterval,
-		client:            c,
-		progressIndicator: ux.NewSpinner(),
+		PollingNRQLValidator: *utilsValidation.NewPollingNRQLValidator(c),
 	}
 
 	return &v
 }
 
-// Validate polls NRDB to assert data is being reported for the given recipe.
-func (m *PollingRecipeValidator) Validate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
-	return m.waitForData(ctx, dm, r)
-}
-
-func (m *PollingRecipeValidator) waitForData(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
-	count := 0
-	ticker := time.NewTicker(m.interval)
-	defer ticker.Stop()
-
-	progressMsg := "Checking for data in New Relic (this may take a few minutes)..."
-	m.progressIndicator.Start(progressMsg)
-	defer m.progressIndicator.Stop()
-
-	for {
-		if count == m.maxAttempts {
-			m.progressIndicator.Fail("")
-			return "", fmt.Errorf("reached max validation attempts")
-		}
-
-		ok, entityGUID, err := m.tryValidate(ctx, dm, r)
-		if err != nil {
-			m.progressIndicator.Fail("")
-			return "", err
-		}
-
-		count++
-
-		if ok {
-			m.progressIndicator.Success("")
-			return entityGUID, nil
-		}
-
-		select {
-		case <-ticker.C:
-			continue
-
-		case <-ctx.Done():
-			m.progressIndicator.Fail("")
-			return "", fmt.Errorf("validation cancelled")
-		}
-	}
-}
-
-func (m *PollingRecipeValidator) tryValidate(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (bool, string, error) {
+// ValidateRecipe polls NRDB to assert data is being reported for the given recipe.
+func (m *PollingRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
 	query, err := substituteHostname(dm, r)
 	if err != nil {
-		return false, "", err
+		return "", err
 	}
 
-	results, err := m.executeQuery(ctx, query)
-	if err != nil {
-		return false, "", err
-	}
-
-	if len(results) == 0 {
-		return false, "", nil
-	}
-
-	// The query is assumed to use a count aggregate function
-	count := results[0]["count"].(float64)
-
-	if count > 0 {
-		// Try and parse an entity GUID from the results.  The query is assumed to
-		// optionally use a facet over entityGuid.  The standard case seems to be
-		// that all entities contain a facet of "entityGuid", and so if we find it
-		// here, we return it.
-		if entityGUID, ok := results[0]["entityGuid"]; ok {
-			return true, entityGUID.(string), nil
-		}
-
-		// In the logs integration, the facet doesn't contain "entityGuid", but
-		// does contain, "entity.guid", so here we check for that also.
-		if entityGUID, ok := results[0]["entity.guids"]; ok {
-			return true, entityGUID.(string), nil
-		}
-
-		return true, "", nil
-	}
-
-	return false, "", nil
+	return m.Validate(ctx, query)
 }
 
 func substituteHostname(dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
@@ -144,20 +55,4 @@ func substituteHostname(dm types.DiscoveryManifest, r types.OpenInstallationReci
 	}
 
 	return tpl.String(), nil
-}
-
-func (m *PollingRecipeValidator) executeQuery(ctx context.Context, query string) ([]nrdb.NRDBResult, error) {
-	profile := credentials.DefaultProfile()
-	if profile == nil || profile.AccountID == 0 {
-		return nil, errors.New("no account ID found in default profile")
-	}
-
-	nrql := nrdb.NRQL(query)
-
-	result, err := m.client.QueryWithContext(ctx, profile.AccountID, nrql)
-	if err != nil {
-		return nil, err
-	}
-
-	return result.Results, nil
 }

--- a/internal/install/validation/polling_recipe_validator_test.go
+++ b/internal/install/validation/polling_recipe_validator_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
 )
 
+const (
+	TestIdentifierKey contextKey = iota
+)
+
 var (
 	emptyResults = []nrdb.NRDBResult{
 		map[string]interface{}{
@@ -36,12 +40,12 @@ func TestValidate(t *testing.T) {
 
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
+	v.ProgressIndicator = pi
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
-	_, err := v.Validate(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r)
 
 	require.NoError(t, err)
 }
@@ -51,16 +55,16 @@ func TestValidate_PassAfterNAttempts(t *testing.T) {
 	c := NewMockNRDBClient()
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
-	v.maxAttempts = 5
-	v.interval = 10 * time.Millisecond
+	v.ProgressIndicator = pi
+	v.MaxAttempts = 5
+	v.Interval = 10 * time.Millisecond
 
 	c.ReturnResultsAfterNAttempts(emptyResults, nonEmptyResults, 5)
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
-	_, err := v.Validate(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r)
 
 	require.NoError(t, err)
 	require.Equal(t, 5, c.Attempts())
@@ -71,14 +75,14 @@ func TestValidate_FailAfterNAttempts(t *testing.T) {
 	c := NewMockNRDBClient()
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
-	v.maxAttempts = 3
-	v.interval = 10 * time.Millisecond
+	v.ProgressIndicator = pi
+	v.MaxAttempts = 3
+	v.Interval = 10 * time.Millisecond
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
-	_, err := v.Validate(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r)
 
 	require.Error(t, err)
 	require.Equal(t, 3, c.Attempts())
@@ -92,14 +96,14 @@ func TestValidate_FailAfterMaxAttempts(t *testing.T) {
 
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
-	v.maxAttempts = 1
-	v.interval = 10 * time.Millisecond
+	v.ProgressIndicator = pi
+	v.MaxAttempts = 1
+	v.Interval = 10 * time.Millisecond
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
-	_, err := v.Validate(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r)
 
 	require.Error(t, err)
 }
@@ -112,8 +116,8 @@ func TestValidate_FailIfContextDone(t *testing.T) {
 
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
-	v.interval = 1 * time.Second
+	v.ProgressIndicator = pi
+	v.Interval = 1 * time.Second
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
@@ -121,7 +125,7 @@ func TestValidate_FailIfContextDone(t *testing.T) {
 	ctx, cancel := context.WithCancel(getTestContext())
 	cancel()
 
-	_, err := v.Validate(ctx, m, r)
+	_, err := v.ValidateRecipe(ctx, m, r)
 
 	require.Error(t, err)
 }
@@ -134,12 +138,12 @@ func TestValidate_QueryError(t *testing.T) {
 
 	pi := ux.NewMockProgressIndicator()
 	v := NewPollingRecipeValidator(c)
-	v.progressIndicator = pi
+	v.ProgressIndicator = pi
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
 
-	_, err := v.Validate(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r)
 
 	require.EqualError(t, err, "test error")
 }

--- a/internal/install/validation/recipe_validator.go
+++ b/internal/install/validation/recipe_validator.go
@@ -8,5 +8,5 @@ import (
 
 // RecipeValidator validates installation of a recipe.
 type RecipeValidator interface {
-	Validate(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe) (entityGUID string, err error)
+	ValidateRecipe(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe) (entityGUID string, err error)
 }

--- a/internal/utils/nrdb_client.go
+++ b/internal/utils/nrdb_client.go
@@ -1,4 +1,4 @@
-package validation
+package utils
 
 import (
 	"context"
@@ -6,6 +6,6 @@ import (
 	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
 )
 
-type nrdbClient interface {
+type NRDBClient interface {
 	QueryWithContext(context.Context, int, nrdb.NRQL) (*nrdb.NRDBResultContainer, error)
 }

--- a/internal/utils/validation/polling_nrql_validator.go
+++ b/internal/utils/validation/polling_nrql_validator.go
@@ -1,0 +1,132 @@
+package validation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/newrelic/newrelic-cli/internal/credentials"
+	"github.com/newrelic/newrelic-cli/internal/install/ux"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/pkg/nrdb"
+)
+
+const (
+	defaultMaxAttempts = 60
+	defaultInterval    = 5 * time.Second
+)
+
+// PollingNRQLValidator polls NRDB to assert data is being reported for the given query.
+type PollingNRQLValidator struct {
+	MaxAttempts       int
+	Interval          time.Duration
+	ProgressIndicator ux.ProgressIndicator
+	client            utils.NRDBClient
+}
+
+// NewPollingNRQLValidator returns a new instance of PollingNRQLValidator.
+func NewPollingNRQLValidator(c utils.NRDBClient) *PollingNRQLValidator {
+	v := PollingNRQLValidator{
+		client:            c,
+		MaxAttempts:       defaultMaxAttempts,
+		Interval:          defaultInterval,
+		ProgressIndicator: ux.NewSpinner(),
+	}
+
+	return &v
+}
+
+// Validate polls NRDB to assert data is being reported for the given query.
+func (m *PollingNRQLValidator) Validate(ctx context.Context, query string) (string, error) {
+	return m.waitForData(ctx, query)
+}
+
+func (m *PollingNRQLValidator) waitForData(ctx context.Context, query string) (string, error) {
+	count := 0
+	ticker := time.NewTicker(m.Interval)
+	defer ticker.Stop()
+
+	progressMsg := "Checking for data in New Relic (this may take a few minutes)..."
+	m.ProgressIndicator.Start(progressMsg)
+	defer m.ProgressIndicator.Stop()
+
+	for {
+		if count == m.MaxAttempts {
+			m.ProgressIndicator.Fail("")
+			return "", fmt.Errorf("reached max validation attempts")
+		}
+
+		ok, entityGUID, err := m.tryValidate(ctx, query)
+		if err != nil {
+			m.ProgressIndicator.Fail("")
+			return "", err
+		}
+
+		count++
+
+		if ok {
+			m.ProgressIndicator.Success("")
+			return entityGUID, nil
+		}
+
+		select {
+		case <-ticker.C:
+			continue
+
+		case <-ctx.Done():
+			m.ProgressIndicator.Fail("")
+			return "", fmt.Errorf("validation cancelled")
+		}
+	}
+}
+
+func (m *PollingNRQLValidator) tryValidate(ctx context.Context, query string) (bool, string, error) {
+	results, err := m.executeQuery(ctx, query)
+	if err != nil {
+		return false, "", err
+	}
+
+	if len(results) == 0 {
+		return false, "", nil
+	}
+
+	// The query is assumed to use a count aggregate function
+	count := results[0]["count"].(float64)
+
+	if count > 0 {
+		// Try and parse an entity GUID from the results.  The query is assumed to
+		// optionally use a facet over entityGuid.  The standard case seems to be
+		// that all entities contain a facet of "entityGuid", and so if we find it
+		// here, we return it.
+		if entityGUID, ok := results[0]["entityGuid"]; ok {
+			return true, entityGUID.(string), nil
+		}
+
+		// In the logs integration, the facet doesn't contain "entityGuid", but
+		// does contain, "entity.guid", so here we check for that also.
+		if entityGUID, ok := results[0]["entity.guids"]; ok {
+			return true, entityGUID.(string), nil
+		}
+
+		return true, "", nil
+	}
+
+	return false, "", nil
+}
+
+func (m *PollingNRQLValidator) executeQuery(ctx context.Context, query string) ([]nrdb.NRDBResult, error) {
+	profile := credentials.DefaultProfile()
+	if profile == nil || profile.AccountID == 0 {
+		return nil, errors.New("no account ID found in default profile")
+	}
+
+	nrql := nrdb.NRQL(query)
+
+	result, err := m.client.QueryWithContext(ctx, profile.AccountID, nrql)
+	if err != nil {
+		return nil, err
+	}
+
+	return result.Results, nil
+}


### PR DESCRIPTION
Depends on newrelic/newrelic-client-go#724.

### Testing
Run cold start command from a fresh VM without the CLI installed.  Once it is finished:

```
sudo newrelic profile list --show-keys
```

You should see that the Insights insert key should have been retrieved and populated when the profile was created.  

Then,

```
sudo newrelic diagnose validate
```

The validation process will kick off and report success once it finds the event.  To locate the diagnostic event manually, run the following query:

```
SELECT * FROM NrIntegrationError WHERE purpose = 'New Relic CLI configuration validation'
```

### To do (future PRs)

- Improve success and error messages
- Improve `profile add` command to make use of the key location functionality