### PR TITLE
feat(logs): removed usage of temp file for log output

### DIFF
--- a/internal/install/execution/go_task_recipe_executor_test.go
+++ b/internal/install/execution/go_task_recipe_executor_test.go
@@ -3,9 +3,10 @@ package execution
 import (
 	"bytes"
 	"context"
-	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 
@@ -13,7 +14,6 @@ import (
 )
 
 func TestExecute_SystemVariableInterpolation(t *testing.T) {
-	//r := NewRecipeBuilder().Vars("TEST_VAR", "testValue").InstallShell("echo {{.TEST_VAR}}").Build()
 	v := types.RecipeVars{
 		"TEST_VAR": "testValue",
 	}
@@ -34,7 +34,7 @@ tasks:
 	e.Stdout = b
 	err := e.Execute(context.Background(), r, v)
 	require.NoError(t, err)
-	require.Equal(t, "testValue\n", b.String())
+	require.True(t, strings.Contains(b.String(), "echo testValue"))
 }
 
 func TestExecute_HandleRecipeLastError(t *testing.T) {
@@ -60,39 +60,28 @@ tasks:
 	require.Contains(t, err.Error(), "testValue")
 }
 
-func TestExecute_HandleInfrastructureRecipeFileCreation(t *testing.T) {
+func TestExecute_WritesCliOutputVar(t *testing.T) {
 	v := types.RecipeVars{
 		"TEST_VAR":         "testValue",
 		"CAPTURE_CLI_LOGS": "true",
 	}
 	r := types.OpenInstallationRecipe{
-		Name: "infrastructure-agent-installer",
+		Name: "test-recipe",
 		Install: `
 version: '3'
 tasks:
   default:
      cmds:
        - |
-         echo "this is random stdout noise"
-         echo some error text >&2
          echo {{.TEST_VAR}} >&2
          exit 1
 `,
 	}
+
 	e := NewGoTaskRecipeExecutor()
 	err := e.Execute(context.Background(), r, v)
-
+	_, containsKey := e.GetOutput().output["CapturedCliOutput"]
+	assert.Truef(t, containsKey, "Output file missing key for 'CapturedCliOutput")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "testValue")
-
-	require.NotEqual(t, "", e.GetOutput().FailedRecipeOutput())
-	_, fileErr := os.Stat(e.GetOutput().FailedRecipeOutput())
-	require.NoError(t, fileErr)
-
-	data, fileErr := os.ReadFile(e.GetOutput().FailedRecipeOutput())
-	require.NoError(t, fileErr)
-	fileContents := string(data)
-	require.True(t, strings.Contains(fileContents, "this is random stdout noise"))
-	require.True(t, strings.Contains(fileContents, "some error text"))
-	require.True(t, strings.Contains(fileContents, "testValue"))
 }

--- a/internal/install/execution/line_capture_buffer.go
+++ b/internal/install/execution/line_capture_buffer.go
@@ -2,30 +2,21 @@ package execution
 
 import (
 	"io"
-	"os"
 
 	log "github.com/sirupsen/logrus"
 )
 
 type LineCaptureBuffer struct {
-	LastFullLine string
-	current      []byte
-	cliOutput    *os.File
-	writer       io.Writer
-}
-
-func NewLineCaptureToFileBuffer(w io.Writer, outputFile *os.File) *LineCaptureBuffer {
-	b := &LineCaptureBuffer{
-		cliOutput: outputFile,
-		writer:    w,
-	}
-
-	return b
+	LastFullLine     string
+	fullRecipeOutput []string
+	current          []byte
+	writer           io.Writer
 }
 
 func NewLineCaptureBuffer(w io.Writer) *LineCaptureBuffer {
 	b := &LineCaptureBuffer{
-		writer: w,
+		writer:           w,
+		fullRecipeOutput: []string{},
 	}
 
 	return b
@@ -35,17 +26,11 @@ func (c *LineCaptureBuffer) Write(p []byte) (n int, err error) {
 	for _, b := range p {
 		if b == '\n' {
 			s := string(c.current)
+			c.fullRecipeOutput = append(c.fullRecipeOutput, s)
 
 			if s != "" {
 				log.Debugf(s)
 				c.LastFullLine = s
-			}
-
-			if nil != c.cliOutput {
-				_, err := c.cliOutput.WriteString(s + "\n")
-				if nil != err {
-					log.Debugf("Couldn't write to cli output file: %e", err)
-				}
 			}
 
 			c.current = []byte{}
@@ -63,4 +48,8 @@ func (c *LineCaptureBuffer) Write(p []byte) (n int, err error) {
 
 func (c *LineCaptureBuffer) Current() string {
 	return string(c.current)
+}
+
+func (c *LineCaptureBuffer) GetFullRecipeOutput() []string {
+	return c.fullRecipeOutput
 }

--- a/internal/install/execution/mock_recipe_executor.go
+++ b/internal/install/execution/mock_recipe_executor.go
@@ -36,6 +36,10 @@ func (m *MockRecipeExecutor) GetOutput() *OutputParser {
 	return m.OutputParser
 }
 
+func (m *MockRecipeExecutor) GetRecipeOutput() []string {
+	return []string{}
+}
+
 func (m *MockRecipeExecutor) SetOutput(value string) {
 	if value != "" {
 		var values map[string]interface{}

--- a/internal/install/execution/mock_recipe_log_forwarder.go
+++ b/internal/install/execution/mock_recipe_log_forwarder.go
@@ -1,0 +1,18 @@
+package execution
+
+import "io"
+
+type MockRecipeLogForwarder struct {
+}
+
+func NewMockRecipeLogForwarder() *MockRecipeLogForwarder {
+	return &MockRecipeLogForwarder{}
+}
+
+func (rlf *MockRecipeLogForwarder) PromptUserToSendLogs(reader io.Reader) bool {
+	return false
+}
+
+func (rlf *MockRecipeLogForwarder) SendLogsToNewRelic(recipeName string, recipeOutput []string) {
+
+}

--- a/internal/install/execution/output_parser.go
+++ b/internal/install/execution/output_parser.go
@@ -33,9 +33,13 @@ func (op *OutputParser) Metadata() map[string]string {
 	return nil
 }
 
-func (op *OutputParser) FailedRecipeOutput() string {
-	if val, ok := op.output["FailedRecipeOutput"]; ok {
-		return val.(string)
+func (op *OutputParser) IsCapturedCliOutput() bool {
+	if val, ok := op.output["CapturedCliOutput"]; ok {
+		valAsBool, isBool := val.(bool)
+		if !isBool {
+			return false
+		}
+		return valAsBool
 	}
-	return ""
+	return false
 }

--- a/internal/install/execution/output_parser_test.go
+++ b/internal/install/execution/output_parser_test.go
@@ -58,26 +58,33 @@ func TestOutputParserShouldGetMetadataMissing(t *testing.T) {
 	assert.Equal(t, result.Metadata()["key1"], "")
 }
 
-func TestOutputParserShouldGetFailedRecipeOutput(t *testing.T) {
-	output := givenJSON("{\"FailedRecipeOutput\":\"/tmp/some/output-file.out\"}")
-
+func TestOutputParserShouldGetCapturedCliOutputFlag(t *testing.T) {
+	// value is true
+	output := givenJSON("{\"CapturedCliOutput\":true}")
 	result := NewOutputParser(output)
-	assert.NotNil(t, result.FailedRecipeOutput())
-	assert.Equal(t, "/tmp/some/output-file.out", result.FailedRecipeOutput())
-}
+	assert.NotNil(t, result.IsCapturedCliOutput())
+	assert.True(t, result.IsCapturedCliOutput())
 
-func TestOutputParserShouldGetNoFailedRecipeOutput(t *testing.T) {
-	output := givenJSON("{\"EntityGuid\":\"abcd\"}")
-	result := NewOutputParser(output)
-	assert.NotNil(t, result.FailedRecipeOutput())
-	assert.Equal(t, "", result.FailedRecipeOutput())
-}
+	// value is false
+	output = givenJSON("{\"CapturedCliOutput\":false}")
+	result = NewOutputParser(output)
+	assert.NotNil(t, result.IsCapturedCliOutput())
+	assert.False(t, result.IsCapturedCliOutput())
 
-func TestOutputParserShouldGetFailedRecipeOutputMissing(t *testing.T) {
-	output := givenJSON("{\"FailedRecipeOutput\":\"\"}")
-	result := NewOutputParser(output)
-	assert.NotNil(t, result.FailedRecipeOutput())
-	assert.Equal(t, "", result.FailedRecipeOutput())
+	// value is empty
+	output = givenJSON("{\"CapturedCliOutput\":\"\"}")
+	result = NewOutputParser(output)
+	assert.False(t, result.IsCapturedCliOutput())
+
+	// value is string, not boolean
+	output = givenJSON("{\"CapturedCliOutput\":\"true\"}")
+	result = NewOutputParser(output)
+	assert.False(t, result.IsCapturedCliOutput())
+
+	// key does not exist
+	output = givenJSON("{\"EntityGuid\":\"abcd\"}")
+	result = NewOutputParser(output)
+	assert.False(t, result.IsCapturedCliOutput())
 }
 
 func TestOutputParserShouldBeEmpty(t *testing.T) {

--- a/internal/install/execution/recipe_executor.go
+++ b/internal/install/execution/recipe_executor.go
@@ -11,4 +11,5 @@ type RecipeExecutor interface {
 	Execute(context.Context, types.OpenInstallationRecipe, types.RecipeVars) error
 	ExecutePreInstall(context.Context, types.OpenInstallationRecipe, types.RecipeVars) error
 	GetOutput() *OutputParser
+	GetRecipeOutput() []string
 }

--- a/internal/install/execution/recipe_log_forwarder.go
+++ b/internal/install/execution/recipe_log_forwarder.go
@@ -18,6 +18,11 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/region"
 )
 
+type LogForwarder interface {
+	PromptUserToSendLogs(reader io.Reader) bool
+	SendLogsToNewRelic(recipeName string, data []string)
+}
+
 type LogEntry struct {
 	Attributes map[string]interface{} `json:"attributes"`
 	LogType    string                 `json:"logType"`
@@ -28,8 +33,8 @@ type RecipeLogForwarder struct {
 	LogEntries []LogEntry
 }
 
-func NewRecipeLogForwarder() RecipeLogForwarder {
-	return RecipeLogForwarder{
+func NewRecipeLogForwarder() *RecipeLogForwarder {
+	return &RecipeLogForwarder{
 		LogEntries: []LogEntry{},
 	}
 }
@@ -51,15 +56,8 @@ func (lf *RecipeLogForwarder) PromptUserToSendLogs(reader io.Reader) bool {
 	return false
 }
 
-func (lf *RecipeLogForwarder) SendLogsToNewRelic(outputFilePath string, recipeName string) {
-	// open file, build log entries
-	f, err := os.Open(outputFilePath)
-	if err != nil {
-		log.Fatalf("open file error: %v", err)
-		return
-	}
-	defer f.Close()
-	lf.buildLogEntryBatch(recipeName, bufio.NewScanner(f))
+func (lf *RecipeLogForwarder) SendLogsToNewRelic(recipeName string, data []string) {
+	lf.buildLogEntryBatch(recipeName, data)
 
 	// building log api client
 	config, err := createLogClientConfig()
@@ -93,14 +91,11 @@ func (lf *RecipeLogForwarder) SendLogsToNewRelic(outputFilePath string, recipeNa
 	}
 }
 
-func (lf *RecipeLogForwarder) buildLogEntryBatch(recipeName string, fs *bufio.Scanner) {
+func (lf *RecipeLogForwarder) buildLogEntryBatch(recipeName string, data []string) {
 	now := time.Now().UnixMilli()
-	for fs.Scan() {
+	for _, line := range data {
 		now++ //using timestamp to retain log sequence
-		lf.LogEntries = append(lf.LogEntries, LogEntry{map[string]interface{}{"nr-install-recipe": recipeName, "timestamp": now}, "cli-output", fs.Text()})
-	}
-	if err := fs.Err(); err != nil {
-		log.Fatalf("scan file error: %v", err)
+		lf.LogEntries = append(lf.LogEntries, LogEntry{map[string]interface{}{"nr-install-recipe": recipeName, "timestamp": now}, "cli-output", line})
 	}
 }
 

--- a/internal/install/execution/recipe_log_forwarder_test.go
+++ b/internal/install/execution/recipe_log_forwarder_test.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,11 +11,6 @@ import (
 // odd hack that works
 func cleanup() {
 	fmt.Printf("\n")
-}
-
-func cleanupWithFile(filename string) {
-	os.Remove(filename)
-	cleanup()
 }
 
 func TestSendLogsIsTrueWhenyYOrNothingEntered(t *testing.T) {
@@ -50,20 +44,8 @@ func TestSendLogsIsFalseWhenAnythingButyYandNothingEntered(t *testing.T) {
 }
 
 func TestSendLogsToNewRelicBuildsLogEntryForEachLogLine(t *testing.T) {
-	file, err := os.CreateTemp("", "some-test-file")
-	assert.NoError(t, err)
-	outputFile := file.Name()
-
-	_, err = file.WriteString("error line one\n")
-	assert.NoError(t, err)
-	_, err = file.WriteString("error line two\n")
-	assert.NoError(t, err)
-	_, err = file.WriteString("error line three\n")
-	assert.NoError(t, err)
-
 	rlf := NewRecipeLogForwarder()
-	rlf.SendLogsToNewRelic(outputFile, "test-recipe")
+	rlf.SendLogsToNewRelic("test-recipe", []string{"error line one\n", "error line two\n", "error line three\n"})
 
 	assert.Equal(t, 3, len(rlf.LogEntries))
-	cleanupWithFile(outputFile)
 }

--- a/internal/install/execution/sh_recipe_executor.go
+++ b/internal/install/execution/sh_recipe_executor.go
@@ -18,18 +18,20 @@ import (
 )
 
 type ShRecipeExecutor struct {
-	Dir    string
-	Stderr io.Writer
-	Stdin  io.Reader
-	Stdout io.Writer
+	Dir          string
+	Stderr       io.Writer
+	Stdin        io.Reader
+	Stdout       io.Writer
+	RecipeOutput []string
 }
 
 func NewShRecipeExecutor() *ShRecipeExecutor {
 	writer := config.Logger.WriterLevel(log.DebugLevel)
 	return &ShRecipeExecutor{
-		Stdin:  os.Stdin,
-		Stdout: writer,
-		Stderr: writer,
+		Stdin:        os.Stdin,
+		Stdout:       writer,
+		Stderr:       writer,
+		RecipeOutput: []string{},
 	}
 }
 
@@ -44,6 +46,10 @@ func (e *ShRecipeExecutor) ExecutePreInstall(ctx context.Context, r types.OpenIn
 
 func (e *ShRecipeExecutor) GetOutput() *OutputParser {
 	return NewOutputParser(map[string]interface{}{})
+}
+
+func (e *ShRecipeExecutor) GetRecipeOutput() []string {
+	return e.RecipeOutput
 }
 
 func (e *ShRecipeExecutor) execute(ctx context.Context, script string, v types.RecipeVars) error {

--- a/internal/install/recipe_install_builder.go
+++ b/internal/install/recipe_install_builder.go
@@ -125,6 +125,10 @@ func (rib *RecipeInstallBuilder) WithOutput(value string) *RecipeInstallBuilder 
 	return rib
 }
 
+func (rib *RecipeInstallBuilder) WithRecipeOutput(value []string) *RecipeInstallBuilder {
+	return rib
+}
+
 func (rib *RecipeInstallBuilder) WithRecipeVarValues(vars map[string]string, err error) *RecipeInstallBuilder {
 	rib.recipeVarProvider.Vars = vars
 	rib.recipeVarProvider.Error = err

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -36,7 +36,7 @@ type RecipeInstall struct {
 	recipeExecutor         execution.RecipeExecutor
 	recipeValidator        RecipeValidator
 	recipeFileFetcher      RecipeFileFetcher
-	recipeLogForwarder     execution.RecipeLogForwarder
+	recipeLogForwarder     *execution.RecipeLogForwarder
 	status                 *execution.InstallStatus
 	prompter               Prompter
 	licenseKeyFetcher      LicenseKeyFetcher
@@ -685,22 +685,25 @@ func (i *RecipeInstall) executeAndValidateWithProgress(ctx context.Context, m *t
 			if errors.Is(err, types.ErrInterrupt) {
 				i.progressIndicator.Canceled("Installing " + r.DisplayName)
 			} else {
-				i.progressIndicator.Fail("Installing " + r.DisplayName)
-				if i.recipeExecutor.GetOutput().FailedRecipeOutput() != "" {
-					outputFilePath := i.recipeExecutor.GetOutput().FailedRecipeOutput()
-					sendLogs := i.recipeLogForwarder.PromptUserToSendLogs(os.Stdin)
-					if sendLogs {
-						i.progressIndicator.Start("Sending logs to New Relic")
-						i.recipeLogForwarder.SendLogsToNewRelic(outputFilePath, r.DisplayName)
-						i.progressIndicator.Success("Complete!")
-					}
-
-					os.Remove(outputFilePath)
-				}
-
+				handleRecipeFailure(i, r.DisplayName)
 			}
 			log.Debugf("install error encountered: %s", err)
 			return "", err
+		}
+	}
+}
+
+func handleRecipeFailure(i *RecipeInstall, recipeName string) {
+	i.progressIndicator.Fail("Installing " + recipeName)
+
+	recipeOutput := i.recipeExecutor.GetRecipeOutput()
+	logCaptureEnabledForRecipe := i.recipeExecutor.GetOutput().IsCapturedCliOutput()
+	if len(recipeOutput) > 0 && logCaptureEnabledForRecipe {
+		sendLogs := i.recipeLogForwarder.PromptUserToSendLogs(os.Stdin)
+		if sendLogs {
+			i.progressIndicator.Start("Sending logs to New Relic")
+			i.recipeLogForwarder.SendLogsToNewRelic(recipeName, recipeOutput)
+			i.progressIndicator.Success("Complete!")
 		}
 	}
 }


### PR DESCRIPTION
Removed capturing CLI output in temp file in favor of storing in memory.  This removes unnecessary file handling/cleanup that surfaced some issues with our windows infra recipes last week 