### PR TITLE
fix: remove region from staging/testing urls

### DIFF
--- a/internal/install/execution/recipe_var_provider.go
+++ b/internal/install/execution/recipe_var_provider.go
@@ -19,7 +19,7 @@ import (
 var (
 	downloadURLAccessListRegex []string = []string{
 		`(.)?download\.newrelic\.com$`,
-		`nr-downloads-ohai-(staging|testing)\.s3-website-us-east-1\.amazonaws\.com$`,
+		`nr-downloads-ohai-(staging|testing)\.s3\.amazonaws\.com$`,
 	}
 )
 

--- a/internal/install/execution/recipe_var_provider_test.go
+++ b/internal/install/execution/recipe_var_provider_test.go
@@ -224,11 +224,11 @@ func TestRecipeVarProvider_AllowInfraStaging(t *testing.T) {
 	}
 
 	// Test for NEW_RELIC_DOWNLOAD_URL
-	os.Setenv("NEW_RELIC_DOWNLOAD_URL", "https://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/")
+	os.Setenv("NEW_RELIC_DOWNLOAD_URL", "https://nr-downloads-ohai-staging.s3.amazonaws.com/")
 
 	v, err := e.Prepare(m, r, false, licenseKey)
 	require.NoError(t, err)
-	require.Contains(t, "https://nr-downloads-ohai-staging.s3-website-us-east-1.amazonaws.com/", v["NEW_RELIC_DOWNLOAD_URL"])
+	require.Contains(t, "https://nr-downloads-ohai-staging.s3.amazonaws.com/", v["NEW_RELIC_DOWNLOAD_URL"])
 }
 
 func TestRecipeVarProvider_AllowInfraTesting(t *testing.T) {
@@ -294,11 +294,11 @@ func TestRecipeVarProvider_AllowInfraTesting(t *testing.T) {
 	}
 
 	// Test for NEW_RELIC_DOWNLOAD_URL
-	os.Setenv("NEW_RELIC_DOWNLOAD_URL", "https://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/")
+	os.Setenv("NEW_RELIC_DOWNLOAD_URL", "https://nr-downloads-ohai-testing.s3.amazonaws.com/")
 
 	v, err := e.Prepare(m, r, false, licenseKey)
 	require.NoError(t, err)
-	require.Contains(t, "https://nr-downloads-ohai-testing.s3-website-us-east-1.amazonaws.com/", v["NEW_RELIC_DOWNLOAD_URL"])
+	require.Contains(t, "https://nr-downloads-ohai-testing.s3.amazonaws.com/", v["NEW_RELIC_DOWNLOAD_URL"])
 }
 
 func TestRecipeVarProvider_DisallowUnknownInfraTesting(t *testing.T) {


### PR DESCRIPTION
Problem:
`https` is not enabled for region links.