### PR TITLE
feat(utils): add yq utility for embedded yaml editing

### DIFF
--- a/internal/utils/command_yq.go
+++ b/internal/utils/command_yq.go
@@ -1,0 +1,139 @@
+package utils
+
+// Borrowed from gojq - cli package
+//
+// The ability to do yaml processing is internal to gojq, so here
+// we've copied in the nesessary bits to get the bare functionality.
+// With this implementation, this subcommand will function much like
+// yq: https://github.com/mikefarah/yq
+//
+// ref: https://github.com/itchyny/gojq/blob/main/cli/yaml.go
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/itchyny/gojq"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	yq "github.com/newrelic/newrelic-cli/internal/utils/yq"
+)
+
+var (
+	outputIndent = 2
+)
+
+var cmdYq = &cobra.Command{
+	Use:   "yq",
+	Short: "Parse json strings",
+	Long: `Parse json strings
+
+The yq subcommand makes use of gojq (https://github.com/itchyny/gojq) to provide
+yaml parsing capabilities.
+`,
+	Example: `echo '"foo": 128' | newrelic utils yq '.foo'`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			log.Fatalln("no filter string provided")
+		}
+
+		if !StdinExists() {
+			log.Fatalln("no input found")
+		}
+
+		return nil
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		query, err := gojq.Parse(args[0])
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		iter := yq.NewYAMLInputIter(os.Stdin, "<stdin>")
+		code, err := gojq.Compile(
+			query,
+			gojq.WithInputIter(iter),
+		)
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		err = process(iter, code)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	},
+}
+
+// cli.process
+// https://github.com/itchyny/gojq/blob/main/cli/cli.go#L337
+func process(iter yq.InputIter, code *gojq.Code) error {
+	var err error
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			return err
+		}
+		if er, ok := v.(error); ok {
+			printError(er)
+			err = &yq.EmptyError{Err: er}
+			// log.Fatalln(er) //todo ?
+			continue
+		}
+		// TODO: if er := cli.printValues(code.Run(v, cli.argvalues...)); er != nil {
+		if er := printValues(code.Run(v)); er != nil {
+			printError(er)
+			err = &yq.EmptyError{Err: er}
+		}
+	}
+}
+
+// cli.printValues
+// https://github.com/itchyny/gojq/blob/main/cli/cli.go#L356
+func printValues(iter gojq.Iter) error {
+	m := createMarshaler()
+	for {
+		v, ok := iter.Next()
+		if !ok {
+			break
+		}
+		if err, ok := v.(error); ok {
+			return err
+		}
+
+		if err := m.Marshal(v, os.Stdout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cli.printError
+// https://github.com/itchyny/gojq/blob/main/cli/cli.go#L422
+func printError(err error) {
+	if er, ok := err.(interface{ IsEmptyError() bool }); !ok || !er.IsEmptyError() {
+		if er, ok := err.(interface{ IsHaltError() bool }); !ok || !er.IsHaltError() {
+			fmt.Fprintf(os.Stderr, "%s: %s\n", "cmdYq", err)
+		} else if er, ok := err.(gojq.ValueError); ok {
+			v := er.Value()
+			if str, ok := v.(string); ok {
+				os.Stderr.Write([]byte(str))
+			} else {
+				bs, _ := gojq.Marshal(v)
+				os.Stderr.Write(bs)
+				os.Stderr.Write([]byte{'\n'})
+			}
+		}
+	}
+}
+
+// cli.createMarshaler
+// https://github.com/itchyny/gojq/blob/main/cli/cli.go#L392
+func createMarshaler() yq.Marshaler {
+	return yq.YamlFormatter(&outputIndent)
+}
+
+func init() {
+	Command.AddCommand(cmdYq)
+}

--- a/internal/utils/command_yq_test.go
+++ b/internal/utils/command_yq_test.go
@@ -1,0 +1,18 @@
+//go:build unit
+// +build unit
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestYq(t *testing.T) {
+	assert.Equal(t, "yq", cmdYq.Name())
+
+	testcobra.CheckCobraMetadata(t, cmdYq)
+}

--- a/internal/utils/yq/error.go
+++ b/internal/utils/yq/error.go
@@ -1,0 +1,129 @@
+package yq
+
+// Borrowed from gojq - cli package
+// ref: https://github.com/itchyny/gojq/blob/main/cli/error.go
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	exitCodeDefaultErr = iota
+)
+
+type EmptyError struct {
+	Err error
+}
+
+func (*EmptyError) Error() string {
+	return ""
+}
+
+func (*EmptyError) IsEmptyError() bool {
+	return true
+}
+
+func (err *EmptyError) ExitCode() int {
+	if err, ok := err.Err.(interface{ ExitCode() int }); ok {
+		return err.ExitCode()
+	}
+	return exitCodeDefaultErr
+}
+
+type yamlParseError struct {
+	fname, contents string
+	err             error
+}
+
+func (err *yamlParseError) Error() string {
+	var line int
+	msg := strings.TrimPrefix(
+		strings.TrimPrefix(err.err.Error(), "yaml: "),
+		"unmarshal errors:\n  ")
+	if fmt.Sscanf(msg, "line %d: ", &line); line == 0 {
+		return "invalid yaml: " + err.fname
+	}
+	msg = msg[strings.Index(msg, ": ")+2:]
+	if i := strings.IndexByte(msg, '\n'); i >= 0 {
+		msg = msg[:i]
+	}
+	linestr := getLineByLine(err.contents, line)
+	return fmt.Sprintf("invalid yaml: %s:%d\n%s  %s",
+		err.fname, line, formatLineInfo(linestr, line, 0), msg)
+}
+
+func getLineByLine(str string, line int) (linestr string) {
+	ss := &stringScanner{str, 0}
+	for {
+		str, _, ok := ss.next()
+		if !ok {
+			break
+		}
+		if line--; line == 0 {
+			linestr = str
+			break
+		}
+	}
+	if len(linestr) > 64 {
+		linestr = trimLastInvalidRune(linestr[:64])
+	}
+	return
+}
+
+func trimLastInvalidRune(s string) string {
+	for i := len(s) - 1; i >= 0 && i > len(s)-utf8.UTFMax; i-- {
+		if b := s[i]; b < utf8.RuneSelf {
+			return s[:i+1]
+		} else if utf8.RuneStart(b) {
+			if r, _ := utf8.DecodeRuneInString(s[i:]); r == utf8.RuneError {
+				return s[:i]
+			}
+			break
+		}
+	}
+	return s
+}
+
+func formatLineInfo(linestr string, line, column int) string {
+	l := strconv.Itoa(line)
+	return "    " + l + " | " + linestr + "\n" +
+		strings.Repeat(" ", len(l)+column) + "       ^"
+}
+
+type stringScanner struct {
+	str    string
+	offset int
+}
+
+func (ss *stringScanner) next() (line string, start int, ok bool) {
+	if ss.offset == len(ss.str) {
+		return
+	}
+	start, ok = ss.offset, true
+	line = ss.str[start:]
+	i := indexNewline(line)
+	if i < 0 {
+		ss.offset = len(ss.str)
+		return
+	}
+	line = line[:i]
+	if strings.HasPrefix(ss.str[start+i:], "\r\n") {
+		i++
+	}
+	ss.offset += i + 1
+	return
+}
+
+// Faster than strings.IndexAny(str, "\r\n").
+func indexNewline(str string) (i int) {
+	if i = strings.IndexByte(str, '\n'); i >= 0 {
+		str = str[:i]
+	}
+	if j := strings.IndexByte(str, '\r'); j >= 0 {
+		i = j
+	}
+	return
+}

--- a/internal/utils/yq/inputs.go
+++ b/internal/utils/yq/inputs.go
@@ -1,0 +1,116 @@
+package yq
+
+// Borrowed from gojq - cli package
+// ref: https://github.com/itchyny/gojq/blob/main/cli/inputs.go
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/itchyny/gojq"
+)
+
+type inputReader struct {
+	io.Reader
+	file *os.File
+	buf  *bytes.Buffer
+}
+
+func newInputReader(r io.Reader) *inputReader {
+	if r, ok := r.(*os.File); ok {
+		if _, err := r.Seek(0, io.SeekCurrent); err == nil {
+			return &inputReader{r, r, nil}
+		}
+	}
+	var buf bytes.Buffer // do not use strings.Builder because we need to Reset
+	return &inputReader{io.TeeReader(r, &buf), nil, &buf}
+}
+
+func (ir *inputReader) getContents(offset *int64, line *int) string {
+	if buf := ir.buf; buf != nil {
+		return buf.String()
+	}
+	if current, err := ir.file.Seek(0, io.SeekCurrent); err == nil {
+		defer func() {
+			if _, err := ir.file.Seek(current, io.SeekStart); err != nil {
+				log.Fatalln("error reading yaml input from stdin")
+			}
+		}()
+	}
+	if _, err := ir.file.Seek(0, io.SeekStart); err != nil {
+		log.Fatalln("error reading yaml input from stdin")
+	}
+	const bufSize = 16 * 1024
+	var buf bytes.Buffer // do not use strings.Builder because we need to Reset
+	if offset != nil && *offset > bufSize {
+		buf.Grow(bufSize)
+		for *offset > bufSize {
+			n, err := io.Copy(&buf, io.LimitReader(ir.file, bufSize))
+			*offset -= n
+			*line += bytes.Count(buf.Bytes(), []byte{'\n'})
+			buf.Reset()
+			if err != nil || n == 0 {
+				break
+			}
+		}
+	}
+	var r io.Reader
+	if offset == nil {
+		r = ir.file
+	} else {
+		r = io.LimitReader(ir.file, bufSize*2)
+	}
+	_, err := io.Copy(&buf, r)
+	if err != nil {
+		log.Fatalln("error copying input into buffer")
+	}
+	return buf.String()
+}
+
+type InputIter interface {
+	gojq.Iter
+	io.Closer
+	Name() string
+}
+
+type yamlInputIter struct {
+	dec   *yaml.Decoder
+	ir    *inputReader
+	fname string
+	err   error
+}
+
+func NewYAMLInputIter(r io.Reader, fname string) InputIter {
+	ir := newInputReader(r)
+	dec := yaml.NewDecoder(ir)
+	return &yamlInputIter{dec: dec, ir: ir, fname: fname}
+}
+
+func (i *yamlInputIter) Next() (interface{}, bool) {
+	if i.err != nil {
+		return nil, false
+	}
+	var v interface{}
+	if err := i.dec.Decode(&v); err != nil {
+		if err == io.EOF {
+			i.err = err
+			return nil, false
+		}
+		i.err = &yamlParseError{i.fname, i.ir.getContents(nil, nil), err}
+		return i.err, true
+	}
+	return normalizeYAML(v), true
+}
+
+func (i *yamlInputIter) Close() error {
+	i.err = io.EOF
+	return nil
+}
+
+func (i *yamlInputIter) Name() string {
+	return i.fname
+}

--- a/internal/utils/yq/marshaler.go
+++ b/internal/utils/yq/marshaler.go
@@ -1,0 +1,35 @@
+package yq
+
+// Borrowed from gojq - cli package
+// ref: https://github.com/itchyny/gojq/blob/main/cli/marshaler.go
+
+import (
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Marshaler interface {
+	Marshal(interface{}, io.Writer) error
+}
+
+func YamlFormatter(indent *int) *YamlMarshaler {
+	return &YamlMarshaler{indent}
+}
+
+type YamlMarshaler struct {
+	indent *int
+}
+
+func (m *YamlMarshaler) Marshal(v interface{}, w io.Writer) error {
+	enc := yaml.NewEncoder(w)
+	if i := m.indent; i != nil {
+		enc.SetIndent(*i)
+	} else {
+		enc.SetIndent(2)
+	}
+	if err := enc.Encode(v); err != nil {
+		return err
+	}
+	return enc.Close()
+}

--- a/internal/utils/yq/yaml.go
+++ b/internal/utils/yq/yaml.go
@@ -1,0 +1,42 @@
+package yq
+
+// Borrowed from gojq - cli package
+// ref: https://github.com/itchyny/gojq/blob/main/cli/yaml.go
+
+import (
+	"fmt"
+	"time"
+)
+
+// Workaround for https://github.com/go-yaml/yaml/issues/139
+func normalizeYAML(v interface{}) interface{} {
+	switch v := v.(type) {
+	case map[interface{}]interface{}:
+		w := make(map[string]interface{}, len(v))
+		for k, v := range v {
+			w[fmt.Sprint(k)] = normalizeYAML(v)
+		}
+		return w
+
+	case map[string]interface{}:
+		w := make(map[string]interface{}, len(v))
+		for k, v := range v {
+			w[k] = normalizeYAML(v)
+		}
+		return w
+
+	case []interface{}:
+		for i, w := range v {
+			v[i] = normalizeYAML(w)
+		}
+		return v
+
+	// go-yaml unmarshals timestamp string to time.Time but gojq cannot handle it.
+	// It is impossible to keep the original timestamp strings.
+	case time.Time:
+		return v.Format(time.RFC3339)
+
+	default:
+		return v
+	}
+}


### PR DESCRIPTION
## Background

The `utils` subcommand was added awhile back (a few years at this point) to give a place where we could expose various utility functions. Among other things, this is useful for embedding utils in the CLI vs relying on them being available on hosts when running recipes.

The `newrelic utils jq` command was added by utilizing [gojq](https://github.com/itchyny/gojq) as a library. `gojq` itself has CLI support for a variety of flags that are intentionally not exposed (see [this issue](https://github.com/itchyny/gojq/issues/181#issuecomment-1221449914) for ref). However, there's nothing really holding us back from adopting the internal package code to expose some additional functionality for ourselves.

## New functionality

This PR adds support for [yq](https://github.com/mikefarah/yq)-like functionality, which is something we're able to graft from `gojq` as the author had added support for yaml input/output. This will greatly enhance our ability to read/write/modify yaml files within recipes. 

Example - editing lists:
```bash
~/dev/go/src/github/newrelic/newrelic-cli (feat/utils-yq) » cat ~/tmp/test/file.yaml
a:
  b: 42
c:
  d: 43
e:
 - 192.168.122.0/24
 - 192.168.122.0/32

~/dev/go/src/github/newrelic/newrelic-cli (feat/utils-yq) » cat ~/tmp/test/file.yaml | ./bin/darwin/newrelic utils yq 'del(.e)' | ./bin/darwin/newrelic utils yq '.e += ["192.168.120.0/24", "192.168.121.0/24"]'
a:
  b: 42
c:
  d: 43
e:
  - 192.168.120.0/24
  - 192.168.121.0/24
```

Example - editing nested structure:
```
~/dev/go/src/github/newrelic/newrelic-cli (feat/utils-yq) » cat ~/tmp/test/file2.yaml
a:
  b: 42
c:
  d:
    foo: 123
    bar: 456
    baz:
      - some
      - nested
      - data
e:
 - 192.168.122.0/24
 - 192.168.122.0/32

~/dev/go/src/github/newrelic/newrelic-cli (feat/utils-yq) » cat ~/tmp/test/file2.yaml | ./bin/darwin/newrelic utils yq 'del(.c.d.baz[1])' | ./bin/darwin/newrelic utils yq '.c.d.bar = "modified"'
a:
  b: 42
c:
  d:
    bar: modified
    baz:
      - some
      - data
    foo: 123
e:
  - 192.168.122.0/24
  - 192.168.122.0/32
```