### PR TITLE
chore(deps): Update github.com/newrelic/newrelic-client-go v0.63.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go v0.62.1
+	github.com/newrelic/newrelic-client-go v0.63.0
 	github.com/onsi/ginkgo v1.16.4 // indirect
 	github.com/onsi/gomega v1.13.0 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -275,13 +275,14 @@ github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/z
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.4.1 h1:CpVNEelQCZBooIPDn+AR3NpivK/TIKU8bDxdASFVQag=
 github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.4.2 h1:6h7AQ0yhTcIsmFmnAwQls75jp2Gzs4iB8W7pjMO+rqo=
+github.com/mitchellh/mapstructure v1.4.2/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/newrelic/newrelic-client-go v0.62.1 h1:3EtnALMolln8G2EdDWx2TUYgh8VqAGJmoqFE46rBoeE=
-github.com/newrelic/newrelic-client-go v0.62.1/go.mod h1:rJrNRX5HzgCnxJm2Hcn6IXmN1KCP/ppmvwkUbnm2Kto=
+github.com/newrelic/newrelic-client-go v0.63.0 h1:FqM9GPLYeSah9m3iU4oe5Obm8Ty/EN+G4XaNlcrqU8o=
+github.com/newrelic/newrelic-client-go v0.63.0/go.mod h1:VXjhsfui0rvhM9cVwnKwlidF8NbXlHZvh63ZKi6fImA=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/internal/apm/command_application.go
+++ b/internal/apm/command_application.go
@@ -6,6 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/newrelic/newrelic-client-go/pkg/common"
 	"github.com/newrelic/newrelic-client-go/pkg/entities"
 
 	"github.com/newrelic/newrelic-cli/internal/client"
@@ -54,7 +55,7 @@ The search command performs a query for an APM application name and/or account I
 			}
 
 			var singleResult *entities.EntityInterface
-			singleResult, err = client.NRClient.Entities.GetEntity(entities.EntityGUID(appGUID))
+			singleResult, err = client.NRClient.Entities.GetEntity(common.EntityGUID(appGUID))
 			utils.LogIfFatal(err)
 			utils.LogIfFatal(output.Print(*singleResult))
 		} else {
@@ -101,7 +102,7 @@ The get command performs a query for an APM application by GUID.
 		var err error
 
 		if appGUID != "" {
-			results, err = client.NRClient.Entities.GetEntity(entities.EntityGUID(appGUID))
+			results, err = client.NRClient.Entities.GetEntity(common.EntityGUID(appGUID))
 			utils.LogIfFatal(err)
 		} else {
 			utils.LogIfError(cmd.Help())

--- a/internal/entities/command_tags.go
+++ b/internal/entities/command_tags.go
@@ -7,11 +7,13 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/newrelic/newrelic-client-go/pkg/common"
+	"github.com/newrelic/newrelic-client-go/pkg/entities"
+
 	"github.com/newrelic/newrelic-cli/internal/client"
 	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/pipe"
 	"github.com/newrelic/newrelic-cli/internal/utils"
-	"github.com/newrelic/newrelic-client-go/pkg/entities"
 )
 
 var (
@@ -42,11 +44,11 @@ The get command returns JSON output of the tags for the requested entity.
 	Run: func(cmd *cobra.Command, args []string) {
 		// Temporary until bulk actions can be build into newrelic-client-go
 		if value, ok := pipe.Get("guid"); ok {
-			tags, err := client.NRClient.Entities.GetTagsForEntityWithContext(utils.SignalCtx, entities.EntityGUID(value[0]))
+			tags, err := client.NRClient.Entities.GetTagsForEntityWithContext(utils.SignalCtx, common.EntityGUID(value[0]))
 			utils.LogIfFatal(err)
 			utils.LogIfError(output.Print(tags))
 		} else {
-			tags, err := client.NRClient.Entities.GetTagsForEntityWithContext(utils.SignalCtx, entities.EntityGUID(entityGUID))
+			tags, err := client.NRClient.Entities.GetTagsForEntityWithContext(utils.SignalCtx, common.EntityGUID(entityGUID))
 			utils.LogIfFatal(err)
 			utils.LogIfError(output.Print(tags))
 		}
@@ -64,7 +66,7 @@ that match the specified keys.
 	Example: "newrelic entity tags delete --guid <entityGUID> --tag tag1 --tag tag2 --tag tag3,tag4",
 	PreRun:  client.RequireClient,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := client.NRClient.Entities.TaggingDeleteTagFromEntityWithContext(utils.SignalCtx, entities.EntityGUID(entityGUID), entityTags)
+		_, err := client.NRClient.Entities.TaggingDeleteTagFromEntityWithContext(utils.SignalCtx, common.EntityGUID(entityGUID), entityTags)
 		utils.LogIfFatal(err)
 
 		log.Info("success")
@@ -84,7 +86,7 @@ The delete-values command deletes the specified tag:value pairs on a given entit
 		tagValues, err := assembleTagValuesInput(entityValues)
 		utils.LogIfFatal(err)
 
-		_, err = client.NRClient.Entities.TaggingDeleteTagValuesFromEntityWithContext(utils.SignalCtx, entities.EntityGUID(entityGUID), tagValues)
+		_, err = client.NRClient.Entities.TaggingDeleteTagValuesFromEntityWithContext(utils.SignalCtx, common.EntityGUID(entityGUID), tagValues)
 		utils.LogIfFatal(err)
 
 		log.Info("success")
@@ -104,7 +106,7 @@ The create command adds tag:value pairs to the given entity.
 		tags, err := assembleTagsInput(entityTags)
 		utils.LogIfFatal(err)
 
-		_, err = client.NRClient.Entities.TaggingAddTagsToEntityWithContext(utils.SignalCtx, entities.EntityGUID(entityGUID), tags)
+		_, err = client.NRClient.Entities.TaggingAddTagsToEntityWithContext(utils.SignalCtx, common.EntityGUID(entityGUID), tags)
 		utils.LogIfFatal(err)
 
 		log.Info("success")
@@ -125,7 +127,7 @@ provided for the given entity.
 		tags, err := assembleTagsInput(entityTags)
 		utils.LogIfFatal(err)
 
-		_, err = client.NRClient.Entities.TaggingReplaceTagsOnEntityWithContext(utils.SignalCtx, entities.EntityGUID(entityGUID), tags)
+		_, err = client.NRClient.Entities.TaggingReplaceTagsOnEntityWithContext(utils.SignalCtx, common.EntityGUID(entityGUID), tags)
 		utils.LogIfFatal(err)
 
 		log.Info("success")

--- a/internal/install/execution/installevents_reporter.go
+++ b/internal/install/execution/installevents_reporter.go
@@ -5,10 +5,11 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/newrelic/newrelic-client-go/pkg/common"
+	"github.com/newrelic/newrelic-client-go/pkg/installevents"
+
 	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
-	"github.com/newrelic/newrelic-client-go/pkg/entities"
-	"github.com/newrelic/newrelic-client-go/pkg/installevents"
 )
 
 type InstallEventsReporter struct {
@@ -87,7 +88,7 @@ func (r InstallEventsReporter) createMultipleRecipeInstallEvents(status *Install
 			Status:                         installevents.InstallationRecipeStatusType(ss.Status),
 			Name:                           ss.Name,
 			DisplayName:                    ss.DisplayName,
-			EntityGUID:                     entities.EntityGUID(ss.EntityGUID),
+			EntityGUID:                     common.EntityGUID(ss.EntityGUID),
 			ValidationDurationMilliseconds: ss.ValidationDurationMs,
 			HostName:                       status.DiscoveryManifest.Hostname,
 			KernelArch:                     status.DiscoveryManifest.KernelArch,
@@ -188,7 +189,7 @@ func buildRecipeStatus(status *InstallStatus, event *RecipeStatusEvent, statusTy
 	if event != nil {
 		i.Name = event.Recipe.Name
 		i.DisplayName = event.Recipe.DisplayName
-		i.EntityGUID = entities.EntityGUID(event.EntityGUID)
+		i.EntityGUID = common.EntityGUID(event.EntityGUID)
 		i.ValidationDurationMilliseconds = event.ValidationDurationMs
 		i.TaskPath = strings.Join(event.TaskPath, ",")
 	}

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-client-go/newrelic"
+	"github.com/newrelic/newrelic-client-go/pkg/common"
 	"github.com/newrelic/newrelic-client-go/pkg/config"
-	"github.com/newrelic/newrelic-client-go/pkg/entities"
 	"github.com/newrelic/newrelic-client-go/pkg/nerdstorage"
 	"github.com/newrelic/newrelic-client-go/pkg/workloads"
+
+	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
 func TestReportRecipeSucceeded_Basic(t *testing.T) {
@@ -174,6 +175,6 @@ func createEntity(t *testing.T, accountID int, c *newrelic.NewRelic) string {
 }
 
 func deleteEntity(t *testing.T, guid string, c *newrelic.NewRelic) {
-	_, err := c.Workloads.WorkloadDelete(entities.EntityGUID(guid))
+	_, err := c.Workloads.WorkloadDelete(common.EntityGUID(guid))
 	require.NoError(t, err)
 }

--- a/internal/workload/command_workload.go
+++ b/internal/workload/command_workload.go
@@ -6,12 +6,14 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
+	"github.com/newrelic/newrelic-client-go/pkg/common"
+	"github.com/newrelic/newrelic-client-go/pkg/entities"
+	"github.com/newrelic/newrelic-client-go/pkg/workloads"
+
 	"github.com/newrelic/newrelic-cli/internal/client"
 	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
 	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
-	"github.com/newrelic/newrelic-client-go/pkg/entities"
-	"github.com/newrelic/newrelic-client-go/pkg/workloads"
 )
 
 var (
@@ -32,7 +34,7 @@ The get command retrieves a specific workload by its workload GUID.
 	Example: `newrelic workload get --accountId 12345678 --guid MjUyMDUyOHxOUjF8V09SS0xPQUR8MTI4Myt`,
 	PreRun:  client.RequireClient,
 	Run: func(cmd *cobra.Command, args []string) {
-		workload, err := client.NRClient.Entities.GetEntitiesWithContext(utils.SignalCtx, []entities.EntityGUID{entities.EntityGUID(guid)})
+		workload, err := client.NRClient.Entities.GetEntitiesWithContext(utils.SignalCtx, []common.EntityGUID{common.EntityGUID(guid)})
 		utils.LogIfFatal(err)
 
 		utils.LogIfFatal(output.Print(workload))
@@ -89,7 +91,7 @@ you also have access to.
 
 		if len(entityGUIDs) > 0 {
 			for _, e := range entityGUIDs {
-				createInput.EntityGUIDs = append(createInput.EntityGUIDs, entities.EntityGUID(e))
+				createInput.EntityGUIDs = append(createInput.EntityGUIDs, common.EntityGUID(e))
 			}
 		}
 
@@ -134,7 +136,7 @@ entities from different sub-accounts that you also have access to.
 
 		if len(entityGUIDs) > 0 {
 			for _, e := range entityGUIDs {
-				updateInput.EntityGUIDs = append(updateInput.EntityGUIDs, entities.EntityGUID(e))
+				updateInput.EntityGUIDs = append(updateInput.EntityGUIDs, common.EntityGUID(e))
 			}
 		}
 
@@ -150,7 +152,7 @@ entities from different sub-accounts that you also have access to.
 			updateInput.ScopeAccounts = &workloads.WorkloadScopeAccountsInput{AccountIDs: scopeAccountIDs}
 		}
 
-		workload, err := client.NRClient.Workloads.WorkloadUpdateWithContext(utils.SignalCtx, entities.EntityGUID(guid), updateInput)
+		workload, err := client.NRClient.Workloads.WorkloadUpdateWithContext(utils.SignalCtx, common.EntityGUID(guid), updateInput)
 		utils.LogIfFatal(err)
 
 		utils.LogIfFatal(output.Print(workload))
@@ -177,7 +179,7 @@ compose the new name.
 			Name: name,
 		}
 
-		workload, err := client.NRClient.Workloads.WorkloadDuplicateWithContext(utils.SignalCtx, accountID, entities.EntityGUID(guid), duplicateInput)
+		workload, err := client.NRClient.Workloads.WorkloadDuplicateWithContext(utils.SignalCtx, accountID, common.EntityGUID(guid), duplicateInput)
 		utils.LogIfFatal(err)
 
 		utils.LogIfFatal(output.Print(workload))
@@ -195,7 +197,7 @@ The delete command accepts a workload's entity GUID.
 	Example: `newrelic workload delete --guid 'MjUyMDUyOHxBOE28QVBQTElDQVRDT058MjE1MDM3Nzk1'`,
 	PreRun:  client.RequireClient,
 	Run: func(cmd *cobra.Command, args []string) {
-		_, err := client.NRClient.Workloads.WorkloadDeleteWithContext(utils.SignalCtx, entities.EntityGUID(guid))
+		_, err := client.NRClient.Workloads.WorkloadDeleteWithContext(utils.SignalCtx, common.EntityGUID(guid))
 		utils.LogIfFatal(err)
 
 		log.Info("success")


### PR DESCRIPTION
newrelic-client-go v0.63.0 has a breaking change, so update all references of `entities.EntityGUID` to `common.EntityGUID`