### PR TITLE
Update install.sh to work on ARM64

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,8 +24,8 @@ fi
 
 if [ "$(uname -m)" == "x86_64" ]; then
     MACHINE="x86_64"
-elif [ "$(uname)" == "aarch64" ]; then
-    MACHINE="aarch64"
+elif [ "$(uname -m)" == "aarch64" ]; then
+    MACHINE="arm64"
 elif [ "$(uname -m)" == "armv7l" ]; then
     MACHINE="armv7"
 else


### PR DESCRIPTION
The installation on aarch64 did not work because uname was missing the -m parameter.
Also the release artifact for ARM64 is called arm64 and not aarch64.

I corrected both and tested it on a Ubuntu 20.04 installation on a Raspberry Pi 4B.