### PR TITLE
fix(install): UnmarshalYAML toStringByFieldName() should handle multiple types when converting interface 

### DIFF
--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v2"
@@ -284,11 +285,20 @@ func toBoolByFieldName(fieldName string, data map[string]interface{}) bool {
 }
 
 func toStringByFieldName(fieldName string, data map[string]interface{}) string {
-	if v, ok := data[fieldName]; ok {
-		return v.(string)
+	out := ""
+	if in, ok := data[fieldName]; ok {
+		switch v := in.(type) {
+		case int:
+			return strconv.Itoa(v)
+		case string:
+			return v
+		case bool:
+			return strconv.FormatBool(v)
+		}
+		return out
 	}
 
-	return ""
+	return out
 }
 
 func expandInstalllMapToString(recipeIn map[string]interface{}) (string, error) {

--- a/internal/install/types/recipe_test.go
+++ b/internal/install/types/recipe_test.go
@@ -1,0 +1,26 @@
+// +build unit
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToStringByFieldName(t *testing.T) {
+	data := map[string]interface{}{
+		"intField":    9600, // e.g. the port used for a db connection URL
+		"stringField": "stringValue",
+		"boolField":   false,
+	}
+
+	intAsString := toStringByFieldName("intField", data)
+	require.Equal(t, "9600", intAsString)
+
+	stringAsString := toStringByFieldName("stringField", data)
+	require.Equal(t, "stringValue", stringAsString)
+
+	boolAsString := toStringByFieldName("boolField", data)
+	require.Equal(t, "false", boolAsString)
+}


### PR DESCRIPTION
This PR updates the `OpenInstallationRecipe` custom `UnmarshalYAML()` method to handle converting multiple types to a string.

I ran into panic errors when unmarshaling the elasticsearch recipe via `--recipePath` because the input variables of the port and SSL checks are `int` and `bool` respectively. The `toStringByFieldName()` helper function needed to be updated to handle these scenarios and others like it. 