### PR TITLE
feat: publish release artifacts to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-west-1"
         with:
-          args: s3 cp ./dist/currentVersion.txt s3://install/newrelic-cli/currentVersion.txt
+          args: s3 cp ./dist/currentVersion.txt s3://nr-downloads-main/install/newrelic-cli/currentVersion.txt
 
       - name: Upload install.sh to S3
         id: upload-install-script-s3
@@ -72,7 +72,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-west-1"
         with:
-          args: s3 cp ./scripts/install.sh s3://install/newrelic-cli/scripts/install.sh
+          args: s3 cp ./scripts/install.sh s3://nr-downloads-main/install/newrelic-cli/scripts/install.sh
 
       - uses: actions/upload-artifact@v2
         with:
@@ -172,4 +172,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: "us-west-1"
         with:
-          args: s3 cp ./dist/NewRelicCLIInstaller.msi s3://install/newrelic-cli/${{ steps.get-version.outputs.version }}/NewRelicCLIInstaller_${{ steps.get-version.outputs.version }}.msi
+          args: s3 cp ./dist/NewRelicCLIInstaller.msi s3://nr-downloads-main/install/newrelic-cli/${{ steps.get-version.outputs.version }}/NewRelicCLIInstaller_${{ steps.get-version.outputs.version }}.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ jobs:
           # Needed for release notes
           fetch-depth: 0
 
+      - id: get-version
+        uses: battila7/get-version-action@v2.2.1
+
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
 
@@ -42,7 +45,34 @@ jobs:
           SNAPCRAFT_TOKEN: ${{ secrets.SNAPCRAFT_TOKEN }}
           SPLIT_PROD_KEY: ${{ secrets.SPLIT_PROD_KEY }}
           SPLIT_STAGING_KEY: ${{ secrets.SPLIT_STAGING_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: make release-publish
+
+      - uses: "finnp/create-file-action@master"
+        env:
+          FILE_NAME: "dist/currentVersion.txt"
+          FILE_DATA: "${{ steps.get-version.outputs.version }}"
+
+      - name: Upload currentVersion.txt to S3
+        id: upload-current-version-s3
+        uses: ItsKarma/aws-cli@v1.70.0
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-west-1"
+        with:
+          args: s3 cp ./dist/currentVersion.txt s3://install/newrelic-cli/currentVersion.txt
+
+      - name: Upload install.sh to S3
+        id: upload-install-script-s3
+        uses: ItsKarma/aws-cli@v1.70.0
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-west-1"
+        with:
+          args: s3 cp ./scripts/install.sh s3://install/newrelic-cli/scripts/install.sh
 
       - uses: actions/upload-artifact@v2
         with:
@@ -69,12 +99,15 @@ jobs:
         env:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
-  release-windows-installer:
+  release-windows-installer-github:
     runs-on: windows-latest
     needs: release
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - id: get-version
+        uses: battila7/get-version-action@v2.2.1
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
@@ -100,13 +133,43 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "::set-output name=upload_url::$(./scripts/get_latest_release_upload_url.sh)"
 
-      - name: Upload Windows installer
-        id: upload-windows-installer
+      - name: Upload Windows installer to GitHub
+        id: upload-windows-installer-github
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
           asset_path: .\build\package\msi\NewRelicCLIInstaller\bin\x64\Release\NewRelicCLIInstaller.msi
-          asset_name: NewRelicCLIInstaller.msi
+          asset_name: NewRelicCLIInstaller_${{ steps.get-version.outputs.version }}.msi
           asset_content_type: application/octet-stream
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: windows-msi
+          path: .\build\package\msi\NewRelicCLIInstaller\bin\x64\Release\NewRelicCLIInstaller.msi
+
+  release-windows-installer-s3:
+    runs-on: ubuntu-latest
+    needs: release-windows-installer-github
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - id: get-version
+        uses: battila7/get-version-action@v2.2.1
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows-msi
+          path: ./dist
+
+      - name: Upload Windows installer to S3 (download.newrelic.com)
+        id: upload-windows-installer-s3
+        uses: ItsKarma/aws-cli@v1.70.0
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: "us-west-1"
+        with:
+          args: s3 cp ./dist/NewRelicCLIInstaller.msi s3://install/newrelic-cli/${{ steps.get-version.outputs.version }}/NewRelicCLIInstaller_${{ steps.get-version.outputs.version }}.msi

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -161,5 +161,6 @@ nfpms:
 blobs:
   -
     provider: s3
-    bucket: install
-    region: us-west-2
+    bucket: nr-downloads-main
+    region: us-west-1
+    folder: "install/newrelic-cli/{{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,3 +157,9 @@ nfpms:
     bindir: /usr/local/bin
     epoch: 1
     release: 1
+
+blobs:
+  -
+    provider: s3
+    bucket: install
+    region: us-west-2


### PR DESCRIPTION
This PR uploads release artifacts to the `nr-downloads-main` bucket in S3 so that they can be made available on download.newrelic.com. 

~We will need to get a service user provisioned and set the `AWS_AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` variables in this repository before using this updated release pipeline.~

A service user has been provisioned and the env vars `AWS_AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` have now been set in this repository.

### Testing
This was tested on my [fork](https://github.com/ctrombley/newrelic-cli) in a messy [pull request](https://github.com/ctrombley/newrelic-cli/pull/1).  Once the pipeline was successful there, the relevant parts were copied upstream to create this PR.