### PR TITLE
Improve proxy support for install scripts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -3,6 +3,17 @@ if (!$p.IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator))
     throw 'This script requires admin privileges to run and the current Windows PowerShell session is not running as Administrator. Start Windows PowerShell by using the Run as Administrator option, and then try running the script again.'
 }
 [Net.ServicePointManager]::SecurityProtocol = 'tls12, tls';
-$version = (New-Object System.Net.WebClient).DownloadString("https://download.newrelic.com/install/newrelic-cli/currentVersion.txt").Trim();
-(New-Object System.Net.WebClient).DownloadFile("https://download.newrelic.com/install/newrelic-cli/${version}/NewRelicCLIInstaller.msi", "$env:TEMP\NewRelicCLIInstaller.msi");
+$WebClient = New-Object System.Net.WebClient
+if ($env:HTTPS_PROXY) {
+    $WebClient.Proxy = New-Object System.Net.WebProxy($env:HTTPS_PROXY, $true)
+}
+$version = $null
+try {
+    $version = $WebClient.DownloadString("https://download.newrelic.com/install/newrelic-cli/currentVersion.txt").Trim();
+    $WebClient.DownloadFile("https://download.newrelic.com/install/newrelic-cli/${version}/NewRelicCLIInstaller.msi", "$env:TEMP\NewRelicCLIInstaller.msi");
+}
+catch {
+    Write-Output "`nCould not download the New Relic CLI installer.`n`nCheck your firewall settings. If you are using a proxy, make sure that you are able to access https://download.newrelic.com and that you have set the HTTPS_PROXY environment variable with your full proxy URL.`n"
+    throw
+}
 msiexec.exe /qn /i $env:TEMP\NewRelicCLIInstaller.msi | Out-Null;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -60,8 +60,12 @@ if [ $IS_CURL_INSTALLED -eq 0 ]; then
 fi
 
 # GitHub's URL for the latest release, will redirect.
-LATEST_URL="https://download.newrelic.com/install/newrelic-cli/currentVersion.txt"
+BASE_URL="https://download.newrelic.com"
+LATEST_URL="$BASE_URL/install/newrelic-cli/currentVersion.txt"
 DESTDIR="${DESTDIR:-/usr/local/bin}"
+
+# Check for connectivity to https://download.newrelic.com
+curl --connect-timeout 10 -IsL "$BASE_URL" > /dev/null || ( echo "Cannot connect to $BASE_URL to download the New Relic CLI. Check your firewall settings. If you are using a proxy, make sure you have set the HTTPS_PROXY environment variable." && exit 132 )
 
 # Create DESTDIR if it does not exist.
 if [ ! -d "$DESTDIR" ]; then 


### PR DESCRIPTION
For `install.sh` and `install.ps1`, check for connectivity to `https://download.newrelic.com` and provide a helpful message if unable to connect.

For `install.ps1`, adds a proxy to the requesting `WebClient` via the optional environment variable `HTTPS_PROXY`, which will enable setting a proxy for the CLI download.