### PR TITLE
chore(install): Remove user/account NerdStorage writes

### DIFF
--- a/internal/install/execution/nerdstorage_status_reporter.go
+++ b/internal/install/execution/nerdstorage_status_reporter.go
@@ -3,7 +3,6 @@ package execution
 import (
 	log "github.com/sirupsen/logrus"
 
-	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/nerdstorage"
 )
@@ -92,13 +91,9 @@ func (r NerdstorageStatusReporter) UpdateRequired(status *InstallStatus) error {
 
 func (r NerdstorageStatusReporter) writeStatus(status *InstallStatus) error {
 	i := r.buildExecutionStatusDocument(status)
-	_, err := r.client.WriteDocumentWithUserScope(i)
-	if err != nil {
-		return err
-	}
 
 	for _, g := range status.EntityGUIDs {
-		_, err = r.client.WriteDocumentWithEntityScope(g, i)
+		_, err := r.client.WriteDocumentWithEntityScope(g, i)
 		if err != nil {
 			return err
 		}
@@ -106,12 +101,6 @@ func (r NerdstorageStatusReporter) writeStatus(status *InstallStatus) error {
 
 	if len(status.EntityGUIDs) == 0 {
 		log.Debug("no entity GUIDs available, skipping entity-scoped status updates")
-	}
-
-	accountID := configAPI.GetActiveProfileAccountID()
-	_, err = r.client.WriteDocumentWithAccountScope(accountID, i)
-	if err != nil {
-		log.Debug("failed to write to account scoped nerd storage")
 	}
 
 	return nil

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -46,10 +46,8 @@ func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 	status.withEntityGUID(entityGUID)
 
-	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
-	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -96,10 +94,8 @@ func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 
-	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
-	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -134,26 +130,6 @@ func getEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStor
 	}
 
 	return c.GetCollectionWithEntityScope(guid, getCollectionInput)
-}
-
-func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.NerdStorage) {
-	di := nerdstorage.DeleteCollectionInput{
-		Collection: collectionID,
-		PackageID:  packageID,
-	}
-	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
-	require.NoError(t, err)
-	require.True(t, ok)
-}
-
-func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
-	di := nerdstorage.DeleteCollectionInput{
-		Collection: collectionID,
-		PackageID:  packageID,
-	}
-	ok, err := c.DeleteCollectionWithUserScope(di)
-	require.NoError(t, err)
-	require.True(t, ok)
 }
 
 func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStorage) {

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -143,7 +143,6 @@ func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.Ne
 	}
 	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
 	require.NoError(t, err)
-	require.True(t, ok)
 }
 
 func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
@@ -153,7 +152,6 @@ func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
 	}
 	ok, err := c.DeleteCollectionWithUserScope(di)
 	require.NoError(t, err)
-	require.True(t, ok)
 }
 
 func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStorage) {

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -145,7 +145,7 @@ func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.Ne
 		Collection: collectionID,
 		PackageID:  packageID,
 	}
-	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
+	_, err := c.DeleteCollectionWithAccountScope(accountID, di)
 	require.NoError(t, err)
 }
 
@@ -154,7 +154,7 @@ func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
 		Collection: collectionID,
 		PackageID:  packageID,
 	}
-	ok, err := c.DeleteCollectionWithUserScope(di)
+	_, err := c.DeleteCollectionWithUserScope(di)
 	require.NoError(t, err)
 }
 

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -62,10 +62,12 @@ func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 
 	time.Sleep(10 * time.Second)
 
+	// Should not write to user collection
 	s, err := getUserStatusCollection(t, c.NerdStorage)
 	require.NoError(t, err)
 	require.Empty(t, s)
 
+	// Should write to entity collection
 	s, err = getEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	require.NoError(t, err)
 	require.NotEmpty(t, s)
@@ -109,10 +111,12 @@ func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	err = r.RecipeInstalled(status, evt)
 	require.NoError(t, err)
 
+	// Should not write to user collection
 	s, err := getUserStatusCollection(t, c.NerdStorage)
 	require.NoError(t, err)
 	require.Empty(t, s)
 
+	// Should not write to entity collection
 	s, err = getEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	require.NoError(t, err)
 	require.Empty(t, s)

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -46,8 +46,10 @@ func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 	status.withEntityGUID(entityGUID)
 
+	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
+	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -94,8 +96,10 @@ func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 
+	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
+	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -130,6 +134,26 @@ func getEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStor
 	}
 
 	return c.GetCollectionWithEntityScope(guid, getCollectionInput)
+}
+
+func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.NerdStorage) {
+	di := nerdstorage.DeleteCollectionInput{
+		Collection: collectionID,
+		PackageID:  packageID,
+	}
+	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
+	require.NoError(t, err)
+	require.True(t, ok)
+}
+
+func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
+	di := nerdstorage.DeleteCollectionInput{
+		Collection: collectionID,
+		PackageID:  packageID,
+	}
+	ok, err := c.DeleteCollectionWithUserScope(di)
+	require.NoError(t, err)
+	require.True(t, ok)
 }
 
 func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStorage) {

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -132,26 +132,6 @@ func getEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStor
 	return c.GetCollectionWithEntityScope(guid, getCollectionInput)
 }
 
-func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.NerdStorage) {
-	di := nerdstorage.DeleteCollectionInput{
-		Collection: collectionID,
-		PackageID:  packageID,
-	}
-	ok, err := c.DeleteCollectionWithAccountScope(accountID, di)
-	require.NoError(t, err)
-	require.True(t, ok)
-}
-
-func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
-	di := nerdstorage.DeleteCollectionInput{
-		Collection: collectionID,
-		PackageID:  packageID,
-	}
-	ok, err := c.DeleteCollectionWithUserScope(di)
-	require.NoError(t, err)
-	require.True(t, ok)
-}
-
 func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStorage) {
 	di := nerdstorage.DeleteCollectionInput{
 		Collection: collectionID,

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -140,6 +140,7 @@ func getEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStor
 	return c.GetCollectionWithEntityScope(guid, getCollectionInput)
 }
 
+// TODO: remove after 5/20/23 since we are no longer writing to these collections.
 func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.NerdStorage) {
 	di := nerdstorage.DeleteCollectionInput{
 		Collection: collectionID,
@@ -149,6 +150,7 @@ func deleteAccountStatusCollection(t *testing.T, accountID int, c nerdstorage.Ne
 	require.NoError(t, err)
 }
 
+// TODO: remove after 5/20/23 since we are no longer writing to these collections.
 func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
 	di := nerdstorage.DeleteCollectionInput{
 		Collection: collectionID,
@@ -158,6 +160,7 @@ func deleteUserStatusCollection(t *testing.T, c nerdstorage.NerdStorage) {
 	require.NoError(t, err)
 }
 
+// TODO: remove after we stop writing to entity storage (NR-99441)
 func deleteEntityStatusCollection(t *testing.T, guid string, c nerdstorage.NerdStorage) {
 	di := nerdstorage.DeleteCollectionInput{
 		Collection: collectionID,

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -46,10 +46,8 @@ func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 	status.withEntityGUID(entityGUID)
 
-	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
-	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{
@@ -70,6 +68,7 @@ func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, s)
 }
+
 func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	accountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
@@ -95,10 +94,8 @@ func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	r := NewNerdStorageStatusReporter(&c.NerdStorage)
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{r}, NewPlatformLinkGenerator())
 
-	defer deleteUserStatusCollection(t, c.NerdStorage)
 	defer deleteEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	defer deleteEntity(t, entityGUID, c)
-	defer deleteAccountStatusCollection(t, a, c.NerdStorage)
 
 	rec := types.OpenInstallationRecipe{Name: "testName"}
 	evt := RecipeStatusEvent{

--- a/internal/install/execution/nerdstorage_status_reporter_integration_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 )
 
-func TestReportRecipeSucceeded_Basic(t *testing.T) {
+func TestReportRecipeSucceeded_SingleEntityGUID(t *testing.T) {
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	accountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
 	if apiKey == "" || accountID == "" {
@@ -64,13 +64,13 @@ func TestReportRecipeSucceeded_Basic(t *testing.T) {
 
 	s, err := getUserStatusCollection(t, c.NerdStorage)
 	require.NoError(t, err)
-	require.NotEmpty(t, s)
+	require.Empty(t, s)
 
 	s, err = getEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	require.NoError(t, err)
 	require.NotEmpty(t, s)
 }
-func TestReportRecipeSucceeded_UserScopeOnly(t *testing.T) {
+func TestReportRecipeSucceeded_NoEntityGUIDs(t *testing.T) {
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	accountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
 	if apiKey == "" || accountID == "" {
@@ -110,7 +110,7 @@ func TestReportRecipeSucceeded_UserScopeOnly(t *testing.T) {
 
 	s, err := getUserStatusCollection(t, c.NerdStorage)
 	require.NoError(t, err)
-	require.NotEmpty(t, s)
+	require.Empty(t, s)
 
 	s, err = getEntityStatusCollection(t, entityGUID, c.NerdStorage)
 	require.NoError(t, err)

--- a/internal/install/execution/nerdstorage_status_reporter_unit_test.go
+++ b/internal/install/execution/nerdstorage_status_reporter_unit_test.go
@@ -22,19 +22,7 @@ func TestRecipeAvailable_Basic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestRecipeAvailable_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.RecipeAvailable(status, NewRecipeStatusEvent(&types.OpenInstallationRecipe{}))
-	require.Error(t, err)
-}
-
-func TestRecipeInstalled_Basic(t *testing.T) {
+func TestRecipeInstalled_SingleEntityGUID(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewPlatformLinkGenerator()
@@ -44,12 +32,12 @@ func TestRecipeInstalled_Basic(t *testing.T) {
 
 	err := r.RecipeInstalled(status, e)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 1, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
-func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
+func TestRecipeInstalled_NoEntityGUIDs(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewPlatformLinkGenerator()
@@ -58,9 +46,9 @@ func TestRecipeInstalled_UserScopeOnly(t *testing.T) {
 
 	err := r.RecipeInstalled(status, e)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
@@ -74,23 +62,9 @@ func TestRecipeInstalled_MultipleEntityGUIDs(t *testing.T) {
 
 	err := r.RecipeInstalled(status, e)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 2, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
-}
-
-func TestRecipeInstalled_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-	status.withEntityGUID("testGuid")
-	e := RecipeStatusEvent{}
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.RecipeInstalled(status, e)
-	require.Error(t, err)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeInstalled_EntityScopeError(t *testing.T) {
@@ -107,7 +81,7 @@ func TestRecipeInstalled_EntityScopeError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestRecipeFailed_Basic(t *testing.T) {
+func TestRecipeFailed_SingleEntityGUID(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewPlatformLinkGenerator()
@@ -117,12 +91,12 @@ func TestRecipeFailed_Basic(t *testing.T) {
 
 	err := r.RecipeFailed(status, e)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 1, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
-func TestRecipeFailed_UserScopeOnly(t *testing.T) {
+func TestRecipeFailed_NoEntityGUIDs(t *testing.T) {
 	c := NewMockNerdStorageClient()
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewPlatformLinkGenerator()
@@ -132,23 +106,9 @@ func TestRecipeFailed_UserScopeOnly(t *testing.T) {
 
 	err := r.RecipeFailed(status, e)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
-}
-
-func TestRecipeFailed_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-	status.withEntityGUID("testGuid")
-	e := RecipeStatusEvent{}
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.RecipeFailed(status, e)
-	require.Error(t, err)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestRecipeFailed_EntityScopeError(t *testing.T) {
@@ -170,24 +130,13 @@ func TestInstallComplete_Basic(t *testing.T) {
 	r := NewNerdStorageStatusReporter(c)
 	slg := NewPlatformLinkGenerator()
 	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
+	status.withEntityGUID("testGuid")
 
 	err := r.InstallComplete(status)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
-	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
-}
-
-func TestInstallComplete_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.InstallComplete(status)
-	require.Error(t, err)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 1, c.writeDocumentWithEntityScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestInstallCanceled_Basic(t *testing.T) {
@@ -198,21 +147,9 @@ func TestInstallCanceled_Basic(t *testing.T) {
 
 	err := r.InstallCanceled(status)
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
-}
-
-func TestInstallCanceled_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.InstallCanceled(status)
-	require.Error(t, err)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }
 
 func TestDiscoveryComplete_Basic(t *testing.T) {
@@ -223,19 +160,7 @@ func TestDiscoveryComplete_Basic(t *testing.T) {
 
 	err := r.DiscoveryComplete(status, types.DiscoveryManifest{})
 	require.NoError(t, err)
-	require.Equal(t, 1, c.writeDocumentWithUserScopeCallCount)
+	require.Equal(t, 0, c.writeDocumentWithUserScopeCallCount)
 	require.Equal(t, 0, c.writeDocumentWithEntityScopeCallCount)
-	require.Equal(t, 1, c.writeDocumentWithAccountScopeCallCount)
-}
-
-func TestDiscoveryComplete_UserScopeError(t *testing.T) {
-	c := NewMockNerdStorageClient()
-	r := NewNerdStorageStatusReporter(c)
-	slg := NewPlatformLinkGenerator()
-	status := NewInstallStatus(types.InstallerContext{}, []StatusSubscriber{}, slg)
-
-	c.WriteDocumentWithUserScopeErr = errors.New("error")
-
-	err := r.DiscoveryComplete(status, types.DiscoveryManifest{})
-	require.Error(t, err)
+	require.Equal(t, 0, c.writeDocumentWithAccountScopeCallCount)
 }


### PR DESCRIPTION
## Summary

Removes writes to account- and user-scoped NerdStorage from the install status reporter. The status reporter should only write to entity scope.

## Context

New Relic UI no longer depends on the `openInstallLibrary` collection, except for entity-scoped NerdStorage data.