### PR TITLE
chore(deps): upgrade newrelic-client-go to v2.12.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.11.1
+	github.com/newrelic/newrelic-client-go/v2 v2.12.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/sirupsen/logrus v1.9.0
@@ -75,3 +75,5 @@ require (
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
+
+replace github.com/newrelic/newrelic-client-go => /Users/sblue/dev/newrelic-client-go

--- a/go.sum
+++ b/go.sum
@@ -125,10 +125,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/newrelic/newrelic-client-go/v2 v2.2.0 h1:zR0eOu9Bpd4kuVCC8tMkF7Kz4ZbfC60laVlvO+Y9hoo=
-github.com/newrelic/newrelic-client-go/v2 v2.2.0/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
-github.com/newrelic/newrelic-client-go/v2 v2.11.1 h1:pGjXCcjMUWcmFJeZjYE6htde5Fw7M+YhRBw5A9wS98M=
-github.com/newrelic/newrelic-client-go/v2 v2.11.1/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
+github.com/newrelic/newrelic-client-go/v2 v2.12.0 h1:w1gCmKkQqQtG/z4HNDs/5dT2lQAssMaJamTH+Vo2P8Y=
+github.com/newrelic/newrelic-client-go/v2 v2.12.0/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
This client upgrade includes adding the ability to prepend additional requesting service names in our request header.

Related to: [newrelic-client-go #985](https://github.com/newrelic/newrelic-client-go/pull/985)