### PR TITLE
Correctly detect aarch64

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$(uname -m)" == "x86_64" ]; then
     MACHINE="x86_64"
-elif [ "$(uname)" == "aarch64" ]; then
+elif [ "$(uname -m)" == "aarch64" ]; then
     MACHINE="aarch64"
 elif [ "$(uname -m)" == "armv7l" ]; then
     MACHINE="armv7"


### PR DESCRIPTION
The installation on aarch64 did not work, because the detection logic was missing a parameter.
Added the -m to uname to correctly get the machine architecture