### PR TITLE
feat(tags): propagate cli tags to recipes via NEW_RELIC_CLI_TAGS

### DIFF
--- a/internal/install/execution/recipe_var_provider.go
+++ b/internal/install/execution/recipe_var_provider.go
@@ -219,9 +219,12 @@ func varFromEnv() types.RecipeVars {
 
 	customAttributes := os.Getenv(EnvNriaCustomAttributes)
 	installCustomAttributes := os.Getenv(EnvInstallCustomAttributes)
-
 	if len(customAttributes) > 0 || len(installCustomAttributes) > 0 {
 		vars[EnvNriaCustomAttributes] = yamlFromJSON(EnvNriaCustomAttributes, customAttributes, strings.Split(installCustomAttributes, ","))
+	}
+
+	if len(installCustomAttributes) > 0 {
+		vars["NEW_RELIC_CLI_TAGS"] = strings.Join(strings.Split(installCustomAttributes, ","), ";")
 	}
 
 	passthroughEnvironment := os.Getenv(EnvNriaPassthroughEnvironment)

--- a/internal/install/execution/recipe_var_provider_test.go
+++ b/internal/install/execution/recipe_var_provider_test.go
@@ -94,6 +94,92 @@ func TestRecipeVarProvider_Basic(t *testing.T) {
 	require.Equal(t, "custom_attributes:\n  owning_team: virtuoso\n  test: \"123\"\n", v["NRIA_CUSTOM_ATTRIBUTES"])
 }
 
+func TestRecipeVarProvider_UserInputVars(t *testing.T) {
+	e := NewRecipeVarProvider()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), t.Name())
+	if err != nil {
+		t.Fatal("error creating temp file")
+	}
+	defer os.Remove(tmpFile.Name())
+
+	output := `
+  {
+    \"hostname\": \"{{.HOSTNAME}}\",
+    \"os\": \"{{.OS}}\",
+    \"platform\": \"{{.PLATFORM}}\",
+    \"platformFamily\": \"{{.PLATFORM_FAMILY}}\",
+    \"platformVersion\": \"{{.PLATFORM_VERSION}}\",
+    \"kernelArch\": \"{{.KERNEL_ARCH}}\",
+    \"kernelVersion\": \"{{.KERNEL_VERSION}}\"
+  }`
+
+	// We convert the `install` section of the recipe to a YAML string,
+	// which is then used to create a Taskfile for go-task.
+	recipeInstallToYaml := map[string]interface{}{
+		"version": "3",
+		"tasks": taskfile.Tasks{
+			"default": &taskfile.Task{
+				Cmds: []*taskfile.Cmd{
+					{
+						Cmd: fmt.Sprintf("echo %s > %s", strings.ReplaceAll(output, "\n", ""), tmpFile.Name()),
+					},
+				},
+				Silent: true,
+			},
+		},
+	}
+
+	installYamlBytes, err := yaml.Marshal(recipeInstallToYaml)
+	require.NoError(t, err)
+
+	m := types.DiscoveryManifest{
+		Hostname:        "testHostname",
+		OS:              "testOS",
+		Platform:        "testPlatform",
+		PlatformFamily:  "testPlatformFamily",
+		PlatformVersion: "testPlatformVersion",
+		KernelArch:      "testKernelArch",
+		KernelVersion:   "testKernelVersion",
+	}
+
+	// need to set envar with input key to mimic user input
+	inputVars := []types.OpenInstallationRecipeInputVariable{
+		{Name: "username"},
+		{Name: "password"},
+	}
+	os.Setenv("username", "some-user")
+	os.Setenv("password", "not-telling")
+
+	r := types.OpenInstallationRecipe{
+		Install:   string(installYamlBytes),
+		InputVars: inputVars,
+	}
+
+	v, err := e.Prepare(m, r, false, "testLicenseKey")
+	require.NoError(t, err)
+	require.Contains(t, m.OS, v["OS"])
+	require.Contains(t, m.Platform, v["Platform"])
+	require.Contains(t, m.PlatformVersion, v["PlatformVersion"])
+	require.Contains(t, m.PlatformFamily, v["PlatformFamily"])
+	require.Contains(t, m.KernelArch, v["KernelArch"])
+	require.Contains(t, m.KernelVersion, v["KernelVersion"])
+	require.Contains(t, "some-user", v["username"])
+	require.Contains(t, "not-telling", v["password"])
+	require.Contains(t, "123", v["a-default"])
+
+	// assumeYes=true no need to setenv for a-default as the Default used
+	inputVars = []types.OpenInstallationRecipeInputVariable{{Name: "a-default", Default: "123"}}
+	r = types.OpenInstallationRecipe{
+		Install:   string(installYamlBytes),
+		InputVars: inputVars,
+	}
+
+	v, err = e.Prepare(m, r, true, "testLicenseKey")
+	require.NoError(t, err)
+	require.Contains(t, "123", v["a-default"])
+}
+
 func TestRecipeVarProvider_CommandLineEnvarsDirectlyPassedToRecipeContext(t *testing.T) {
 	e := NewRecipeVarProvider()
 
@@ -168,6 +254,75 @@ func TestRecipeVarProvider_CommandLineEnvarsDirectlyPassedToRecipeContext(t *tes
 	assert.Equal(t, anotherDownloadURL, v["NEW_RELIC_DOWNLOAD_URL"])
 	assert.Contains(t, v["NEW_RELIC_CLI_LOG_FILE_PATH"], logFilePath)
 	assert.Equal(t, v["NR_CLI_CLUSTERNAME"], clusterName)
+}
+
+func TestRecipeVarProvider_CommandLineTagsPassedFormattedToRecipeContext(t *testing.T) {
+	e := NewRecipeVarProvider()
+
+	tmpFile, err := ioutil.TempFile(os.TempDir(), t.Name())
+	if err != nil {
+		t.Fatal("error creating temp file")
+	}
+
+	defer os.Remove(tmpFile.Name())
+
+	output := `
+  {
+    \"hostname\": \"{{.HOSTNAME}}\",
+    \"os\": \"{{.OS}}\",
+    \"platform\": \"{{.PLATFORM}}\",
+    \"platformFamily\": \"{{.PLATFORM_FAMILY}}\",
+    \"platformVersion\": \"{{.PLATFORM_VERSION}}\",
+    \"kernelArch\": \"{{.KERNEL_ARCH}}\",
+    \"kernelVersion\": \"{{.KERNEL_VERSION}}\"
+  }`
+
+	// We convert the `install` section of the recipe to a YAML string,
+	// which is then used to create a Taskfile for go-task.
+	recipeInstallToYaml := map[string]interface{}{
+		"version": "3",
+		"tasks": taskfile.Tasks{
+			"default": &taskfile.Task{
+				Cmds: []*taskfile.Cmd{
+					{
+						Cmd: fmt.Sprintf("echo %s > %s", strings.ReplaceAll(output, "\n", ""), tmpFile.Name()),
+					},
+				},
+				Silent: true,
+			},
+		},
+	}
+
+	installYamlBytes, err := yaml.Marshal(recipeInstallToYaml)
+	require.NoError(t, err)
+
+	m := types.DiscoveryManifest{
+		Hostname:        "testHostname",
+		OS:              "testOS",
+		Platform:        "testPlatform",
+		PlatformFamily:  "testPlatformFamily",
+		PlatformVersion: "testPlatformVersion",
+		KernelArch:      "testKernelArch",
+		KernelVersion:   "testKernelVersion",
+	}
+
+	r := types.OpenInstallationRecipe{
+		Install: string(installYamlBytes),
+	}
+
+	cliTags := "some:tag,another:something,nr_deployed_by:unit_test"
+	expectedCliTags := "some:tag;another:something;nr_deployed_by:unit_test"
+	os.Setenv(EnvInstallCustomAttributes, cliTags)
+
+	v, err := e.Prepare(m, r, false, "testLicenseKey")
+	require.NoError(t, err)
+	require.Contains(t, v["OS"], m.OS)
+	assert.Contains(t, m.Platform, v["Platform"])
+	assert.Contains(t, m.PlatformVersion, v["PlatformVersion"])
+	assert.Contains(t, m.PlatformFamily, v["PlatformFamily"])
+	assert.Contains(t, m.KernelArch, v["KernelArch"])
+	assert.Contains(t, m.KernelVersion, v["KernelVersion"])
+	assert.Contains(t, v["NEW_RELIC_CLI_TAGS"], expectedCliTags)
 }
 
 func Test_yamlFromJSON_convertsValidJsonToYaml(t *testing.T) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -2,8 +2,9 @@ package utils
 
 import (
 	"errors"
-	log "github.com/sirupsen/logrus"
 	"testing"
+
+	log "github.com/sirupsen/logrus"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Passing all `--tag` arguments through to open-install-library recipe's context via `NEW_RELIC_CLI_TAGS` variable.

key:values will be semicolon delimited i.e. `key:value;another_key:another_value`