### PR TITLE
Feat command to migrate configuration file v3->v4

### DIFF
--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/entities"
 	"github.com/newrelic/newrelic-cli/internal/events"
 	"github.com/newrelic/newrelic-cli/internal/install"
+	"github.com/newrelic/newrelic-cli/internal/integrations"
 	"github.com/newrelic/newrelic-cli/internal/nerdgraph"
 	"github.com/newrelic/newrelic-cli/internal/nerdstorage"
 	"github.com/newrelic/newrelic-cli/internal/nrql"
@@ -53,6 +54,7 @@ func init() {
 	Command.AddCommand(reporting.Command)
 	Command.AddCommand(utils.Command)
 	Command.AddCommand(workload.Command)
+	Command.AddCommand(integrations.Command)
 
 	CheckPrereleaseMode(Command)
 

--- a/internal/integrations/command.go
+++ b/internal/integrations/command.go
@@ -1,0 +1,12 @@
+package integrations
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// Command represents the agent command
+var Command = &cobra.Command{
+	Use:   "integrations",
+	Short: "Utilities for New Relic Agent's onHost integrations",
+	Long:  `Utilities for New Relic Agent's onHost integrations`,
+}

--- a/internal/integrations/command_config.go
+++ b/internal/integrations/command_config.go
@@ -1,0 +1,52 @@
+package integrations
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+)
+
+var (
+	pathConfiguration string
+	pathDefinition    string
+	pathOutput        string
+)
+
+var cmdConfig = &cobra.Command{
+	Use:     "config",
+	Short:   "Configuration helpers for New Relic onHost integrations",
+	Long:    `Configuration helpers for New Relic onHost integrations`,
+	Example: "newrelic integrations config migrateV3toV4 --pathDefinition /file/path --pathConfiguration /file/path --pathOutput /file/path",
+}
+
+var cmdMigrateV3toV4 = &cobra.Command{
+	Use:     "migrateV3toV4",
+	Short:   "migrate V3 configuration to V4 configuration format",
+	Long:    `migrate V3 configuration to V4 configuration format`,
+	Example: "newrelic integrations config migrateV3toV4 --pathDefinition /file/path --pathConfiguration /file/path --pathOutput /file/path",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		result := MigrateV3toV4Result{
+			MigrateV3toV4Result: migrateV3toV4(pathConfiguration, pathDefinition, pathOutput),
+		}
+
+		utils.LogIfFatal(output.Print(result))
+	},
+}
+
+func init() {
+
+	Command.AddCommand(cmdConfig)
+
+	cmdConfig.AddCommand(cmdMigrateV3toV4)
+
+	cmdMigrateV3toV4.Flags().StringVarP(&pathConfiguration, "pathConfiguration", "c", "", "path configuration")
+	cmdMigrateV3toV4.Flags().StringVarP(&pathDefinition, "pathDefinition", "d", "", "path definition")
+	cmdMigrateV3toV4.Flags().StringVarP(&pathOutput, "pathOutput", "o", "", "path output")
+
+	utils.LogIfError(cmdMigrateV3toV4.MarkFlagRequired("pathConfiguration"))
+	utils.LogIfError(cmdMigrateV3toV4.MarkFlagRequired("pathDefinition"))
+	utils.LogIfError(cmdMigrateV3toV4.MarkFlagRequired("pathOutput"))
+
+}

--- a/internal/integrations/command_test.go
+++ b/internal/integrations/command_test.go
@@ -1,0 +1,18 @@
+// +build unit
+
+package integrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestInstallCommand(t *testing.T) {
+	assert.Equal(t, "integrations", Command.Name())
+
+	testcobra.CheckCobraMetadata(t, Command)
+	testcobra.CheckCobraRequiredFlags(t, Command, []string{})
+}

--- a/internal/integrations/model.go
+++ b/internal/integrations/model.go
@@ -1,0 +1,72 @@
+package integrations
+
+import "time"
+
+// This code is taken directly from the infrastructure agent
+// To avoid an extra dependency it has been copied/pasted
+
+// V3 Configuration Model
+
+// Plugin represents a single plugin, with all associated metadata
+type Plugin struct {
+	Name            string                      `yaml:"name"`             // Name of the plugin (required)
+	Description     string                      `yaml:"description"`      // A short plugin description (optional)
+	Commands        map[string]*PluginV1Command `yaml:"commands"`         // Map of commands for v1 plugins
+	OS              string                      `yaml:"os"`               // OS (or comma-separated list of OSes) supported for the plugin
+	ProtocolVersion int                         `yaml:"protocol_version"` // Protocol version (0 == original version)
+}
+
+type PluginV1Command struct {
+	Command  []string `yaml:"command"`  // Command to execute, run from the plugin's directory.
+	Prefix   string   `yaml:"prefix"`   // "Plugin path" for inventory data produced by the plugin. Not applicable for event sources.
+	Interval int      `yaml:"interval"` // Number of seconds to wait between invocations of the source.
+}
+
+type PluginInstanceWrapper struct {
+	IntegrationName string              `yaml:"integration_name"`
+	Instances       []*PluginV1Instance `yaml:"instances"`
+}
+
+type PluginV1Instance struct {
+	Name            string            `yaml:"name"`
+	Command         string            `yaml:"command"`
+	Arguments       map[string]string `yaml:"arguments"`
+	Labels          map[string]string `yaml:"labels"`
+	IntegrationUser string            `yaml:"integration_user"`
+}
+
+// V4 Configuration Model
+
+// YAML stores the information from a single V4 integrations file
+type v4 struct {
+	Integrations []ConfigEntry `yaml:"integrations"`
+}
+
+// ConfigEntry holds an integrations YAML configuration entry. It may define multiple types of tasks
+type ConfigEntry struct {
+	InstanceName    string            `yaml:"name,omitempty" json:"name"`         // integration instance name
+	CLIArgs         []string          `yaml:"cli_args,omitempty" json:"cli_args"` // optional when executable is deduced by "name" instead of "exec"
+	Exec            ShlexOpt          `yaml:"exec,omitempty" json:"exec"`         // it may be a CLI string or a YAML array
+	Env             map[string]string `yaml:"env,omitempty" json:"env"`           // User-defined environment variables
+	Interval        string            `yaml:"interval,omitempty" json:"interval"` // User-defined interval string (duration notation)
+	Timeout         *time.Duration    `yaml:"timeout,omitempty" json:"timeout"`
+	User            string            `yaml:"integration_user,omitempty" json:"integration_user"`
+	WorkDir         string            `yaml:"working_dir,omitempty" json:"working_dir"`
+	Labels          map[string]string `yaml:"labels,omitempty" json:"labels"`
+	When            EnableConditions  `yaml:"when,omitempty" json:"when"`
+	InventorySource string            `yaml:"inventory_source,omitempty" json:"inventory_source"`
+}
+
+// ShlexOpt is a wrapper around []string so we can use go-shlex for shell tokenizing
+type ShlexOpt []string
+
+// EnableConditions condition the execution of an integration to the trueness of ALL the conditions
+type EnableConditions struct {
+	// Feature allows enabling/disabling the OHI via agent cfg "feature" or cmd-channel Feature Flag
+	Feature string `yaml:"feature,omitempty"`
+	// FileExists conditions the execution of the OHI only if the given file path exists
+	FileExists string `yaml:"file_exists,omitempty"`
+	// EnvExists conditions the execution of the OHI only if the given
+	// environment variables exists and match the value.
+	EnvExists map[string]string `yaml:"env_exists,omitempty"`
+}

--- a/internal/integrations/utils.go
+++ b/internal/integrations/utils.go
@@ -1,0 +1,192 @@
+package integrations
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+)
+
+const (
+	metricArg      = "metrics"
+	inventoryArg   = "inventory"
+	eventsArg      = "events"
+	prefixArg      = "--"
+	prefixArgShort = "-"
+)
+
+// MigrateV3toV4Result represents the result of a migration
+type MigrateV3toV4Result struct {
+	MigrateV3toV4Result string `json:"migrateV3toV4Result"`
+}
+
+func migrateV3toV4(pathConfiguration string, pathDefinition string, pathOutput string) string {
+	// Reading old Definition file
+	v3Definition := Plugin{}
+	v3DefinitionBytes, err := readAndUnmarshallConfig(pathDefinition, &v3Definition)
+	if err != nil {
+		log.Fatal(fmt.Errorf("error reading old config definition: %w", err))
+	}
+
+	// Reading old Configuration file
+	v3Configuration := PluginInstanceWrapper{}
+	v3ConfigurationBytes, err := readAndUnmarshallConfig(pathConfiguration, &v3Configuration)
+	if err != nil {
+		log.Fatal(fmt.Errorf("error reading old config configuration: %w", err))
+	}
+
+	// Populating new config
+	v4config, err := populateV4Config(v3Definition, v3Configuration)
+	if err != nil {
+		log.Fatal(fmt.Errorf("error populating new config: %w", err))
+	}
+
+	// Writing output
+	err = writeOutput(pathOutput, v4config, v3DefinitionBytes, v3ConfigurationBytes)
+	if err != nil {
+		log.Fatal(fmt.Errorf("error writing output: %w", err))
+	}
+
+	return fmt.Sprintf("The config has been migrated and placed in: %s", pathOutput)
+}
+
+func readAndUnmarshallConfig(path string, out interface{}) ([]byte, error) {
+	// Reading old definition file
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s, %w", path, err)
+	}
+
+	err = yaml.Unmarshal(bytes, out)
+	if err != nil {
+		return nil, fmt.Errorf("unmashalling %s, %w", path, err)
+	}
+
+	return bytes, nil
+}
+
+func populateV4Config(v3Definition Plugin, v3Configuration PluginInstanceWrapper) (*v4, error) {
+	if v3Configuration.IntegrationName != v3Definition.Name {
+		return nil, fmt.Errorf("IntegrationName != Name: %s!=%s", v3Configuration.IntegrationName, v3Definition.Name)
+	}
+
+	// The field os does not have currently a simple way to be migrated
+	if v3Definition.OS != "" {
+		log.Debugf("The old definitions had a os directive, %s. Usually it is not needed, use `when` field otherwhise", v3Definition.OS)
+	}
+
+	v4Config := &v4{}
+	for commandName, pluginV1Command := range v3Definition.Commands {
+		for _, pluginV1Instance := range v3Configuration.Instances {
+			if commandName == pluginV1Instance.Command {
+				integrationInstance := populateConfigEntry(pluginV1Instance, pluginV1Command)
+				v4Config.Integrations = append(v4Config.Integrations, integrationInstance)
+			}
+		}
+	}
+
+	return v4Config, nil
+}
+
+func populateConfigEntry(pluginV1Instance *PluginV1Instance, pluginV1Command *PluginV1Command) ConfigEntry {
+	configEntry := ConfigEntry{}
+	if len(pluginV1Command.Command) == 0 {
+		return configEntry
+	}
+
+	executable := pluginV1Command.Command[0]
+	configEntry.InstanceName = path.Base(executable)
+	configEntry.Interval = fmt.Sprintf("%ds", pluginV1Command.Interval)
+	configEntry.Labels = pluginV1Instance.Labels
+	configEntry.User = pluginV1Instance.IntegrationUser
+	configEntry.InventorySource = pluginV1Command.Prefix
+	configEntry.Env = map[string]string{}
+	for k, v := range pluginV1Instance.Arguments {
+		configEntry.Env[strings.ToUpper(k)] = v
+	}
+
+	// Please notice that this is a simplification. If it is an absolute path we are adding it to the exec
+	// if is a relative path or a integration name, we are assuming it is a standard integration included into the path
+	if path.IsAbs(executable) {
+		configEntry.Exec = pluginV1Command.Command
+	} else {
+		buildCLIArgs(pluginV1Command, &configEntry)
+	}
+	return configEntry
+}
+
+func buildCLIArgs(pluginV1Command *PluginV1Command, configEntry *ConfigEntry) {
+	for index, arg := range pluginV1Command.Command {
+		if index == 0 {
+			// the first arg in command is the binary name
+			continue
+		}
+
+		sanitized := strings.TrimPrefix(arg, prefixArg)
+		sanitized = strings.TrimPrefix(sanitized, prefixArgShort)
+		if sanitized == metricArg || sanitized == inventoryArg || sanitized == eventsArg {
+			configEntry.Env[strings.ToUpper(sanitized)] = "true"
+		} else {
+			configEntry.CLIArgs = append(configEntry.CLIArgs, arg)
+		}
+	}
+}
+
+func writeOutput(pathOutput string, v4Config *v4, definitionBytes []byte, configurationBytes []byte) error {
+	if v4Config == nil {
+		return fmt.Errorf("v4Config pointer is nil")
+	}
+
+	file, err := os.OpenFile(pathOutput, os.O_RDWR|os.O_CREATE|syscall.O_TRUNC, 0666)
+	if err != nil {
+		return fmt.Errorf("opening File %s, %w", pathOutput, err)
+	}
+	defer file.Close()
+
+	err = writeV4Config(v4Config, file)
+	if err != nil {
+		return fmt.Errorf("writing v4 config, %w", err)
+	}
+
+	err = writeTextAsComment(file, string(definitionBytes))
+	if err != nil {
+		return fmt.Errorf("adding old definition as comment, %w", err)
+	}
+
+	err = writeTextAsComment(file, string(configurationBytes))
+	if err != nil {
+		return fmt.Errorf("adding old configuration as comment, %w", err)
+	}
+
+	return nil
+}
+
+func writeV4Config(v4Config *v4, file *os.File) error {
+	// see https://github.com/go-yaml/yaml/commit/7649d4548cb53a614db133b2a8ac1f31859dda8c
+	yaml.FutureLineWrap()
+	v4ConfigBytes, err := yaml.Marshal(*v4Config)
+	if err != nil {
+		return fmt.Errorf("marshallig v4Config, %w", err)
+	}
+
+	_, err = file.Write(v4ConfigBytes)
+	if err != nil {
+		return fmt.Errorf("writing v4ConfigBytes, %w", err)
+	}
+	return nil
+}
+
+func writeTextAsComment(file *os.File, text string) error {
+	fileCommented := strings.ReplaceAll(text, "\n", "\n## ")
+	fileCommented = "\n\n## " + fileCommented
+
+	_, err := file.Write([]byte(fileCommented))
+	if err != nil {
+		return fmt.Errorf("writing text as comment: %w", err)
+	}
+	return nil
+}

--- a/internal/integrations/utils.go
+++ b/internal/integrations/utils.go
@@ -6,7 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 )
@@ -15,6 +15,7 @@ const (
 	metricArg      = "metrics"
 	inventoryArg   = "inventory"
 	eventsArg      = "events"
+	exeSuffix      = ".exe"
 	prefixArg      = "--"
 	prefixArgShort = "-"
 )
@@ -99,7 +100,8 @@ func populateConfigEntry(pluginV1Instance *PluginV1Instance, pluginV1Command *Pl
 	}
 
 	executable := pluginV1Command.Command[0]
-	configEntry.InstanceName = path.Base(executable)
+	binaryName := filepath.Base(executable)
+	configEntry.InstanceName = strings.TrimSuffix(binaryName, exeSuffix)
 	configEntry.Interval = fmt.Sprintf("%ds", pluginV1Command.Interval)
 	configEntry.Labels = pluginV1Instance.Labels
 	configEntry.User = pluginV1Instance.IntegrationUser
@@ -111,7 +113,7 @@ func populateConfigEntry(pluginV1Instance *PluginV1Instance, pluginV1Command *Pl
 
 	// Please notice that this is a simplification. If it is an absolute path we are adding it to the exec
 	// if is a relative path or a integration name, we are assuming it is a standard integration included into the path
-	if path.IsAbs(executable) {
+	if filepath.IsAbs(executable) {
 		configEntry.Exec = pluginV1Command.Command
 	} else {
 		buildCLIArgs(pluginV1Command, &configEntry)

--- a/internal/integrations/utils_test.go
+++ b/internal/integrations/utils_test.go
@@ -1,0 +1,165 @@
+// +build unit
+
+package integrations
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"path"
+	"strings"
+	"testing"
+)
+
+func TestPopulateV4ConfigRelativePath(t *testing.T) {
+	command := []string{
+		"./relative/path/testBinary",
+		"--metrics",
+		"-events",
+		"--not_standard_flag",
+		"not_standard_value",
+	}
+	labelMap := map[string]string{
+		"oneKeyLabel": "oneValueLabel",
+		"twoKeyLabel": "twoValueLabel",
+	}
+	argMap := map[string]string{
+		"oneKeyArg": "oneValueArg",
+		"twoKeyArg": "twoValueArg",
+	}
+	plugin := getPluginExample(command)
+	pluginWrapper := getPluginWrapperExample(argMap, labelMap)
+
+	v4Config, err := populateV4Config(plugin, pluginWrapper)
+	require.NoError(t, err, "no error is expected")
+	require.Len(t, v4Config.Integrations, 1)
+
+	instance := v4Config.Integrations[0]
+	assert.Equal(t, "testUser", instance.User)
+	assert.Equal(t, "inventoryPrefix", instance.InventorySource)
+	assert.Equal(t, "12345s", instance.Interval)
+	assert.Equal(t, "true", instance.Env["METRICS"])
+	assert.Equal(t, "true", instance.Env["EVENTS"])
+	assert.Equal(t, instance.Labels, labelMap)
+	for k, v := range argMap {
+		assert.Equal(t, instance.Env[strings.ToUpper(k)], v)
+	}
+	assert.Equal(t, ShlexOpt(nil), instance.Exec)
+	assert.Equal(t, []string{"--not_standard_flag", "not_standard_value"}, instance.CLIArgs)
+	assert.Equal(t, "testBinary", instance.InstanceName)
+}
+
+func TestPopulateV4ConfigAbsolutePath(t *testing.T) {
+	command := []string{
+		"/absolute/path/testBinary",
+		"--metrics",
+		"-events",
+		"--not_standard_flag",
+		"not_standard_value",
+	}
+
+	plugin := getPluginExample(command)
+	pluginWrapper := getPluginWrapperExample(nil, nil)
+	v4Config, err := populateV4Config(plugin, pluginWrapper)
+
+	require.NoError(t, err, "no error is expected")
+	require.Len(t, v4Config.Integrations, 1)
+
+	instance := v4Config.Integrations[0]
+	assert.Equal(t, "testUser", instance.User)
+	assert.Equal(t, "inventoryPrefix", instance.InventorySource)
+	assert.Equal(t, "12345s", instance.Interval)
+	assert.NotEqual(t, "true", instance.Env["METRICS"])
+	assert.NotEqual(t, "true", instance.Env["EVENTS"])
+	assert.Equal(t, []string(nil), instance.CLIArgs)
+	assert.Equal(t, ShlexOpt{
+		"/absolute/path/testBinary",
+		"--metrics",
+		"-events",
+		"--not_standard_flag",
+		"not_standard_value",
+	}, instance.Exec)
+	assert.Equal(t, "testBinary", instance.InstanceName)
+
+}
+
+func TestPopulateV4ConfigWrongName(t *testing.T) {
+	v4Config, err := populateV4Config(
+		Plugin{
+			Name: "testIntegration",
+		},
+		PluginInstanceWrapper{
+			IntegrationName: "different",
+		},
+	)
+
+	require.Error(t, err, "error is expected")
+	require.Nil(t, v4Config, 0)
+}
+
+func TestYAMLValidity(t *testing.T) {
+	tmpPath := t.TempDir()
+	tmpFile := path.Join(tmpPath, "testingFile")
+
+	command := []string{
+		"./relative/path/testBinary",
+		"--metrics",
+		"-events",
+		"--not_standard_flag",
+		"not_standard_value",
+	}
+	argMap := map[string]string{
+		"oneKeyArg": "oneValueArg",
+		"twoKeyArg": "twoValueArg",
+	}
+
+	plugin := getPluginExample(command)
+	pluginWrapper := getPluginWrapperExample(argMap, nil)
+	v4Config, err := populateV4Config(plugin, pluginWrapper)
+	require.NoError(t, err, "no error is expected")
+
+	err = writeOutput(tmpFile, v4Config, []byte("testComment"), []byte("testCommentTwo"))
+	require.NoError(t, err, "no error is expected")
+
+	testV4 := v4{}
+	readBytes, err := readAndUnmarshallConfig(tmpFile, &testV4)
+	require.NoError(t, err, "no error is expected")
+
+	assert.Equal(t, testV4, *v4Config, readBytes)
+}
+
+func getPluginExample(command []string) Plugin {
+	plugin := Plugin{
+		Name: "testIntegration",
+		Commands: map[string]*PluginV1Command{
+			"testCommand": {
+				Command:  command,
+				Prefix:   "inventoryPrefix",
+				Interval: 12345,
+			},
+		},
+	}
+	return plugin
+}
+
+func getPluginWrapperExample(argMap map[string]string, labelMap map[string]string) PluginInstanceWrapper {
+	pluginWrapper := PluginInstanceWrapper{
+		IntegrationName: "testIntegration",
+		Instances: []*PluginV1Instance{
+			{
+				Name:            "testCommandName",
+				Command:         "testCommand",
+				Arguments:       argMap,
+				Labels:          labelMap,
+				IntegrationUser: "testUser",
+			},
+			{
+				Name:            "testCommandNameTwo",
+				Command:         "testCommandTwo",
+				Arguments:       map[string]string{},
+				Labels:          map[string]string{},
+				IntegrationUser: "testUserTwo",
+			},
+		},
+	}
+	return pluginWrapper
+}


### PR DESCRIPTION
### Purpose of the PR

We wrote a small helper in order to simplify the migration between V3 and V4 configuration of onHost integration.

Both the users and the support could be interested in this tool since given a V3 definition and configuration generates a working V4 configuration file.

### Doubts

I was not 100% sure that this is the right place for the new functionality or if it is better to place it under the `agent` command.

