### PR TITLE
feat(install): add padding to highlighted text for better legibility

### DIFF
--- a/internal/install/ux/spinner_progress_indicator.go
+++ b/internal/install/ux/spinner_progress_indicator.go
@@ -100,7 +100,7 @@ func printInstallFinalMessage(printText string, bgColor color.Attribute) {
 	boldWhite := white.Add(color.Bold)
 	background := boldWhite.Add(bgColor)
 	fmt.Print("  ")
-	background.Print(printText)
+	background.Print(fmt.Sprintf(" %s ", printText))
 	fmt.Println()
 }
 


### PR DESCRIPTION
The PR improves the legibility and UX of the highlighted install status text by adding padding (whitespace) to the highlighted output (see screenshots).

![Screen_Shot_2022-04-15_at_11_21_46_AM](https://user-images.githubusercontent.com/2590905/163596068-efe77526-fdef-49ee-96f8-76a0b9e62efa.jpg) <br>
![Screen_Shot_2022-04-15_at_11_24_47_AM](https://user-images.githubusercontent.com/2590905/163596072-c8bfc5f8-8209-45bf-81cf-6bc8e7e1155b.jpg) <br>
![Screen_Shot_2022-04-15_at_11_22_00_AM](https://user-images.githubusercontent.com/2590905/163596070-db5c5f41-e7ff-4747-b932-8983203daa6e.jpg) <br>
![Screen_Shot_2022-04-15_at_11_25_22_AM](https://user-images.githubusercontent.com/2590905/163596076-ef573367-e1f4-4ea2-8a15-a69881edfcf5.jpg)
 