### PR TITLE
feat(envars-to-recipe):  Passing envars as yaml to recipe context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/briandowns/spinner v1.15.0
 	github.com/fatih/color v1.13.0
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-task/task/v3 v3.11.0
 	github.com/google/uuid v1.3.0
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/frankban/quicktest v1.13.1/go.mod h1:NeW+ay9A/U67EYXNFA1nPE8e/tnQv/09
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.2.6-0.20210321163835-bac9a21098b9 h1:jJbnXj03Jfx6sU+EEjk1J6tCUZN48K5/wqKtHYvpn4M=
 github.com/go-ole/go-ole v1.2.6-0.20210321163835-bac9a21098b9/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=


### PR DESCRIPTION
This PR considers both `NRIA_CUSTOM_ATTRIBUTES` and `NRIA_PASSTHROUGH_ENVIRONMENT` envars.  If either envar is present on the command line when running an install, they are parsed/added to the recipe context as yaml 'chunks'.  This allows us to update the recipe yaml to check for `{{.NRIA_CUSTOM_ATTRIBUTES}}` or `{{.NRIA_PASSTHROUGH_ENVIRONMENT}}` and append their values to `newrelic-infra.yml` without needing to transform data in bash.

Example output from a test EC2 instance - comparing `env` output to  `echo "{{.NRIA_CUSTOM_ATTRIBUTES}}"` and `echo "{{.NRIA_PASSTHROUGH_ENVIRONMENT}}"`

```
DEBUG NRIA_CUSTOM_ATTRIBUTES={"customAttribute_1":"SOME_ATTRIBUTE_YAY","customAttribute_2": "SOME_ATTRIBUTE_2"} 
DEBUG NRIA_PASSTHROUGH_ENVIRONMENT=one,two,three,fourteen 
DEBUG custom_attributes:                            
DEBUG   customAttribute_1: SOME_ATTRIBUTE_YAY      
DEBUG   customAttribute_2: SOME_ATTRIBUTE_2        
DEBUG passthrough_environment:                     
DEBUG - one                                        
DEBUG - two                                        
DEBUG - three                                      
DEBUG - fourteen                                   
```

custom_attributes:
https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#custom-attributes

passthrough_environment:
https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/configuration/infrastructure-agent-configuration-settings/#passthrough_-environment