### PR TITLE
feat(NR-94773): Add `installId` to platform links

### DIFF
--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -67,6 +67,7 @@ type referrerParamValue struct {
 	NerdletID  string `json:"nerdletId,omitempty"`
 	Referrer   string `json:"referrer,omitempty"`
 	EntityGUID string `json:"entityGuid,omitempty"`
+	InstallID  string `json:"installId,omitempty"`
 }
 
 type loggingLauncher struct {
@@ -78,7 +79,7 @@ type loggingLauncher struct {
 // the UI can use to understand how/where the URL was generated. This allows the
 // UI to return to its previous state in the case of a user closing the browser
 // and then clicking a redirect URL in the CLI's output.
-func (g *PlatformLinkGenerator) generateReferrerParam(entityGUID string) string {
+func (g *PlatformLinkGenerator) generateReferrerParam(entityGUID string, installID string) string {
 	p := referrerParamValue{
 		NerdletID: "nr1-install-newrelic.installation-plan",
 		Referrer:  "newrelic-cli",
@@ -86,6 +87,10 @@ func (g *PlatformLinkGenerator) generateReferrerParam(entityGUID string) string 
 
 	if entityGUID != "" {
 		p.EntityGUID = entityGUID
+	}
+
+	if installID != "" {
+		p.InstallID = installID
 	}
 
 	stringifiedParam, err := json.Marshal(p)
@@ -102,7 +107,7 @@ func (g *PlatformLinkGenerator) generateExplorerLink(status InstallStatus) strin
 		nrPlatformHostname(),
 		utils.Base64Encode(status.successLinkConfig.Filter),
 		configAPI.GetActiveProfileAccountID(),
-		utils.Base64Encode(g.generateReferrerParam(status.HostEntityGUID())),
+		utils.Base64Encode(g.generateReferrerParam(status.HostEntityGUID(), status.InstallID)),
 	)
 
 	shortURL, err := g.generateShortNewRelicURL(longURL)

--- a/internal/install/execution/platform_link_generator_test.go
+++ b/internal/install/execution/platform_link_generator_test.go
@@ -79,7 +79,7 @@ func TestGenerateRedirectURL_InstallPartialSuccess(t *testing.T) {
 	g, s := b.build()
 
 	result := g.GenerateRedirectURL(*s)
-	expectedEncodedQueryParamSubstring := utils.Base64Encode(g.generateReferrerParam(infraName))
+	expectedEncodedQueryParamSubstring := utils.Base64Encode(g.generateReferrerParam(infraName, b.installStatus.InstallID))
 
 	require.Equal(t, 1, len(s.EntityGUIDs))
 	require.Equal(t, 1, len(s.Installed))
@@ -94,6 +94,19 @@ func TestGenerateRedirectURL_InstallFailed(t *testing.T) {
 
 	b := newPlatformLinkGeneratorBuilder()
 	b.recipeStatusUpdate(infraName, "Failed")
+	g, s := b.build()
+
+	result := g.GenerateRedirectURL(*s)
+	require.Contains(t, result, "explorer")
+}
+
+func TestGenerateRedirectURL_InstallCanceled(t *testing.T) {
+	t.Parallel()
+
+	infraName := "infrastructure-agent-installer"
+
+	b := newPlatformLinkGeneratorBuilder()
+	b.recipeStatusUpdate(infraName, "Canceled")
 	g, s := b.build()
 
 	result := g.GenerateRedirectURL(*s)
@@ -148,6 +161,8 @@ func (p *platformLinkGeneratorBuilder) recipeStatusUpdate(rn, status string) *pl
 	switch status {
 	case "Failed":
 		p.installStatus.RecipeFailed(rs)
+	case "Canceled":
+		p.installStatus.RecipeCanceled(rs)
 	case "Installed":
 		// just for testing, assume name is the same as entity id
 		rs.EntityGUID = rn


### PR DESCRIPTION
Adds `installId` to the platform redirect links generated by the CLI. This will allow the browser UI to fetch historic data for the related install statuses and recipes.