### PR TITLE
chore(infra): infra agent gpg key path update

### DIFF
--- a/internal/install/recipes/local_recipe_fetcher_test.go
+++ b/internal/install/recipes/local_recipe_fetcher_test.go
@@ -193,7 +193,7 @@ install:
       cmds:
         - |
           sudo apt-get install gnupg2 -y
-          sudo curl -s https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg | sudo apt-key add -
+          sudo curl -s https://download.newrelic.com/infrastructure_agent/keys/newrelic_apt_key_current.gpg | sudo apt-key add -
       silent: true
 
     add_nr_source:


### PR DESCRIPTION
This PR is to help the TDP team complete the infra agent's PGP key path update. Original PR is: https://github.com/newrelic/newrelic-cli/pull/1346 and credits to @rubenruizdegauna 