### PR TITLE
fix(scripts): install dir check

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,6 +63,11 @@ fi
 LATEST_URL="https://download.newrelic.com/install/newrelic-cli/currentVersion.txt"
 DESTDIR="${DESTDIR:-/usr/local/bin}"
 
+# Create DESTDIR if it does not exist.
+if [ ! -d "$DESTDIR" ]; then 
+    mkdir -m 755 -p "$DESTDIR"
+fi
+
 if [ -z "$VERSION" ]; then
     VERSION=$(curl -sL $LATEST_URL | cut -d "v" -f 2)
 fi


### PR DESCRIPTION
If it does not exist, creates default `DESTDIR` path (`/usr/local/bin`) where the `install.sh` script moves the downloaded `newrelic` binary to. Corrects `not a directory` error in MacOS.