### PR TITLE
fix(install): allow CLI installation on new Macs w/ M1 chip

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,7 +24,7 @@ fi
 
 if [ "$(uname -m)" == "x86_64" ]; then
     MACHINE="x86_64"
-elif [ "$(uname -m)" == "aarch64" ]; then
+elif [ "$(uname -m)" == "aarch64" ] || [ "$(uname -m)" == "arm64" ]; then
     MACHINE="arm64"
 elif [ "$(uname -m)" == "armv7l" ]; then
     MACHINE="armv7"


### PR DESCRIPTION
Printing out the name of the machine hardware via `uname -m` on the new M1 chip MacBooks outputs `arm64`, thus we need to include a check for this in the install script.

<img width="424" alt="Screen Shot 2022-04-01 at 5 06 02 PM" src="https://user-images.githubusercontent.com/2590905/161347336-ebbc04c2-49ab-4080-ae3b-e20f4d65cbe4.png">

FIxes #1250 