### PR TITLE
chore(release): re-do windows zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,13 @@ jobs:
           sudo mv dist/newrelic_windows_amd64_v1/newrelic.exe dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe
           osslsigncode sign -pkcs12 cert.pfx -pass "$PFX_PASSWORD" -h sha512 -t http://timestamp.digicert.com \
             -in dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe -out dist/newrelic_windows_amd64_v1/newrelic.exe
-          rm -f cert.pfx dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe 
+          rm -f cert.pfx dist/newrelic_windows_amd64_v1/newrelic-unsigned.exe
+
+      - name: Re-do Windows_x86_64.zip
+        run: |
+          VERSION=$(ls dist/*Windows_x86_64.zip | cut -d_ -f2)
+          rm -f dist/newrelic-cli_${VERSION}_Windows_x86_64.zip
+          zip -q dist/newrelic-cli_${VERSION}_Windows_x86_64.zip dist/newrelic_windows_amd64_v1/newrelic.exe
 
       - name: Checkout newrelic-forks/homebrew-core
         uses: actions/checkout@v3


### PR DESCRIPTION
As I do not see how to sign the `newrelic.exe` for Windows from within `goreleaser` before zipping it, I am trying this approach:

- After `make release-publish` runs, delete the `dist/newrelic-cli_<VERSION>_Windows_x86_64.zip` archive that is produced by goreleaser.
- Then, get the version tag and generate that same zip `dist/newrelic-cli_<VERSION>_Windows_x86_64.zip` in a new job step via a linux `zip` command. By this time, the `newrelic.exe` that is compressed into that zip file is (should be) already signed.
- Finally, this file should be picked up by the later step that uploads everything to S3/Github (need to confirm).