### PR TITLE
chore(build): sort changelog by tag instead of date

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -40,7 +40,7 @@ if [ -x "bin/${NATIVE_OS}/newrelic" ]; then
 fi
 
 # Auto-generate CHANGELOG updates
-git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md
+git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md --sort semver
 
 # Commit CHANGELOG updates
 git add CHANGELOG.md


### PR DESCRIPTION
We used to sort by tag, however git-chglog requires a flag to sort by semver tag now. This PR gets our CHANGELOG sorted properly.  