### PR TITLE
Fix/sign newrelic exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           sudo mv dist/newrelic_windows_amd64_v1/newrelic.exe dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe
           osslsigncode sign -pkcs12 cert.pfx -pass "$PFX_PASSWORD" -h sha512 -t http://timestamp.digicert.com \
             -in dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe -out dist/newrelic_windows_amd64_v1/newrelic.exe
-          rm -f cert.pfx
+          rm -f cert.pfx dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe 
 
       - name: Checkout newrelic-forks/homebrew-core
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,7 +100,8 @@ jobs:
           echo "$PFX_CONTENT" | base64 -d > cert.pfx
           sudo apt-get install osslsigncode -y
           sudo mv dist/newrelic_windows_amd64_v1/newrelic.exe dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe
-          osslsigncode sign -pkcs12 cert.pfx -pass "$PFX_PASSWORD" -h sha512 -t http://timestamp.digicert.com -in newrelic-unsigned.exe -out newrelic.exe
+          osslsigncode sign -pkcs12 cert.pfx -pass "$PFX_PASSWORD" -h sha512 -t http://timestamp.digicert.com \
+            -in dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe -out dist/newrelic_windows_amd64_v1/newrelic.exe
           rm -f cert.pfx
 
       - name: Checkout newrelic-forks/homebrew-core

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,18 @@ jobs:
           name: windows-binary
           path: dist/newrelic_windows_amd64_v1/newrelic.exe
 
+      - name: Sign newrelic.exe
+        shell: bash
+        env:
+          PFX_CONTENT: ${{ secrets.PFX_BASE64_CONTENT }}
+          PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
+        run: |
+          echo "$PFX_CONTENT" | base64 -d > cert.pfx
+          sudo apt-get install osslsigncode -y
+          sudo mv dist/newrelic_windows_amd64_v1/newrelic.exe dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe
+          osslsigncode sign -pkcs12 cert.pfx -pass "$PFX_PASSWORD" -h sha512 -t http://timestamp.digicert.com -in newrelic-unsigned.exe -out newrelic.exe
+          rm -f cert.pfx
+
       - name: Checkout newrelic-forks/homebrew-core
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
To sign the `newrelic.exe` binary