### PR TITLE
chore(envars): check envar length prior to attempting yaml transformation

### DIFF
--- a/internal/install/execution/recipe_var_provider.go
+++ b/internal/install/execution/recipe_var_provider.go
@@ -209,8 +209,16 @@ func varFromEnv() types.RecipeVars {
 	vars["NEW_RELIC_DOWNLOAD_URL"] = downloadURL
 	vars["NEW_RELIC_CLI_LOG_FILE_PATH"] = config.GetDefaultLogFilePath()
 	vars["NR_CLI_CLUSTERNAME"] = os.Getenv("NR_CLI_CLUSTERNAME")
-	vars["NRIA_CUSTOM_ATTRIBUTES"] = yamlFromJSON(os.Getenv("NRIA_CUSTOM_ATTRIBUTES"))
-	vars["NRIA_PASSTHROUGH_ENVIRONMENT"] = yamlFromCommaDelimitedString(os.Getenv("NRIA_PASSTHROUGH_ENVIRONMENT"))
+
+	customAttributes := os.Getenv("NRIA_CUSTOM_ATTRIBUTES")
+	if len(customAttributes) > 0 {
+		vars["NRIA_CUSTOM_ATTRIBUTES"] = yamlFromJSON(customAttributes)
+	}
+
+	passthroughEnvironment := os.Getenv("NRIA_PASSTHROUGH_ENVIRONMENT")
+	if len(passthroughEnvironment) > 0 {
+		vars["NRIA_PASSTHROUGH_ENVIRONMENT"] = yamlFromCommaDelimitedString(passthroughEnvironment)
+	}
 
 	return vars
 }

--- a/internal/install/execution/recipe_var_provider_test.go
+++ b/internal/install/execution/recipe_var_provider_test.go
@@ -79,6 +79,8 @@ func TestRecipeVarProvider_Basic(t *testing.T) {
 	require.Contains(t, m.PlatformFamily, v["PlatformFamily"])
 	require.Contains(t, m.KernelArch, v["KernelArch"])
 	require.Contains(t, m.KernelVersion, v["KernelVersion"])
+	require.Equal(t, "", v["NRIA_CUSTOM_ATTRIBUTES"])
+	require.Equal(t, "", v["NRIA_PASSTHROUGH_ENVIRONMENT"])
 	require.Contains(t, "https://download.newrelic.com/", v["NEW_RELIC_DOWNLOAD_URL"])
 }
 
@@ -153,7 +155,7 @@ func TestRecipeVarProvider_CommandLineEnvarsDirectlyPassedToRecipeContext(t *tes
 	assert.Contains(t, m.PlatformFamily, v["PlatformFamily"])
 	assert.Contains(t, m.KernelArch, v["KernelArch"])
 	assert.Contains(t, m.KernelVersion, v["KernelVersion"])
-	assert.Equal(t, v["NEW_RELIC_DOWNLOAD_URL"], anotherDownloadURL)
+	assert.Equal(t, anotherDownloadURL, v["NEW_RELIC_DOWNLOAD_URL"])
 	assert.Contains(t, v["NEW_RELIC_CLI_LOG_FILE_PATH"], logFilePath)
 	assert.Equal(t, v["NR_CLI_CLUSTERNAME"], clusterName)
 }


### PR DESCRIPTION
Cuts down on verbose warning logs; still leaving length check within transformation methods