### PR TITLE
feat(install): Pluralize installId url param

### DIFF
--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -64,10 +64,10 @@ func (g *PlatformLinkGenerator) GenerateRedirectURL(status InstallStatus) string
 }
 
 type referrerParamValue struct {
-	NerdletID  string `json:"nerdletId,omitempty"`
-	Referrer   string `json:"referrer,omitempty"`
-	EntityGUID string `json:"entityGuid,omitempty"`
-	InstallID  string `json:"installId,omitempty"`
+	NerdletID  string   `json:"nerdletId,omitempty"`
+	Referrer   string   `json:"referrer,omitempty"`
+	EntityGUID string   `json:"entityGuid,omitempty"`
+	InstallIDs []string `json:"installIds,omitempty"`
 }
 
 type loggingLauncher struct {
@@ -90,7 +90,8 @@ func (g *PlatformLinkGenerator) generateReferrerParam(entityGUID string, install
 	}
 
 	if installID != "" {
-		p.InstallID = installID
+		// UI expects an array of strings
+		p.InstallIDs = []string{installID}
 	}
 
 	stringifiedParam, err := json.Marshal(p)


### PR DESCRIPTION
Changes url param `installId` to `installIds` to align with UI expectations. The UI is already compatible with this so it is not a breaking change.

I tested by compiling manually and running a partial guided install on an EC2 instance. I then followed the link and confirmed:
1. The install status rehydrated correctly
2. The url param contained `installIds` not `installId`