### PR TITLE
fix: Close metadata file and prevent file lock during recipe write

### DIFF
--- a/build/compile.mk
+++ b/build/compile.mk
@@ -57,4 +57,8 @@ compile-linux-x86: deps-only compile-only
 compile-windows: GOOS=windows
 compile-windows: deps-only compile-only
 
+compile-windows-x86: GOOS=windows
+compile-windows-x86: GOARCH=386
+compile-windows-x86: deps-only compile-only
+
 .PHONY: clean-compile compile compile-darwin compile-linux compile-only compile-windows

--- a/internal/install/execution/go_task_recipe_executor.go
+++ b/internal/install/execution/go_task_recipe_executor.go
@@ -50,7 +50,6 @@ func (re *GoTaskRecipeExecutor) ExecutePreInstall(ctx context.Context, r types.O
 }
 
 func (re *GoTaskRecipeExecutor) Execute(ctx context.Context, r types.OpenInstallationRecipe, recipeVars types.RecipeVars) (retErr error) {
-
 	defer func() {
 		if r := recover(); r != nil {
 			switch x := r.(type) {
@@ -78,7 +77,7 @@ func (re *GoTaskRecipeExecutor) Execute(ctx context.Context, r types.OpenInstall
 	if err != nil {
 		return err
 	}
-	defer outputJSONFile.Close()
+	outputJSONFile.Close()
 	defer os.Remove(outputJSONFile.Name())
 
 	silentInstall, _ := strconv.ParseBool(recipeVars["assumeYes"])
@@ -116,7 +115,7 @@ func (re *GoTaskRecipeExecutor) Execute(ctx context.Context, r types.OpenInstall
 			"err": err,
 		}).Debug("Task execution returned error")
 
-		//should contain both out and err
+		// should contain both out and err
 		re.RecipeOutput = stdoutCapture.GetFullRecipeOutput()
 		re.setOutput(outputJSONFile.Name())
 


### PR DESCRIPTION
Problem: Unable to write to metadata file with window recipe due to it kept open by CLI
Fix: Close metadata file after creating
![image](https://user-images.githubusercontent.com/94071514/231577722-a45bf82f-249b-4ba5-99bc-85c5504b5c20.png)

Add a new compile option for Windows x86