### PR TITLE
chore(release): test ps1 signing and using sha256

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,8 +188,8 @@ jobs:
         env:
           PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
           PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
-        working-directory: .\
-        run: .\build\package\msi\NewRelicCLIInstaller\SignPS1.cmd
+        working-directory: .\build\package\msi\NewRelicCLIInstaller
+        run: .\SignPS1.cmd
       
       - name: Delete PFX certificate
         env: 

--- a/build/package/msi/NewRelicCLIInstaller/SignMSI.cmd
+++ b/build/package/msi/NewRelicCLIInstaller/SignMSI.cmd
@@ -1,1 +1,1 @@
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com bin\x64\Release\NewRelicCLIInstaller.msi
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /fd SHA256 /t http://timestamp.digicert.com bin\x64\Release\NewRelicCLIInstaller.msi

--- a/build/package/msi/NewRelicCLIInstaller/SignPS1.cmd
+++ b/build/package/msi/NewRelicCLIInstaller/SignPS1.cmd
@@ -1,1 +1,1 @@
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /t http://timestamp.digicert.com .\scripts\install.ps1
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64\SignTool.exe" sign /f "%PFX_PATH%" /p "%PFX_PASSWORD%" /fd SHA256 /t http://timestamp.digicert.com .\scripts\install.ps1


### PR DESCRIPTION
The `.msi` file is signed with SHA1; `.ps1` file is not signed. Trying to fix this last one and improving by using SHA256.