### PR TITLE
feat(install): Add account scoped nerd storage write

### DIFF
--- a/internal/install/execution/mock_nerdstorage_client.go
+++ b/internal/install/execution/mock_nerdstorage_client.go
@@ -3,12 +3,15 @@ package execution
 import "github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
 
 type MockNerdStorageClient struct {
-	WriteDocumentWithUserScopeVal         interface{}
-	WriteDocumentWithEntityScopeVal       interface{}
-	WriteDocumentWithUserScopeErr         error
-	WriteDocumentWithEntityScopeErr       error
-	writeDocumentWithUserScopeCallCount   int
-	writeDocumentWithEntityScopeCallCount int
+	WriteDocumentWithUserScopeVal          interface{}
+	WriteDocumentWithEntityScopeVal        interface{}
+	WriteDocumentWithAccountScopeVal       interface{}
+	WriteDocumentWithUserScopeErr          error
+	WriteDocumentWithEntityScopeErr        error
+	WriteDocumentWithAccountScopeErr       error
+	writeDocumentWithUserScopeCallCount    int
+	writeDocumentWithEntityScopeCallCount  int
+	writeDocumentWithAccountScopeCallCount int
 }
 
 func NewMockNerdStorageClient() *MockNerdStorageClient {
@@ -28,4 +31,9 @@ func (c *MockNerdStorageClient) WriteDocumentWithUserScope(nerdstorage.WriteDocu
 func (c *MockNerdStorageClient) WriteDocumentWithEntityScope(string, nerdstorage.WriteDocumentInput) (interface{}, error) {
 	c.writeDocumentWithEntityScopeCallCount++
 	return c.WriteDocumentWithEntityScopeVal, c.WriteDocumentWithEntityScopeErr
+}
+
+func (c *MockNerdStorageClient) WriteDocumentWithAccountScope(int, nerdstorage.WriteDocumentInput) (interface{}, error) {
+	c.writeDocumentWithAccountScopeCallCount++
+	return c.WriteDocumentWithAccountScopeVal, c.WriteDocumentWithAccountScopeErr
 }

--- a/internal/install/execution/nerdstorage_client.go
+++ b/internal/install/execution/nerdstorage_client.go
@@ -7,4 +7,5 @@ import (
 type NerdStorageClient interface {
 	WriteDocumentWithUserScope(nerdstorage.WriteDocumentInput) (interface{}, error)
 	WriteDocumentWithEntityScope(string, nerdstorage.WriteDocumentInput) (interface{}, error)
+	WriteDocumentWithAccountScope(int, nerdstorage.WriteDocumentInput) (interface{}, error)
 }

--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -3,6 +3,7 @@ package execution
 import (
 	log "github.com/sirupsen/logrus"
 
+	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
 )
@@ -13,7 +14,7 @@ const (
 )
 
 // NerdstorageStatusReporter is an implementation of the ExecutionStatusReporter
-// interface that reports esecution status into NerdStorage.
+// interface that reports execution status into NerdStorage.
 type NerdstorageStatusReporter struct {
 	client NerdStorageClient
 }
@@ -87,7 +88,7 @@ func (r NerdstorageStatusReporter) writeStatus(status *InstallStatus) error {
 	}
 
 	for _, g := range status.EntityGUIDs {
-		_, err := r.client.WriteDocumentWithEntityScope(g, i)
+		_, err = r.client.WriteDocumentWithEntityScope(g, i)
 		if err != nil {
 			return err
 		}
@@ -95,6 +96,12 @@ func (r NerdstorageStatusReporter) writeStatus(status *InstallStatus) error {
 
 	if len(status.EntityGUIDs) == 0 {
 		log.Debug("no entity GUIDs available, skipping entity-scoped status updates")
+	}
+
+	defaultProfile := credentials.DefaultProfile()
+	_, err = r.client.WriteDocumentWithAccountScope(defaultProfile.AccountID, i)
+	if err != nil {
+		log.Debug("failed to write to account scoped nerd storage")
 	}
 
 	return nil

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -46,6 +46,7 @@ func TestReportRecipeSucceeded_Basic(t *testing.T) {
 	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
+	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -94,6 +95,7 @@ func TestReportRecipeSucceeded_UserScopeOnly(t *testing.T) {
 	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
+	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -128,6 +130,16 @@ func getEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStor
 	}
 
 	return c.GetCollectionWithEntityScope(guid, getCollectionInput)
+}
+
+func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.NerdStorage) {
+	di := nerdstorage.DeleteCollectionInput{
+		Collection: collectionID,
+		PackageID:  packageID,
+	}
+	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -49,6 +49,7 @@ func TestRecipeInstalled_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 1, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
@@ -62,6 +63,7 @@ func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
@@ -77,6 +79,7 @@ func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 2, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeInstalled_UserScopeError(t *testing.T) {
@@ -119,6 +122,7 @@ func TestRecipeFailed_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 1, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeFailed_UserScopeOnly(t *testing.T) {
@@ -133,6 +137,7 @@ func TestRecipeFailed_UserScopeOnly(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeFailed_UserScopeError(t *testing.T) {
@@ -173,6 +178,7 @@ func TestInstallComplete_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestInstallComplete_UserScopeError(t *testing.T) {
@@ -197,6 +203,7 @@ func TestInstallCanceled_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestInstallCanceled_UserScopeError(t *testing.T) {
@@ -221,6 +228,7 @@ func TestDiscoveryComplete_Basic(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestDiscoveryComplete_UserScopeError(t *testing.T) {

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/newrelic/newrelic-cli/internal/credentials"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 func TestRecipesAvailable_Basic(t *testing.T) {
+	credentials.SetDefaultProfile(credentials.Profile{AccountID: 12345})
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewConcreteSuccessLinkGenerator()


### PR DESCRIPTION
The PLG team is doing some work around recommendations. Our team is working on a feature that would display all recommendations for a specific user. 

Problem we would like to solve:
The way the recommendations are currently stored will make getting the recommendations extremely costly. Our team would need to loop through every account the user has access to then every entity for every account and check for documents in Nerd Store. 

Proposed Solution:
We would like to store the same documents in account scoped nerdstore. This solution allows us to then get all accounts the user has access to and go right to Nerd Store to check for documents. 

There are some limitations to this solution. We understand that we may run into nerd store limits but based on the total number of these documents currently stored in production (~57k) we think this solution will be sufficient for now. Eventually, we would like to implement something more robust. 