### PR TITLE
chore(release): pfx cert in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,17 +167,35 @@ jobs:
       - name: Compile installer
         run: msbuild .\build\package\msi\NewRelicCLIInstaller.sln
 
+      - name: Create PFX certificate
+        id: create-pfx
+        env:
+          PFX_CONTENT: ${{ secrets.PFX_BASE64_CONTENT }}
+        run: |
+          $pfxPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath "cert.pfx";
+          $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
+          Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
+          Write-Output "::set-output name=PFX_PATH::$pfxPath";
+
       - name: Sign installer
         env:
-          PFX_PASSWORD: ${{ secrets.PFX_PASSWORD }}
+          PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
         working-directory: .\build\package\msi\NewRelicCLIInstaller
         run: .\SignMSI.cmd
 
       - name: Sign install script
         env:
-          PFX_PASSWORD: ${{ secrets.PFX_PASSWORD }}
+          PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
         working-directory: .\
         run: .\build\package\msi\NewRelicCLIInstaller\SignPS1.cmd
+      
+      - name: Delete PFX certificate
+        env: 
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
+        run: |
+          Remove-Item -Path $env:PFX_PATH;
 
       - name: Get latest release upload URL
         id: get-latest-release-upload-url

--- a/build/package/msi/NewRelicCLIInstaller/SignMSI.cmd
+++ b/build/package/msi/NewRelicCLIInstaller/SignMSI.cmd
@@ -1,1 +1,1 @@
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f developer-toolkit.pfx /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com bin\x64\Release\NewRelicCLIInstaller.msi
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com bin\x64\Release\NewRelicCLIInstaller.msi

--- a/build/package/msi/NewRelicCLIInstaller/SignPS1.cmd
+++ b/build/package/msi/NewRelicCLIInstaller/SignPS1.cmd
@@ -1,1 +1,1 @@
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f .\build\package\msi\NewRelicCLIInstaller\developer-toolkit.pfx /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com .\scripts\install.ps1
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com .\scripts\install.ps1


### PR DESCRIPTION
In order to remove the current code signing PFX certificate from the repo, a new one was requested, and its base64 value was added to the GitHub secrets (as PFX_BASE64_CONTENT). This value along with the new certificate's password (PFX_CERT_PASSWORD) are now being used from inside the `release.yml` file. Two new steps were added in the `release.yml` workflow for `release-windows-installer` job to: 1) create the PFX certificate and then 2) delete the certificate, after the scripts signing is complete. This will help us to keep the certificate private, with no public exposure through the repo.