### PR TITLE
fix(dashboard): addition of 'zero' to the dashboard HCL parser utility

### DIFF
--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -63,8 +63,9 @@ type DashboardWidgetLegend struct {
 }
 
 type DashboardWidgetYAxisLeft struct {
-	Max float64 `json:"max,omitempty"`
-	Min float64 `json:"min,omitempty"`
+	Max  float64 `json:"max,omitempty"`
+	Min  float64 `json:"min,omitempty"`
+	Zero bool    `json:"zero,omitempty"`
 }
 
 type DashboardWidgetNullValues struct {
@@ -142,6 +143,9 @@ func GenerateDashboardHCL(resourceLabel string, shiftWidth int, input []byte) (s
 						h.WriteBooleanAttribute("ignore_time_range", config.PlatformOptions.IgnoreTimeRange)
 						h.WriteFloatAttribute("y_axis_left_min", config.YAxisLeft.Min)
 						h.WriteFloatAttribute("y_axis_left_max", config.YAxisLeft.Max)
+						if w.Visualization.ID == "viz.line" {
+							h.WriteBooleanAttribute("y_axis_left_zero", config.YAxisLeft.Zero)
+						}
 						h.WriteBlock("null_values", []string{}, func() {
 							h.WriteStringAttribute("null_value", config.NullValues.NullValue)
 							for _, so := range config.NullValues.SeriesOverrides {


### PR DESCRIPTION
## Description

This PR addresses [NR-108075](https://issues.newrelic.com/browse/NR-108075), comprising of the following changes - 
- Addition of a condition in the dashboard utility in the CLI to convert the given Dashboard JSON to HCL, to receive the newly added attribute, `zero` (in newrelic-client-go) as `y_axis_left_zero` in HCL, to be used in Terraform.

Linked changes in dependencies
**terraform-provider-newrelic** : [PR](https://github.com/newrelic/terraform-provider-newrelic/pull/2329)
**newrelic-client-go** : [PR](https://github.com/newrelic/newrelic-client-go/pull/1023)