### PR TITLE
chore(install): Improve network error detection and messaging

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -41,6 +41,11 @@ var Command = &cobra.Command{
 		logLevel := configAPI.GetLogLevel()
 		config.InitFileLogger(logLevel)
 
+		if err := checkNetwork(client.NRClient); err != nil {
+			log.Fatal(err)
+			return nil
+		}
+
 		err := assertProfileIsValid()
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Moves the call to `checkNetwork()` from inside the installer to before fetching the license key. Also adds more descriptive and helpful error messages if `checkNetwork()` fails.