### PR TITLE
feat: update infrastructure-agent debian gpg key path

### DIFF
--- a/internal/install/recipes/local_recipe_fetcher_test.go
+++ b/internal/install/recipes/local_recipe_fetcher_test.go
@@ -193,7 +193,7 @@ install:
       cmds:
         - |
           sudo apt-get install gnupg2 -y
-          sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+          sudo curl -s https://download.newrelic.com/infrastructure_agent/keys/newrelic_apt_key_current.gpg | sudo apt-key add -
       silent: true
 
     add_nr_source:


### PR DESCRIPTION
As part of a new strategy to rotate packages GPG keys, the path of the current key will be changed. We still maintain the path of the previous key, but from now on, all the packages will be pointed to infrastructure_agent/keys/ bucket path.

See https://download.newrelic.com/infrastructure_agent/keys/

Let us know if you need further information