### PR TITLE
README: Update "developer toolkit" link to developers.newrelic.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Docker Size](https://img.shields.io/docker/image-size/newrelic/cli.svg?sort=semver)](https://hub.docker.com/r/newrelic/k8s-operator)
 [![Docker Version](https://img.shields.io/docker/v/newrelic/cli.svg?sort=semver)](https://hub.docker.com/r/newrelic/k8s-operator)
 
-The New Relic CLI is an officially supported command line interface for New Relic, released as part of the [Developer Toolkit](https://newrelic.github.io/developer-toolkit/).
+The New Relic CLI is an officially supported command line interface for New Relic, released as part of the [Developer Toolkit](https://developer.newrelic.com).
 
 - [Overview](#overview)
   - [Getting Started](#getting-started)


### PR DESCRIPTION
The link previously referenced a github.io link that's currently a 404 (and has been for a while). I couldn't find a mirror of this, so linking to https://developer.newrelic.com seems like the best alternative.