### PR TITLE
fix: get chocolatey publish pipeline working

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,12 +66,6 @@ jobs:
           GH_USER_EMAIL: developer-toolkit-team@newrelic.com
           GH_USER_NAME: 'New Relic Developer Toolkit Bot'
 
-      - name: Upload chocolatey package
-        shell: bash
-        run: make chocolatey-publish
-        env:
-          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-
       - name: Install aws cli
         run: |
           sudo apt-get install awscli -y
@@ -219,6 +213,12 @@ jobs:
         id: upload-current-version
         run: |
           aws s3 cp currentVersion.txt s3://nr-downloads-main/install/newrelic-cli/currentVersion.txt --profile virtuoso
+
+      - name: Upload chocolatey package
+        shell: bash
+        run: make chocolatey-publish
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
 
       - name: Cleanup configs
         run: |

--- a/build/chocolatey.mk
+++ b/build/chocolatey.mk
@@ -1,8 +1,8 @@
 #
 # Makefile fragment for Chocolatey actions
 #
-CHOCO         ?= docker run --rm -v $$PWD:$$PWD -w $$PWD linuturk/mono-choco
-CHOCOLATEY_BUILD_DIR	?= build/package/chocolatey
+CHOCOLATEY_BUILD_DIR    ?= build/package/chocolatey
+CHOCO                   ?= docker run --rm -v $$PWD/$(CHOCOLATEY_BUILD_DIR):$$PWD -w $$PWD linuturk/mono-choco
 
 chocolatey-publish: chocolatey-build
 	@echo "=== $(PROJECT_NAME) === [ chocolatey-publish ]: publishing chocolatey package"
@@ -10,19 +10,15 @@ chocolatey-publish: chocolatey-build
 		echo "Failure: CHOCOLATEY_API_KEY not set" ; \
 		exit 1 ; \
 	fi
-	@cd $(CHOCOLATEY_BUILD_DIR) && \
-		$(CHOCO) push --source https://chocolatey.org/ -k ${CHOCOLATEY_API_KEY} newrelic-cli.${PROJECT_VER_TAGGED}.nupkg \
-	; cd -
+	$(CHOCO) push --source https://chocolatey.org/ -k ${CHOCOLATEY_API_KEY} newrelic-cli.${PROJECT_VER_TAGGED}.nupkg
 
 
 chocolatey-build:
 	@echo "=== $(PROJECT_NAME) === [ chocolatey-build ]: publishing chocolatey package"
 	@cp LICENSE $(CHOCOLATEY_BUILD_DIR)/tools/LICENSE.txt
-	@cd $(CHOCOLATEY_BUILD_DIR) && \
-		curl -sL -o tools/NewRelicCLIInstaller.msi https://download.newrelic.com/install/newrelic-cli/v${PROJECT_VER_TAGGED}/NewRelicCLIInstaller.msi && \
-		rm -f newrelic-cli.${PROJECT_VER_TAGGED}.nupkg && \
-		sed -i '' -e "s/    <version>.*<\/version>/    <version>${PROJECT_VER_TAGGED}<\/version>/g" newrelic-cli.nuspec && \
-		$(CHOCO) pack \
-	; cd -
+	@curl -sL -o $(CHOCOLATEY_BUILD_DIR)/tools/NewRelicCLIInstaller.msi https://download.newrelic.com/install/newrelic-cli/v${PROJECT_VER_TAGGED}/NewRelicCLIInstaller.msi
+	@rm -f newrelic-cli.${PROJECT_VER_TAGGED}.nupkg
+	@sed -i '' -e "s/    <version>.*<\/version>/    <version>${PROJECT_VER_TAGGED}<\/version>/g" $(CHOCOLATEY_BUILD_DIR)/newrelic-cli.nuspec
+	$(CHOCO) pack
 
 .PHONY: chocolatey-build chocolatey-publish


### PR DESCRIPTION
Seems like changing directory from within the make target was [causing problems in Github actions](https://github.com/newrelic/newrelic-cli/runs/3489733702?check_suite_focus=true):

```
Run make chocolatey-publish
=== newrelic-cli === [ chocolatey-build ]: publishing chocolatey package
sed: can't read : No such file or directory
```

Also, this now takes a dependency on the MSI in S3, so it needs to be moved after that artifact's publish step.