### PR TITLE
chore(install): Allow user continue to install even when core bundle

### DIFF
--- a/internal/install/bundler_builder.go
+++ b/internal/install/bundler_builder.go
@@ -12,22 +12,18 @@ func NewBundlerBuilder() *BundlerBuilder {
 }
 
 func (bb *BundlerBuilder) WithCoreRecipe(name string) *BundlerBuilder {
-	coreRecipes := []*recipes.BundleRecipe{
-		{
-			Recipe: recipes.NewRecipeBuilder().Name(name).Build(),
-		},
-	}
-	bb.coreRecipes = coreRecipes
+	bb.coreRecipes = append(bb.coreRecipes, &recipes.BundleRecipe{
+		Recipe: recipes.NewRecipeBuilder().Name(name).Build(),
+	})
+
 	return bb
 }
 
 func (bb *BundlerBuilder) WithAdditionalRecipe(name string) *BundlerBuilder {
-	additionalRecipes := []*recipes.BundleRecipe{
-		{
-			Recipe: recipes.NewRecipeBuilder().Name(name).Build(),
-		},
-	}
-	bb.additionalRecipes = additionalRecipes
+	bb.additionalRecipes = append(bb.additionalRecipes, &recipes.BundleRecipe{
+		Recipe: recipes.NewRecipeBuilder().Name(name).Build(),
+	})
+
 	return bb
 }
 

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -354,11 +354,7 @@ func (i *RecipeInstall) installCoreBundle(bundler RecipeBundler, bundleInstaller
 	if i.shouldInstallCore() {
 		coreBundle := bundler.CreateCoreBundle()
 		log.Debugf("Core bundle recipes:%s", coreBundle)
-		err := bundleInstaller.InstallStopOnError(coreBundle, true)
-		if err != nil {
-			log.Debugf("error installing core bundle:%s", err)
-			return err
-		}
+		bundleInstaller.InstallContinueOnError(coreBundle, true)
 	} else {
 		log.Debugf("Skipping core bundle")
 	}


### PR DESCRIPTION
APM can still be installed if the core bundle failed to install.  We want to allow users to continue attempt installing APM if the core bundle failed.