### PR TITLE
fix(install): Update scripts/install.sh to use a proxy with curl if HTTPS_PROXY is set

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -59,6 +59,13 @@ if [ $IS_CURL_INSTALLED -eq 0 ]; then
     fi
 fi
 
+# Set curl flags to use the proxy if one has been specified 
+if [ -n "$HTTPS_PROXY" ]; then 
+    CURL_FLAGS="-sLx $HTTPS_PROXY"
+else
+    CURL_FLAGS="-sL"
+fi
+
 # GitHub's URL for the latest release, will redirect.
 LATEST_URL="https://download.newrelic.com/install/newrelic-cli/currentVersion.txt"
 DESTDIR="${DESTDIR:-/usr/local/bin}"
@@ -69,7 +76,7 @@ if [ ! -d "$DESTDIR" ]; then
 fi
 
 if [ -z "$VERSION" ]; then
-    VERSION=$(curl -sL $LATEST_URL | cut -d "v" -f 2)
+    VERSION=$(curl $CURL_FLAGS $LATEST_URL | cut -d "v" -f 2)
 fi
 
 echo "Installing New Relic CLI v${VERSION}"
@@ -88,7 +95,7 @@ trap error ERR
 RELEASE_URL="https://download.newrelic.com/install/newrelic-cli/v${VERSION}/newrelic-cli_${VERSION}_${OS}_${MACHINE}.tar.gz"
 
 # Download & unpack the release tarball.
-curl -sL --retry 3 "${RELEASE_URL}" | tar -xz
+curl $CURL_FLAGS --retry 3 "${RELEASE_URL}" | tar -xz
 
 if [ "$UID" != "0" ]; then
     echo "Installing to $DESTDIR using sudo"


### PR DESCRIPTION
The updates I have made will detect if the HTTPS_PROXY environment variable has been set, and if it has it will then use the proxy with the subsequent curl commands (check connection, downloaded latest version info, then download the correct tar file). This is required so that the guided install can then be updated to set the proxy environment variable in the command line that users will copy and paste from the UI, allowing it to work when a proxy must be used from a host.