### PR TITLE
chore(install): Update install summary data link

### DIFF
--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -43,7 +43,6 @@ type InstallStatus struct {
 	statusSubscriber      []StatusSubscriber
 	successLinkConfig     types.OpenInstallationSuccessLinkConfig
 	PlatformLinkGenerator LinkGenerator
-	recipesSelected       []types.OpenInstallationRecipe
 }
 
 type RecipeStatus struct {
@@ -147,16 +146,6 @@ func (s *InstallStatus) RecipeAvailable(event RecipeStatusEvent) {
 	s.withRecipeEvent(event, RecipeStatusTypes.AVAILABLE)
 	for _, ss := range s.statusSubscriber {
 		if err := ss.RecipeAvailable(s, event); err != nil {
-			log.Debugf("Could not report recipe execution status: %s", err)
-		}
-	}
-}
-
-func (s *InstallStatus) RecipesSelected(recipes []types.OpenInstallationRecipe) {
-	s.recipesSelected = recipes
-
-	for _, r := range s.statusSubscriber {
-		if err := r.RecipesSelected(s, recipes); err != nil {
 			log.Debugf("Could not report recipe execution status: %s", err)
 		}
 	}
@@ -309,15 +298,6 @@ func (s *InstallStatus) hasAnyRecipeStatus(status RecipeStatusType) bool {
 	}
 
 	return false
-}
-
-func (s *InstallStatus) AllSelectedRecipesInstalled() bool {
-	installedCount := len(s.Installed)
-	if installedCount == 0 {
-		return false
-	}
-
-	return installedCount == len(s.recipesSelected)
 }
 
 func (s *InstallStatus) SetTargetedInstall() {

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -52,7 +52,12 @@ func (g *PlatformLinkGenerator) GenerateLoggingLink(entityGUID string) string {
 // also provided in the nerdstorage document. This provides the user two options
 // to see their data - click from the CLI output or from the frontend.
 func (g *PlatformLinkGenerator) GenerateRedirectURL(status InstallStatus) string {
-	if status.AllSelectedRecipesInstalled() {
+	installedCount := len(status.Installed)
+	haveFailure := status.HasUnsupportedRecipes && status.HasFailedRecipes
+	fmt.Printf("install = %+v\n", installedCount)
+
+	// if don't have failure and only one installed, and we have entity GUID, also generate  entity link
+	if !haveFailure && installedCount == 1 && len(status.EntityGUIDs) == 1 {
 		return g.GenerateEntityLink(status.HostEntityGUID())
 	}
 

--- a/internal/install/execution/platform_link_generator_test.go
+++ b/internal/install/execution/platform_link_generator_test.go
@@ -4,6 +4,7 @@
 package execution
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -14,170 +15,138 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/utils"
 )
 
-func TestGenerateRedirectURL_InstallSuccess(t *testing.T) {
+func TestGenerateRedirectURL_ShouldGenerateEntityLinkWhenOneInstalledWithNoFailure(t *testing.T) {
 	t.Parallel()
 
-	g := NewPlatformLinkGenerator()
-	// We set an API key in the unit test so we don't make an real HTTP request
-	// to the New Relic short URL service (see integration test), and so we can test
-	// the query param being added for the fallback installation strategy below.
-	g.apiKey = ""
-
 	recipeName := "infrastructure-agent-installer"
-	entityGUID := "ABC123"
-	recipe := types.OpenInstallationRecipe{
-		Name:        recipeName,
-		DisplayName: "Infrastructure Agent",
-	}
-	recipeStatus := &RecipeStatus{
-		DisplayName: "Infrastructure Agent",
-		Name:        recipeName,
-		Status:      RecipeStatusTypes.INSTALLED,
-		EntityGUID:  entityGUID,
-	}
-	installStatus := InstallStatus{
-		recipesSelected: []types.OpenInstallationRecipe{recipe},
-		Installed:       []*RecipeStatus{recipeStatus},
-		EntityGUIDs:     []string{entityGUID},
-	}
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(recipeName, "Installed")
+	g, s := b.build()
 
-	expectedURL := fmt.Sprintf("https://%s/redirect/entity/%s", nrPlatformHostname(), entityGUID)
-	result := g.GenerateRedirectURL(installStatus)
+	expectedURL := fmt.Sprintf("https://%s/redirect/entity/%s", nrPlatformHostname(), recipeName)
+
+	result := g.GenerateRedirectURL(*s)
+	require.Equal(t, 1, len(s.EntityGUIDs))
+	require.Equal(t, 1, len(s.Installed))
 	require.Equal(t, expectedURL, result)
+}
+
+func TestGenerateRedirectURL_ShoudGenerateStatusLinkWhenMoreThanOneInstalled(t *testing.T) {
+	t.Parallel()
+
+	infraName := "infrastructure-agent-installer"
+	loggingName := "Log-integration"
+
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(infraName, "Installed")
+	b.recipeStatusUpdate(loggingName, "Installed")
+	g, s := b.build()
+
+	result := g.GenerateRedirectURL(*s)
+	require.Contains(t, result, "explorer")
 }
 
 func TestGenerateLoggingURL_InstallSuccess(t *testing.T) {
 	t.Parallel()
 
-	g := NewPlatformLinkGenerator()
+	rName := "MXxBUE18QVBQTElDQVRJT058OTE2NzQxNg"
+	loggingName := "Log-integration"
 
-	// We set an API key in the unit test so we don't make an real HTTP request
-	// to the New Relic short URL service (see integration test), and so we can test
-	// the query param being added for the fallback installation strategy below.
-	g.apiKey = ""
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(rName, "Installed")
+	b.recipeStatusUpdate(loggingName, "Installed")
+	g, s := b.build()
 	accountID := configAPI.GetActiveProfileAccountID()
 
-	infraEntityGUID := "MXxBUE18QVBQTElDQVRJT058OTE2NzQxNg"
-	infraRecipe := types.OpenInstallationRecipe{
-		Name:        "infrastructure-agent-installer",
-		DisplayName: "Infrastructure Agent",
-	}
-	logsRecipe := types.OpenInstallationRecipe{
-		Name:        "logs-integration",
-		DisplayName: "Logs integration",
-	}
-	agentInstalledStatus := &RecipeStatus{
-		DisplayName: "Infrastructure Agent",
-		Name:        "infrastructure-agent-installer",
-		Status:      RecipeStatusTypes.INSTALLED,
-		EntityGUID:  infraEntityGUID,
-	}
-	logsInstalledStatus := &RecipeStatus{
-		DisplayName: "Logs integration",
-		Name:        "logs-integration",
-		Status:      RecipeStatusTypes.INSTALLED,
-	}
-	installStatus := InstallStatus{
-		recipesSelected: []types.OpenInstallationRecipe{infraRecipe, logsRecipe},
-		Installed:       []*RecipeStatus{agentInstalledStatus, logsInstalledStatus},
-		EntityGUIDs:     []string{infraEntityGUID},
-		Statuses:        []*RecipeStatus{agentInstalledStatus, logsInstalledStatus},
-	}
-
 	launcherEncodedParams := "eyJxdWVyeSI6IlwiZW50aXR5Lmd1aWQuSU5GUkFcIjpcIk1YeEJVRTE4UVZCUVRFbERRVlJKVDA1OE9URTJOelF4TmdcIiIsInJlZmVycmVyIjoibmV3cmVsaWMtY2xpIn0="
-	expectedRedirectURL := fmt.Sprintf("https://%s/redirect/entity/%s", nrPlatformHostname(), infraEntityGUID)
 	expectedLoggingLink := fmt.Sprintf("https://%s/launcher/logger.log-launcher?platform[accountId]=%d&launcher=%s", nrPlatformHostname(), accountID, launcherEncodedParams)
 
-	redirectURLResult := g.GenerateRedirectURL(installStatus)
-	loggingLinkResult := g.GenerateLoggingLink(infraEntityGUID)
-	require.Contains(t, redirectURLResult, expectedRedirectURL)
+	redirectURLResult := g.GenerateRedirectURL(*s)
+	loggingLinkResult := g.GenerateLoggingLink(rName)
+	require.Contains(t, redirectURLResult, "explorer")
 	require.Contains(t, loggingLinkResult, expectedLoggingLink)
 }
 
 func TestGenerateRedirectURL_InstallPartialSuccess(t *testing.T) {
 	t.Parallel()
 
-	g := NewPlatformLinkGenerator()
-	// We set an API key in the unit test so we don't make an real HTTP request
-	// to the New Relic short URL service (see integration test), and so we can test
-	// the query param being added for the fallback installation strategy below.
-	g.apiKey = ""
+	infraName := "infrastructure-agent-installer"
+	loggingName := "Log-integration"
 
-	infraEntityGUID := "ABC123"
-	infraRecipe := types.OpenInstallationRecipe{
-		Name:        "infrastructure-agent-installer",
-		DisplayName: "Infrastructure Agent",
-	}
-	logsRecipe := types.OpenInstallationRecipe{
-		Name:        "logs-integration",
-		DisplayName: "Logs integration",
-	}
-	installedRecipeStatus := &RecipeStatus{
-		DisplayName: "Infrastructure Agent",
-		Name:        "infrastructure-agent-installer",
-		Status:      RecipeStatusTypes.INSTALLED,
-		EntityGUID:  infraEntityGUID,
-	}
-	failedRecipeStatus := &RecipeStatus{
-		DisplayName: "Logs integration",
-		Name:        "logs-integration",
-		Status:      RecipeStatusTypes.FAILED,
-	}
-	installStatus := InstallStatus{
-		recipesSelected: []types.OpenInstallationRecipe{infraRecipe, logsRecipe},
-		Installed:       []*RecipeStatus{installedRecipeStatus},
-		Failed:          []*RecipeStatus{failedRecipeStatus},
-		EntityGUIDs:     []string{infraEntityGUID},
-		Statuses:        []*RecipeStatus{installedRecipeStatus, failedRecipeStatus},
-	}
-	expectedEncodedQueryParamSubstring := utils.Base64Encode(g.generateReferrerParam(infraEntityGUID))
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(infraName, "Installed")
+	b.recipeStatusUpdate(loggingName, "Installed")
+	g, s := b.build()
 
-	result := g.GenerateRedirectURL(installStatus)
+	result := g.GenerateRedirectURL(*s)
+	expectedEncodedQueryParamSubstring := utils.Base64Encode(g.generateReferrerParam(infraName))
+
 	require.Contains(t, result, expectedEncodedQueryParamSubstring)
 }
 
 func TestGenerateRedirectURL_InstallFailed(t *testing.T) {
 	t.Parallel()
 
-	g := NewPlatformLinkGenerator()
-	// We set an API key in the unit test so we don't make an real HTTP request
-	// to the New Relic short URL service (see integration test), and so we can test
-	// the query param being added for the fallback installation strategy below.
-	g.apiKey = ""
+	infraName := "infrastructure-agent-installer"
 
-	infraRecipe := types.OpenInstallationRecipe{
-		Name:        "infrastructure-agent-installer",
-		DisplayName: "Infrastructure Agent",
-	}
-	failedRecipeStatus := &RecipeStatus{
-		DisplayName: "Infrastructure Agent",
-		Name:        "infrastructure-agent-installer",
-		Status:      RecipeStatusTypes.FAILED,
-	}
-	installStatus := InstallStatus{
-		recipesSelected: []types.OpenInstallationRecipe{infraRecipe},
-		Failed:          []*RecipeStatus{failedRecipeStatus},
-		Statuses:        []*RecipeStatus{failedRecipeStatus},
-	}
-	expectedEncodedQueryParamSubstring := "eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5pbnN0YWxsYXRpb24tcGxhbiIsInJlZmVycmVyIjoibmV3cmVsaWMtY2xpIn0="
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(infraName, "Failed")
+	g, s := b.build()
 
-	result := g.GenerateRedirectURL(installStatus)
-	require.Contains(t, result, expectedEncodedQueryParamSubstring)
+	result := g.GenerateRedirectURL(*s)
+	require.Contains(t, result, "explorer")
 }
 
 func TestGenerateRedirectURL_NoRecipesInstalled(t *testing.T) {
 	t.Parallel()
 
-	g := NewPlatformLinkGenerator()
-	// We unset the API key in the unit test so we don't make
-	// an HTTP request to the New Relic short URL service and
-	// so we can test the referrer param being added for the fallback
-	// installation strategy.
-	g.apiKey = ""
+	b := newPlatformLinkGeneratorBuilder()
+	g, s := b.build()
 
-	installStatus := InstallStatus{}
-	expectedEncodedQueryParamSubstring := "eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5pbnN0YWxsYXRpb24tcGxhbiIsInJlZmVycmVyIjoibmV3cmVsaWMtY2xpIn0="
+	result := g.GenerateRedirectURL(*s)
+	require.Contains(t, result, "explorer")
+}
 
-	result := g.GenerateRedirectURL(installStatus)
-	require.Contains(t, result, expectedEncodedQueryParamSubstring)
+type platformLinkGeneratorBuilder struct {
+	platformLinkGenerator *PlatformLinkGenerator
+	installStatus         *InstallStatus
+}
+
+func newPlatformLinkGeneratorBuilder() *platformLinkGeneratorBuilder {
+	p := &platformLinkGeneratorBuilder{
+		platformLinkGenerator: NewPlatformLinkGenerator(),
+	}
+
+	p.installStatus = NewInstallStatus(make([]StatusSubscriber, 0), p.platformLinkGenerator)
+	// We set an API key in the unit test so we don't make an real HTTP request
+	// to the New Relic short URL service (see integration test), and so we can test
+	// the query param being added for the fallback installation strategy below.
+	p.platformLinkGenerator.apiKey = ""
+	return p
+}
+
+func (p *platformLinkGeneratorBuilder) recipeStatusUpdate(rn, status string) *platformLinkGeneratorBuilder {
+
+	r := types.OpenInstallationRecipe{
+		Name: rn,
+	}
+
+	infraInstallEvent := RecipeStatusEvent{
+		EntityGUID: rn,
+		Recipe:     r,
+	}
+
+	switch status {
+	case "Failed":
+		p.installStatus.RecipeFailed(infraInstallEvent)
+	case "Installed":
+		p.installStatus.RecipeInstalled(infraInstallEvent)
+	}
+
+	return p
+}
+
+func (p *platformLinkGeneratorBuilder) build() (*PlatformLinkGenerator, *InstallStatus) {
+	p.installStatus.completed(errors.New(""))
+	return p.platformLinkGenerator, p.installStatus
 }

--- a/internal/install/execution/recipe_var_provider.go
+++ b/internal/install/execution/recipe_var_provider.go
@@ -206,6 +206,7 @@ func varFromEnv() types.RecipeVars {
 	vars["NEW_RELIC_DOWNLOAD_URL"] = downloadURL
 
 	vars["NEW_RELIC_CLI_LOG_FILE_PATH"] = config.GetDefaultLogFilePath()
+	vars["NR_CLI_CLUSTERNAME"] = os.Getenv("NR_CLI_CLUSTERNAME")
 
 	return vars
 }

--- a/internal/install/interfaces.go
+++ b/internal/install/interfaces.go
@@ -56,8 +56,8 @@ type RecipeInstaller interface {
 	install(ctx context.Context) error
 	assertDiscoveryValid(ctx context.Context, m *types.DiscoveryManifest) error
 	discover(ctx context.Context) (*types.DiscoveryManifest, error)
-	executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, vars types.RecipeVars) (string, error)
-	validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest, vars types.RecipeVars) (string, error)
+	executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, vars types.RecipeVars, assumeYes bool) (string, error)
+	validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest, vars types.RecipeVars, assumeYes bool) (string, error)
 	executeAndValidateWithProgress(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, assumeYes bool) (string, error)
 }
 

--- a/internal/install/mock_recipe_installer.go
+++ b/internal/install/mock_recipe_installer.go
@@ -33,12 +33,12 @@ func (mri *mockRecipeInstaller) discover(ctx context.Context) (*types.DiscoveryM
 	return nil, args.Error(1)
 }
 
-func (mri *mockRecipeInstaller) executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, vars types.RecipeVars) (string, error) {
+func (mri *mockRecipeInstaller) executeAndValidate(ctx context.Context, m *types.DiscoveryManifest, r *types.OpenInstallationRecipe, vars types.RecipeVars, assumeYes bool) (string, error) {
 	args := mri.Called(ctx, m, r, vars)
 	return args.String(0), args.Error(1)
 }
 
-func (mri *mockRecipeInstaller) validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest, vars types.RecipeVars) (string, error) {
+func (mri *mockRecipeInstaller) validateRecipeViaAllMethods(ctx context.Context, r *types.OpenInstallationRecipe, m *types.DiscoveryManifest, vars types.RecipeVars, assumeYes bool) (string, error) {
 	args := mri.Called(ctx, r, m, vars)
 	return args.String(0), args.Error(1)
 }

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -313,7 +313,7 @@ func TestExecuteAndValidateWithProgressWhenInstallWithNoValidationMethod(t *test
 func TestExecuteAndValidateRecipeWithAllMethodWithNoValidationMethods(t *testing.T) {
 	recipeInstall := NewRecipeInstallBuilder().Build()
 
-	entityGUID, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipes.NewRecipeBuilder().Name("").Build(), &types.DiscoveryManifest{}, nil)
+	entityGUID, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipes.NewRecipeBuilder().Name("").Build(), &types.DiscoveryManifest{}, nil, false)
 
 	assert.NoError(t, err)
 	assert.Equal(t, "", entityGUID)
@@ -325,7 +325,7 @@ func TestExecuteAndValidateRecipeWithAllMethodWithAgentValidatorError(t *testing
 	recipe := recipes.NewRecipeBuilder().Name("").Build()
 	recipe.ValidationURL = "http://url.com"
 
-	_, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipe, &types.DiscoveryManifest{}, nil)
+	_, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipe, &types.DiscoveryManifest{}, nil, false)
 
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), expected.Error()))
@@ -338,7 +338,7 @@ func TestExecuteAndValidateRecipeWithAllMethodWithRecipeValidationError(t *testi
 	recipe := recipes.NewRecipeBuilder().Name("").Build()
 	recipe.ValidationNRQL = "FROM SOMETHING"
 
-	_, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipe, &types.DiscoveryManifest{}, nil)
+	_, err := recipeInstall.validateRecipeViaAllMethods(context.TODO(), recipe, &types.DiscoveryManifest{}, nil, false)
 
 	assert.Error(t, err)
 	assert.True(t, strings.Contains(err.Error(), expected.Error()))


### PR DESCRIPTION
* Update so only a Single install would generate a entity link,
  otherwise alwasys show status summary (fix for k8s)
* Remove select feature from install status, it's no longer
  Need after last CLI flow changes
* Update tests