### PR TITLE
fix(install): fix task path field name and support nested tasks

### DIFF
--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -69,9 +69,9 @@ var RecipeStatusTypes = struct {
 }
 
 type StatusError struct {
-	Message string   `json:"message"`
-	Details string   `json:"details"`
-	Tasks   []string `json:"tasks"`
+	Message  string   `json:"message"`
+	Details  string   `json:"details"`
+	TaskPath []string `json:"taskPath"`
 }
 
 func NewInstallStatus(reporters []StatusSubscriber, successLinkGenerator SuccessLinkGenerator) *InstallStatus {
@@ -295,8 +295,8 @@ func (s *InstallStatus) withRecipeEvent(e RecipeStatusEvent, rs RecipeStatusType
 	s.withSuccessLinkConfig(e.Recipe.SuccessLinkConfig)
 
 	statusError := StatusError{
-		Message: e.Msg,
-		Tasks:   e.Tasks,
+		Message:  e.Msg,
+		TaskPath: e.TaskPath,
 	}
 
 	s.Error = statusError
@@ -305,7 +305,7 @@ func (s *InstallStatus) withRecipeEvent(e RecipeStatusEvent, rs RecipeStatusType
 		"recipe_name":                    e.Recipe.Name,
 		"status":                         rs,
 		"error":                          statusError.Message,
-		"tasks":                          statusError.Tasks,
+		"tasks":                          statusError.TaskPath,
 		"guid":                           e.EntityGUID,
 		"validationDurationMilliseconds": e.ValidationDurationMilliseconds,
 	}).Debug("recipe event")
@@ -354,7 +354,7 @@ func (s *InstallStatus) completed(err error) {
 		}
 
 		if e, ok := err.(types.GoTaskError); ok {
-			statusError.Tasks = e.Tasks()
+			statusError.TaskPath = e.TaskPath()
 		}
 
 		s.Error = statusError

--- a/internal/install/execution/status_subscriber.go
+++ b/internal/install/execution/status_subscriber.go
@@ -21,7 +21,7 @@ type StatusSubscriber interface {
 type RecipeStatusEvent struct {
 	Recipe                         types.OpenInstallationRecipe
 	Msg                            string
-	Tasks                          []string
+	TaskPath                       []string
 	EntityGUID                     string
 	ValidationDurationMilliseconds int64
 }

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -238,7 +238,7 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 
 		if e, ok := err.(types.GoTaskError); ok {
 			e.SetError(msg)
-			se.Tasks = e.Tasks()
+			se.TaskPath = e.TaskPath()
 		} else {
 			err = errors.New(msg)
 		}

--- a/internal/install/types/discovery_manifest_test.go
+++ b/internal/install/types/discovery_manifest_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 package types
 
 import (

--- a/internal/install/types/errors_test.go
+++ b/internal/install/types/errors_test.go
@@ -1,0 +1,33 @@
+// +build unit
+
+package types
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGoTaskGeneralError(t *testing.T) {
+	err := errors.New(`some error`)
+	e := NewGoTaskGeneralError(err)
+	require.Equal(t, []string{}, e.TaskPath())
+	require.Equal(t, e.Error(), "some error")
+
+	err = errors.New(`task: Failed to run task "default": some error`)
+	e = NewGoTaskGeneralError(err)
+	require.Equal(t, []string{"default"}, e.TaskPath())
+	require.Equal(t, e.Error(), "some error")
+
+	err = errors.New(`task: Failed to run task "default": task: Failed to run task "subTask": some error`)
+	e = NewGoTaskGeneralError(err)
+	require.Equal(t, []string{"default", "subTask"}, e.TaskPath())
+	require.Equal(t, e.Error(), "some error")
+
+	err = errors.New(`task: Failed to run task "default": task: Failed to run task "subTask": task: Failed to run task "nestedSubTask": some error`)
+	e = NewGoTaskGeneralError(err)
+	require.Equal(t, []string{"default", "subTask", "nestedSubTask"}, e.TaskPath())
+	require.Equal(t, e.Error(), "some error")
+
+}


### PR DESCRIPTION
### Testing:
Run a guided install with this code & force an error.  (I've done this by using the `-c` option against a recipe that isn't compatible with the platform I'm on).  Look in Tessen for the error event and check that the `error_task_path` attribute contains the task the error occurred in:

```
FROM TessenAction SELECT error_task_path where email = 'your_email@newrelic.com' and category = 'GuidedInstall' and error_message is NOT NULL
```