### PR TITLE
feat(install): Add vars to the nrql validator

### DIFF
--- a/internal/install/interfaces.go
+++ b/internal/install/interfaces.go
@@ -38,7 +38,7 @@ type RecipeFilterRunner interface {
 
 // RecipeValidator validates installation of a recipe.
 type RecipeValidator interface {
-	ValidateRecipe(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe) (entityGUID string, err error)
+	ValidateRecipe(context.Context, types.DiscoveryManifest, types.OpenInstallationRecipe, types.RecipeVars) (entityGUID string, err error)
 }
 
 type RecipeVarPreparer interface {

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -394,7 +394,7 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 	}
 
 	validationStart := time.Now()
-	entityGUID, err := i.validateRecipeViaAllMethods(ctx, r, m)
+	entityGUID, err := i.validateRecipeViaAllMethods(ctx, r, m, vars)
 	validationDurationMs := time.Since(validationStart).Milliseconds()
 	if err != nil {
 		validationErr := fmt.Errorf("encountered an error while validating receipt of data for %s: %w", r.Name, err)
@@ -418,7 +418,7 @@ func (i *RecipeInstaller) executeAndValidate(ctx context.Context, m *types.Disco
 
 type validationFunc func() (string, error)
 
-func (i *RecipeInstaller) validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest) (string, error) {
+func (i *RecipeInstaller) validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest, v types.RecipeVars) (string, error) {
 	timeoutCtx, cancel := context.WithTimeout(ctx, validationTimeout)
 	defer cancel()
 
@@ -442,7 +442,7 @@ func (i *RecipeInstaller) validateRecipeViaAllMethods(ctx context.Context, r *ty
 	// Add NRQL validation if configured
 	if r.ValidationNRQL != "" {
 		validationFuncs = append(validationFuncs, func() (string, error) {
-			return i.recipeValidator.ValidateRecipe(timeoutCtx, *m, *r)
+			return i.recipeValidator.ValidateRecipe(timeoutCtx, *m, *r, v)
 		})
 	} else {
 		log.Debugf("skipping NRQL validation due to lack of validationNRQL")

--- a/internal/install/validation/mock_recipe_validator.go
+++ b/internal/install/validation/mock_recipe_validator.go
@@ -20,7 +20,7 @@ func NewMockRecipeValidator() *MockRecipeValidator {
 	return &MockRecipeValidator{}
 }
 
-func (m *MockRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
+func (m *MockRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, v types.RecipeVars) (string, error) {
 	m.ValidateCallCount++
 
 	var err error

--- a/internal/install/validation/polling_recipe_validator.go
+++ b/internal/install/validation/polling_recipe_validator.go
@@ -28,8 +28,8 @@ func NewPollingRecipeValidator(c utils.NRDBClient) *PollingRecipeValidator {
 }
 
 // ValidateRecipe polls NRDB to assert data is being reported for the given recipe.
-func (m *PollingRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
-	query, err := substituteHostname(dm, r)
+func (m *PollingRecipeValidator) ValidateRecipe(ctx context.Context, dm types.DiscoveryManifest, r types.OpenInstallationRecipe, v types.RecipeVars) (string, error) {
+	query, err := substituteVariables(dm, r, v)
 	if err != nil {
 		return "", err
 	}
@@ -37,16 +37,10 @@ func (m *PollingRecipeValidator) ValidateRecipe(ctx context.Context, dm types.Di
 	return m.Validate(ctx, query)
 }
 
-func substituteHostname(dm types.DiscoveryManifest, r types.OpenInstallationRecipe) (string, error) {
+func substituteVariables(dm types.DiscoveryManifest, r types.OpenInstallationRecipe, v types.RecipeVars) (string, error) {
 	tmpl, err := template.New("validationNRQL").Parse(string(r.ValidationNRQL))
 	if err != nil {
 		panic(err)
-	}
-
-	v := struct {
-		HOSTNAME string
-	}{
-		HOSTNAME: dm.Hostname,
 	}
 
 	var tpl bytes.Buffer

--- a/internal/install/validation/polling_recipe_validator_test.go
+++ b/internal/install/validation/polling_recipe_validator_test.go
@@ -43,8 +43,9 @@ func TestValidate_shouldSucceed(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.NoError(t, err)
 }
@@ -60,8 +61,9 @@ func TestValidate_shouldFailEmpty(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.Error(t, err)
 }
@@ -77,8 +79,9 @@ func TestValidate_PassAfterNAttempts(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.NoError(t, err)
 	require.Equal(t, 5, c.Attempts())
@@ -93,8 +96,9 @@ func TestValidate_FailAfterNAttempts(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.Error(t, err)
 	require.Equal(t, 3, c.Attempts())
@@ -112,8 +116,9 @@ func TestValidate_FailAfterMaxAttempts(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.Error(t, err)
 }
@@ -130,11 +135,12 @@ func TestValidate_FailIfContextDone(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
 	ctx, cancel := context.WithCancel(getTestContext())
 	cancel()
 
-	_, err := v.ValidateRecipe(ctx, m, r)
+	_, err := v.ValidateRecipe(ctx, m, r, rv)
 
 	require.Error(t, err)
 }
@@ -151,8 +157,9 @@ func TestValidate_QueryError(t *testing.T) {
 
 	r := types.OpenInstallationRecipe{}
 	m := types.DiscoveryManifest{}
+	rv := types.RecipeVars{}
 
-	_, err := v.ValidateRecipe(getTestContext(), m, r)
+	_, err := v.ValidateRecipe(getTestContext(), m, r, rv)
 
 	require.Error(t, err)
 }


### PR DESCRIPTION
Currently only the `{{.HOSTNAME}}` variable is replaced in the validationNrql. For the Kubernetes recipe we need to match on the cluster name, which is in a different variable. 

Query: `SELECT count(*) FROM K8sClusterSample FACET entityGuid WHERE clusterName LIKE '{{.NR_CLI_CLUSTERNAME}}'
`