### PR TITLE
feat(install): Log STDERR for requireAtDiscovery script to INFO if the user is targeting a specific recipe.

### DIFF
--- a/internal/install/execution/sh_recipe_executor.go
+++ b/internal/install/execution/sh_recipe_executor.go
@@ -24,12 +24,15 @@ type ShRecipeExecutor struct {
 	Stdout io.Writer
 }
 
-func NewShRecipeExecutor() *ShRecipeExecutor {
-	writer := config.Logger.WriterLevel(log.DebugLevel)
+func NewShRecipeExecutor(infoLogging bool) *ShRecipeExecutor {
+	errLogLevel := log.DebugLevel
+	if infoLogging {
+		errLogLevel = log.InfoLevel
+	}
 	return &ShRecipeExecutor{
 		Stdin:  os.Stdin,
-		Stdout: writer,
-		Stderr: writer,
+		Stdout: config.Logger.WriterLevel(log.DebugLevel),
+		Stderr: config.Logger.WriterLevel(errLogLevel),
 	}
 }
 

--- a/internal/install/execution/sh_recipe_executor_test.go
+++ b/internal/install/execution/sh_recipe_executor_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestExecutePreInstall_Basic(t *testing.T) {
-	e := NewShRecipeExecutor()
+	e := NewShRecipeExecutor(false)
 	b := bytes.NewBufferString("")
 	e.Stdout = b
 
@@ -29,7 +29,7 @@ func TestExecutePreInstall_Basic(t *testing.T) {
 }
 
 func TestExecutePreInstall_Error(t *testing.T) {
-	e := NewShRecipeExecutor()
+	e := NewShRecipeExecutor(false)
 	b := bytes.NewBufferString("")
 	e.Stdout = b
 
@@ -46,7 +46,7 @@ func TestExecutePreInstall_Error(t *testing.T) {
 }
 
 func TestExecutePreInstall_RecipeVars(t *testing.T) {
-	e := NewShRecipeExecutor()
+	e := NewShRecipeExecutor(false)
 	b := bytes.NewBufferString("")
 	e.Stdout = b
 
@@ -65,7 +65,7 @@ func TestExecutePreInstall_RecipeVars(t *testing.T) {
 }
 
 func TestExecutePreInstall_EnvVars(t *testing.T) {
-	e := NewShRecipeExecutor()
+	e := NewShRecipeExecutor(false)
 	b := bytes.NewBufferString("")
 	e.Stdout = b
 
@@ -83,7 +83,7 @@ func TestExecutePreInstall_EnvVars(t *testing.T) {
 }
 
 func TestExecutePreInstall_AllVars(t *testing.T) {
-	e := NewShRecipeExecutor()
+	e := NewShRecipeExecutor(false)
 	b := bytes.NewBufferString("")
 	e.Stdout = b
 

--- a/internal/install/recipes/recipe_filter_runner.go
+++ b/internal/install/recipes/recipe_filter_runner.go
@@ -26,7 +26,7 @@ func NewRecipeFilterRunner(ic types.InstallerContext, s *execution.InstallStatus
 		installStatus: s,
 		availablilityFilters: []RecipeFilterer{
 			NewProcessMatchRecipeFilterer(),
-			NewScriptEvaluationRecipeFilterer(s),
+			NewScriptEvaluationRecipeFilterer(s, ic.RecipesProvided()),
 		},
 		userSkippedFilters: []RecipeFilterer{
 			skipFilter,
@@ -133,8 +133,8 @@ type ScriptEvaluationRecipeFilterer struct {
 	installStatus  *execution.InstallStatus
 }
 
-func NewScriptEvaluationRecipeFilterer(installStatus *execution.InstallStatus) *ScriptEvaluationRecipeFilterer {
-	recipeExecutor := execution.NewShRecipeExecutor()
+func NewScriptEvaluationRecipeFilterer(installStatus *execution.InstallStatus, infoLogging bool) *ScriptEvaluationRecipeFilterer {
+	recipeExecutor := execution.NewShRecipeExecutor(infoLogging)
 
 	return &ScriptEvaluationRecipeFilterer{
 		recipeExecutor: recipeExecutor,


### PR DESCRIPTION
### Use case
As a customer installing a particular recipe, I want to know why the recipe is unsupported. With the current behaviour (logging stdout and stderr to debug), customers do not get any indication of why their installation is unsupported.

### Current output
![image](https://user-images.githubusercontent.com/7886905/138443424-0c86eb46-69a3-4a63-863d-09e28f6479ef.png)

### Output after the change
![image](https://user-images.githubusercontent.com/7886905/138443504-4e434a78-9845-48e0-99f0-2f0ee7c0b370.png)

