### PR TITLE
chore(release): use GitHub Actions UI to trigger release workflow via `workflow_dispatch` event 

### DIFF
--- a/.github/workflows/e2e-eu.yml
+++ b/.github/workflows/e2e-eu.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Release workflow calls this workflow
+  workflow_call:
 
 jobs:
   validate-all:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Release workflow calls this workflow
+  workflow_call:
 
 jobs:
   validate-all:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,18 @@
 name: Release
 
+permissions: write-all
+
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: New release version
+        # NOTE...
+        #
+        # TBD: If we make this required, we won't need to do
+        # the automated version bump with svu and gobump
+        required: false
+        default: x.x.x
 
 jobs:
   release:
@@ -42,7 +51,13 @@ jobs:
           SNAPCRAFT_TOKEN: ${{ secrets.SNAPCRAFT_TOKEN }}
           SPLIT_PROD_KEY: ${{ secrets.SPLIT_PROD_KEY }}
           SPLIT_STAGING_KEY: ${{ secrets.SPLIT_STAGING_KEY }}
-        run: make release-publish
+        run: |
+          git config --global user.name nr-developer-toolkit
+          git config --global user.email 62031461+nr-developer-toolkit@users.noreply.github.com
+
+          ./scripts/release.sh
+
+          make release-publish
 
       - id: get-version
         uses: battila7/get-version-action@v2.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,8 @@ jobs:
           SPLIT_PROD_KEY: ${{ secrets.SPLIT_PROD_KEY }}
           SPLIT_STAGING_KEY: ${{ secrets.SPLIT_STAGING_KEY }}
         run: |
-          git config --global user.name nr-developer-toolkit
-          git config --global user.email 62031461+nr-developer-toolkit@users.noreply.github.com
+          git config --global user.name ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_USERNAME }}
+          git config --global user.email ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_EMAIL }}
 
           ./scripts/release.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,24 @@ name: Release
 
 permissions: write-all
 
+# Triggered via GitHub Actions UI
 on:
   workflow_dispatch:
-    inputs:
-      version:
-        description: New release version
-        # NOTE...
-        #
-        # TBD: If we make this required, we won't need to do
-        # the automated version bump with svu and gobump
-        required: false
-        default: x.x.x
 
 jobs:
+  test:
+    if: github.ref == 'refs/heads/main'
+    uses: newrelic/newrelic-cli/.github/workflows/test.yml@main
+  e2e:
+    if: github.ref == 'refs/heads/main'
+    uses: newrelic/newrelic-cli/.github/workflows/e2e.yml@main
+  e2e-eu:
+    if: github.ref == 'refs/heads/main'
+    uses: newrelic/newrelic-cli/.github/workflows/e2e-eu.yml@main
+
   release:
+    if: github.ref == 'refs/heads/main'
+    needs: [test, e2e, e2e-eu]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -32,6 +36,7 @@ jobs:
         with:
           # Needed for release notes
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1
@@ -45,7 +50,7 @@ jobs:
       - name: Publish Release
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.DEV_TOOLKIT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           SNAPCRAFT_TOKEN: ${{ secrets.SNAPCRAFT_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Release workflow calls this workflow
+  workflow_call:
 
 jobs:
   lint:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,8 +21,6 @@ VER_CMD=${GOBIN}/svu
 VER_BUMP=${GOBIN}/gobump
 CHANGELOG_CMD=${GOBIN}/git-chglog
 CHANGELOG_FILE=CHANGELOG.md
-REL_CMD=${GOBIN}/goreleaser
-RELEASE_NOTES_FILE=${SRCDIR}/tmp/relnotes.md
 SPELL_CMD=${GOBIN}/misspell
 
 # Compare versions

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,32 +2,58 @@
 
 COLOR_RED='\033[0;31m'
 COLOR_NONE='\033[0m'
+
+DEFAULT_BRANCH='main'
 CURRENT_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
 if [ $CURRENT_GIT_BRANCH != 'main' ]; then
   printf "\n"
-  printf "${COLOR_RED} Error: The release.sh script must be run while on the main branch. \n ${COLOR_NONE}"
+  printf "${COLOR_RED} Error: Must be on main branch to create a new release. \n ${COLOR_NONE}"
   printf "\n"
 
   exit 1
 fi
 
-if [ $# -ne 1 ]; then
-  printf "\n"
-  printf "${COLOR_RED} Error: Release version argument required. \n\n ${COLOR_NONE}"
-  printf " Example: \n\n    ./tools/release.sh 0.9.0 \n\n"
-  printf "  Example (make): \n\n    make release version=0.9.0 \n"
-  printf "\n"
+SRCDIR=${SRCDIR:-"."}
+GOBIN=$(go env GOPATH)/bin
+VER_PACKAGE="internal/version"
+VER_CMD=${GOBIN}/svu
+VER_BUMP=${GOBIN}/gobump
+CHANGELOG_CMD=${GOBIN}/git-chglog
+CHANGELOG_FILE=CHANGELOG.md
+REL_CMD=${GOBIN}/goreleaser
+RELEASE_NOTES_FILE=${SRCDIR}/tmp/relnotes.md
+SPELL_CMD=${GOBIN}/misspell
 
+# Compare versions
+VER_CURR=$(${VER_CMD} current --strip-prefix)
+VER_NEXT=$(${VER_CMD} next --strip-prefix)
+
+echo " "
+echo "Comparing tag versions..."
+echo "Current version: ${VER_CURR}"
+echo "Next version:    ${VER_NEXT}"
+echo " "
+
+if [ "${VER_CURR}" = "${VER_NEXT}" ]; then
+  echo "No new version recommended, exiting"
+  exit 0
+fi
+
+GIT_USER=$(git config user.name)
+GIT_EMAIL=$(git config user.email)
+
+if [ -z "${GIT_USER}" ]; then
+  echo "git user.name not set"
   exit 1
 fi
 
-RELEASE_VERSION=$1
-GIT_USER=$(git config user.email)
+if [ -z "${GIT_EMAIL}" ]; then
+  echo "git user.email not set"
+  exit 1
+fi
 
-echo "Generating release for v${RELEASE_VERSION} using system user git user ${GIT_USER}"
-
-git checkout -b release/v${RELEASE_VERSION}
+echo "Generating release for v${VER_NEXT} with git user ${GIT_USER}"
 
 # Auto-generate CLI documentation
 NATIVE_OS=$(go version | awk -F '[ /]' '{print $4}')
@@ -36,15 +62,32 @@ if [ -x "bin/${NATIVE_OS}/newrelic" ]; then
    mkdir -p docs/cli
    bin/${NATIVE_OS}/newrelic documentation --outputDir docs/cli/ --format markdown
    git add docs/cli/*
-   git commit -m "chore(docs): Regenerate CLI docs for v${RELEASE_VERSION}"
+
+   # Commit generated docs
+   git commit --no-verify -m "chore(docs): regenerate CLI docs for v${VER_NEXT}"
 fi
 
 # Auto-generate CHANGELOG updates
-git-chglog --next-tag v${RELEASE_VERSION} -o CHANGELOG.md --sort semver
+${CHANGELOG_CMD} --next-tag v${VER_NEXT} -o ${CHANGELOG_FILE}
+
 # Fix any spelling issues in the CHANGELOG
-misspell -source text -w CHANGELOG.md
+${SPELL_CMD} -source text -w ${CHANGELOG_FILE}
 
 # Commit CHANGELOG updates
 git add CHANGELOG.md
-git commit -m "chore(changelog): Update CHANGELOG for v${RELEASE_VERSION}"
-git push origin release/v${RELEASE_VERSION}
+git commit --no-verify -m "chore(changelog): update CHANGELOG for v${VER_NEXT}"
+git push --no-verify origin HEAD:${DEFAULT_BRANCH}
+
+if [ $? -ne 0 ]; then
+  echo "Failed to push branch updates, exiting"
+  exit 1
+fi
+
+# Create and push new tag
+git tag v${VER_NEXT}
+git push --no-verify origin HEAD:${DEFAULT_BRANCH} --tags
+
+if [ $? -ne 0 ]; then
+  echo "Failed to push tag, exiting"
+  exit $?
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -24,8 +24,8 @@ CHANGELOG_FILE=CHANGELOG.md
 SPELL_CMD=${GOBIN}/misspell
 
 # Compare versions
-VER_CURR=$(${VER_CMD} current --strip-prefix)
-VER_NEXT=$(${VER_CMD} next --strip-prefix)
+VER_CURR=$(${VER_CMD} current)
+VER_NEXT=$(${VER_CMD} next)
 
 echo " "
 echo "Comparing tag versions..."
@@ -51,7 +51,7 @@ if [ -z "${GIT_EMAIL}" ]; then
   exit 1
 fi
 
-echo "Generating release for v${VER_NEXT} with git user ${GIT_USER}"
+echo "Generating release for ${VER_NEXT} with git user ${GIT_USER}"
 
 # Auto-generate CLI documentation
 NATIVE_OS=$(go version | awk -F '[ /]' '{print $4}')
@@ -62,18 +62,18 @@ if [ -x "bin/${NATIVE_OS}/newrelic" ]; then
    git add docs/cli/*
 
    # Commit generated docs
-   git commit --no-verify -m "chore(docs): regenerate CLI docs for v${VER_NEXT}"
+   git commit --no-verify -m "chore(docs): regenerate CLI docs for ${VER_NEXT}"
 fi
 
 # Auto-generate CHANGELOG updates
-${CHANGELOG_CMD} --next-tag v${VER_NEXT} -o ${CHANGELOG_FILE}
+${CHANGELOG_CMD} --next-tag ${VER_NEXT} -o ${CHANGELOG_FILE}
 
 # Fix any spelling issues in the CHANGELOG
 ${SPELL_CMD} -source text -w ${CHANGELOG_FILE}
 
 # Commit CHANGELOG updates
 git add ${CHANGELOG_FILE}
-git commit --no-verify -m "chore(changelog): update CHANGELOG for v${VER_NEXT}"
+git commit --no-verify -m "chore(changelog): update CHANGELOG for ${VER_NEXT}"
 git push --no-verify origin HEAD:${DEFAULT_BRANCH}
 
 if [ $? -ne 0 ]; then
@@ -82,7 +82,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Create and push new tag
-git tag v${VER_NEXT}
+git tag ${VER_NEXT}
 git push --no-verify origin HEAD:${DEFAULT_BRANCH} --tags
 
 if [ $? -ne 0 ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -72,7 +72,7 @@ ${CHANGELOG_CMD} --next-tag v${VER_NEXT} -o ${CHANGELOG_FILE}
 ${SPELL_CMD} -source text -w ${CHANGELOG_FILE}
 
 # Commit CHANGELOG updates
-git add CHANGELOG.md
+git add ${CHANGELOG_FILE}
 git commit --no-verify -m "chore(changelog): update CHANGELOG for v${VER_NEXT}"
 git push --no-verify origin HEAD:${DEFAULT_BRANCH}
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,7 +35,7 @@ echo " "
 
 if [ "${VER_CURR}" = "${VER_NEXT}" ]; then
   echo "No new version recommended, exiting"
-  exit 0
+  exit 1
 fi
 
 GIT_USER=$(git config user.name)


### PR DESCRIPTION
🤖 **New releases will be created via the GitHub Actions UI** 🤖 

![manually-trigger-release-workflow](https://user-images.githubusercontent.com/2590905/139956594-312ebec9-f523-4f54-b129-2beca7142075.jpg)

**Checklist**
- [x] Cutting a new release is triggered from the GitHub Actions UI, which triggers the `workflow_dispatch` event
- [x] Release job is dependent on all tests and workflows passing (especially the end to end tests)
- [x] New tag version is automatically bumped based semantic commits using [**svu**](https://github.com/caarlos0/svu)
- [x] CHANGELOG is properly added to the release with the latest release notes
- [x] Document release flow
- [x] Ensure latest open-install-library is pulled