### PR TITLE
chore: update client to v0.60.1, add context to config validation

### DIFF
--- a/cmd/newrelic/command_integration_test.go
+++ b/cmd/newrelic/command_integration_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -38,7 +39,7 @@ func TestInitializeProfile(t *testing.T) {
 	// Init without the necessary environment variables
 	os.Setenv("NEW_RELIC_API_KEY", "")
 	os.Setenv("NEW_RELIC_ACCOUNT_ID", "")
-	initializeProfile()
+	initializeProfile(context.Background())
 
 	// Load credentials from disk
 	c, err := credentials.LoadCredentials(f)
@@ -50,7 +51,7 @@ func TestInitializeProfile(t *testing.T) {
 	// Init with environment
 	os.Setenv("NEW_RELIC_API_KEY", apiKey)
 	os.Setenv("NEW_RELIC_ACCOUNT_ID", envAccountID)
-	initializeProfile()
+	initializeProfile(context.Background())
 
 	// Initialize the new configuration directory
 	c, err = credentials.LoadCredentials(f)
@@ -70,7 +71,7 @@ func TestInitializeProfile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	initializeProfile()
+	initializeProfile(context.Background())
 }
 
 func TestFetchLicenseKey_missingKey(t *testing.T) {
@@ -87,7 +88,7 @@ func TestFetchLicenseKey_missingKey(t *testing.T) {
 		NerdGraph: nerdgraph.New(tc),
 	}
 
-	response, err := fetchLicenseKey(nr, 0)
+	response, err := fetchLicenseKey(context.Background(), nr, 0)
 	require.Error(t, err, types.ErrorFetchingLicenseKey)
 	require.Empty(t, response)
 }
@@ -106,7 +107,7 @@ func TestFetchLicenseKey_nilKey(t *testing.T) {
 		NerdGraph: nerdgraph.New(tc),
 	}
 
-	response, err := fetchLicenseKey(nr, 0)
+	response, err := fetchLicenseKey(context.Background(), nr, 0)
 	require.Error(t, err, types.ErrorFetchingLicenseKey)
 	require.Empty(t, response)
 }
@@ -124,7 +125,7 @@ func TestFetchLicenseKey_withKey(t *testing.T) {
 		NerdGraph: nerdgraph.New(tc),
 	}
 
-	response, err := fetchLicenseKey(nr, 0)
+	response, err := fetchLicenseKey(context.Background(), nr, 0)
 	require.NoError(t, err)
 	require.Equal(t, "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", response)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/llorllale/go-gitlint v0.0.0-20210608233938-d6303cc52cc5
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.4.1
-	github.com/newrelic/newrelic-client-go v0.60.0
+	github.com/newrelic/newrelic-client-go v0.60.1
 	github.com/newrelic/tutone v0.6.1
 	github.com/pkg/errors v0.9.1
 	github.com/psampaz/go-mod-outdated v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -768,8 +768,8 @@ github.com/nakabonne/nestif v0.3.0/go.mod h1:dI314BppzXjJ4HsCnbo7XzrJHPszZsjnk5w
 github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
-github.com/newrelic/newrelic-client-go v0.60.0 h1:kXE5+dAD30zhOQu8YKb0sseP0Ro6o6JQrlw2pM1WUdY=
-github.com/newrelic/newrelic-client-go v0.60.0/go.mod h1:ejGD81//o2UqWdaRl7bPrVpCgWuAL9YdcBsbpkNNYjI=
+github.com/newrelic/newrelic-client-go v0.60.1 h1:pghyELDn5PLRQdu4RUNXKGlagG1RSRxQbo7Mz3Jd6aQ=
+github.com/newrelic/newrelic-client-go v0.60.1/go.mod h1:ejGD81//o2UqWdaRl7bPrVpCgWuAL9YdcBsbpkNNYjI=
 github.com/newrelic/tutone v0.6.1 h1:hO3gumrOvTeIQjHHEB8J9oGloC0GHxbIAXU1FazSe6Q=
 github.com/newrelic/tutone v0.6.1/go.mod h1:dOSVZu/5kTucS3dxLIf6S5Ra3FPzBcT9NDBm4kfDGx0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-client-go/newrelic"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
+	"github.com/newrelic/newrelic-client-go/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
 	"github.com/newrelic/newrelic-client-go/pkg/workloads"
 )
@@ -162,16 +163,16 @@ func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdS
 }
 
 func createEntity(t *testing.T, accountID int, c *newrelic.NewRelic) string {
-	i := workloads.CreateInput{
+	i := workloads.WorkloadCreateInput{
 		Name: "testEntity",
 	}
-	e, err := c.Workloads.CreateWorkload(accountID, i)
+	e, err := c.Workloads.WorkloadCreate(accountID, i)
 	require.NoError(t, err)
 
-	return e.GUID
+	return string(e.GUID)
 }
 
 func deleteEntity(t *testing.T, guid string, c *newrelic.NewRelic) {
-	_, err := c.Workloads.DeleteWorkload(guid)
+	_, err := c.Workloads.WorkloadDelete(entities.EntityGUID(guid))
 	require.NoError(t, err)
 }

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -143,7 +143,7 @@ func (i *RecipeInstaller) Install() error {
 	var err error
 
 	// log.Printf("Validating connectivity to the New Relic platform...")
-	// if err = i.configValidator.Validate(ctx); err != nil {
+	// if err = i.configValidator.Validate(utils.SignalCtx); err != nil {
 	// 	return err
 	// }
 
@@ -156,7 +156,7 @@ func (i *RecipeInstaller) Install() error {
 		i.status.InstallCanceled()
 		return nil
 	case err = <-errChan:
-		if err == types.ErrInterrupt {
+		if errors.Is(err, types.ErrInterrupt) {
 			i.status.InstallCanceled()
 			return err
 		}

--- a/internal/utils/retry_test.go
+++ b/internal/utils/retry_test.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -18,7 +19,7 @@ func TestShouldRetryAndPass(t *testing.T) {
 		CallsBeforeSuccess: 3,
 	}
 	r := NewRetry(3, 0, m.testErrorUntilFunc)
-	err := r.ExecWithRetries()
+	err := r.ExecWithRetries(context.Background())
 	require.Equal(t, 3, m.CallCount)
 	require.NoError(t, err)
 }
@@ -26,7 +27,7 @@ func TestShouldRetryAndPass(t *testing.T) {
 func TestShouldRetryAndFail(t *testing.T) {
 	m := MockFunc{}
 	r := NewRetry(3, 0, m.testErrorFunc)
-	err := r.ExecWithRetries()
+	err := r.ExecWithRetries(context.Background())
 	require.Equal(t, 3, m.CallCount)
 	require.Equal(t, err.Error(), errorAfterAllRetry)
 }
@@ -36,7 +37,7 @@ func TestShouldNotRetry(t *testing.T) {
 		CallsBeforeSuccess: 3,
 	}
 	r := NewRetry(3, 0, m.testOkFunc)
-	err := r.ExecWithRetries()
+	err := r.ExecWithRetries(context.Background())
 	require.Equal(t, 1, m.CallCount)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
- update `newrelic-client-go` to v0.60.1, including generated `workload` types
- make `utils.Retry` context-aware
- use context-aware methods during config initialization, config validation, and a few other locations