### PR TITLE
fix(install): add defensive code to trim whitespace from version string so version check works again

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -162,7 +162,7 @@ func fetchLatestRelease(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	gitTag := string(respBytes)
+	gitTag := strings.TrimSpace(string(respBytes))
 	_, err = semver.NewVersion(gitTag)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
The GitHub Action `battila7/get-version-action` `output` value is a version string that contains an extra empty space which is causing issues with that check. This PR trims the extra empty space around the version string to get this working again.