### PR TITLE
chore(metadata): only send metadata belonging to recipe

### DIFF
--- a/internal/install/execution/go_task_recipe_executor.go
+++ b/internal/install/execution/go_task_recipe_executor.go
@@ -199,17 +199,18 @@ func (re *GoTaskRecipeExecutor) setOutput(outputFileName string) {
 		log.Debugf("error openning json output file %s", outputFileName)
 		return
 	}
-
 	defer outputFile.Close()
 
-	outputBytes, err := ioutil.ReadAll(outputFile)
-	if err == nil && len(outputBytes) > 0 {
+	outputBytes, _ := ioutil.ReadAll(outputFile)
+	if len(outputBytes) > 0 {
 		var result map[string]interface{}
 		if err := json.Unmarshal(outputBytes, &result); err == nil {
 			re.Output = NewOutputParser(result)
 		} else {
 			log.Debugf("error while unmarshaling json output from file %s details:%s", outputFileName, err.Error())
 		}
+	} else {
+		re.Output = NewOutputParser(map[string]interface{}{})
 	}
 }
 

--- a/internal/install/execution/installevents_reporter_test.go
+++ b/internal/install/execution/installevents_reporter_test.go
@@ -5,9 +5,10 @@ package execution
 import (
 	"testing"
 
-	"github.com/newrelic/newrelic-client-go/v2/pkg/installevents"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/installevents"
 
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 )


### PR DESCRIPTION
In an effort to cleanup metadata use sourced from our recipes, make sure we clear out any existing metadata if none is available.  The recipe execution context where output is stored is shared across all recipe executions...we've always overwritten prior metadata if subsequent recipe metadata was present, but if not, the original metadata was attached to all subsequent recipe statuses being reported