### PR TITLE
fix(default config): comment out fetching of license key

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -63,9 +63,15 @@ func RequireClient(cmd *cobra.Command, args []string) {
 }
 
 func FetchLicenseKey(accountID int, profileName string) (string, error) {
-	client, err := NewClient(profileName)
-	if err != nil {
-		return "", err
+	var client *newrelic.NewRelic
+	var err error
+	if profileName == "" {
+		client = NRClient
+	} else {
+		client, err = NewClient(profileName)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	var key string


### PR DESCRIPTION
Reported that user had a default profile configured in `$HOME/.newrelic/` which _should_ have been considered when running install without specifying envars or `--profile <some-profile-name>`

Turns out a side-effect to asserting a valid profile is we rebuild a client object with an empty profile reference.  This causes a lookup for api and license keys to fail/remove what was there.

Solution is to reuse existing client object for install commands if no profile name is provided (presence of a non-nil client object is part of this commands `PreRun:` hook