### PR TITLE
chore(install): increase license key fetch retry timeout to 5 minutes

### DIFF
--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,32 @@
+//go:build integration
+
+package client
+
+import (
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-cli/internal/config"
+)
+
+func TestClientFetchLicenseKey(t *testing.T) {
+	t.Parallel()
+
+	testAccountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
+	if testAccountID == "" {
+		t.Skipf("New Relic internal testing account required")
+	}
+
+	acctID, err := strconv.Atoi(testAccountID)
+	if err != nil {
+		t.Skipf("error converting NEW_RELIC_ACCOUNT_ID to integer")
+	}
+
+	maxTimeoutSeconds := config.DefaultMaxTimeoutSeconds
+	result, err := FetchLicenseKey(acctID, "default", &maxTimeoutSeconds)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ const (
 
 	DefaultPostRetryDelaySec = 5
 	DefaultPostMaxRetries    = 20
+	DefaultMaxTimeoutSeconds = 300 // 5 minutes
 )
 
 var (

--- a/internal/diagnose/config_validator.go
+++ b/internal/diagnose/config_validator.go
@@ -45,7 +45,7 @@ func NewConfigValidator(client *newrelic.NewRelic) *ConfigValidator {
 		client:               client,
 		PollingNRQLValidator: v,
 		PostRetryDelaySec:    config.DefaultPostRetryDelaySec,
-		PostMaxRetries:       config.DefaultPostMaxRetries,
+		PostMaxRetries:       config.DefaultMaxTimeoutSeconds / config.DefaultPostRetryDelaySec,
 	}
 }
 

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -46,7 +46,7 @@ var Command = &cobra.Command{
 			return nil
 		}
 
-		err := assertProfileIsValid()
+		err := assertProfileIsValid(config.DefaultMaxTimeoutSeconds)
 		if err != nil {
 			log.Fatal(err)
 			return nil
@@ -84,7 +84,7 @@ var Command = &cobra.Command{
 	},
 }
 
-func assertProfileIsValid() error {
+func assertProfileIsValid(maxTimeoutSeconds int) error {
 	accountID := configAPI.GetActiveProfileAccountID()
 	if accountID == 0 {
 		return fmt.Errorf("accountID is required")
@@ -98,7 +98,7 @@ func assertProfileIsValid() error {
 		return fmt.Errorf("region is required")
 	}
 
-	licenseKey, err := client.FetchLicenseKey(accountID, config.FlagProfileName)
+	licenseKey, err := client.FetchLicenseKey(accountID, config.FlagProfileName, &maxTimeoutSeconds)
 	if err != nil {
 		return fmt.Errorf("could not fetch license key for account %d: %s", accountID, err)
 	}

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestInstallCommand(t *testing.T) {
+	t.Parallel()
+
 	assert.Equal(t, "install", Command.Name())
 
 	testcobra.CheckCobraMetadata(t, Command)

--- a/internal/install/license_key_fetcher.go
+++ b/internal/install/license_key_fetcher.go
@@ -7,36 +7,34 @@ import (
 
 	"github.com/newrelic/newrelic-cli/internal/client"
 	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
-	"github.com/newrelic/newrelic-cli/internal/install/recipes"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 )
 
 // relies on the Nerdgraph service
 type ServiceLicenseKeyFetcher struct {
-	client     recipes.NerdGraphClient
-	LicenseKey string
+	maxTimeoutSeconds int
+	LicenseKey        string
 }
 
 type LicenseKeyFetcher interface {
 	FetchLicenseKey(context.Context) (string, error)
 }
 
-func NewServiceLicenseKeyFetcher(client recipes.NerdGraphClient) LicenseKeyFetcher {
+func NewServiceLicenseKeyFetcher(maxTimeoutSeconds int) LicenseKeyFetcher {
 	f := ServiceLicenseKeyFetcher{
-		client: client,
+		maxTimeoutSeconds: maxTimeoutSeconds,
 	}
 
 	return &f
 }
 
 func (f *ServiceLicenseKeyFetcher) FetchLicenseKey(ctx context.Context) (string, error) {
-
 	if f.LicenseKey != "" {
 		return f.LicenseKey, nil
 	}
 
 	accountID := configAPI.GetActiveProfileAccountID()
-	licenseKey, err := client.FetchLicenseKey(accountID, configAPI.GetActiveProfileName())
+	licenseKey, err := client.FetchLicenseKey(accountID, configAPI.GetActiveProfileName(), &f.maxTimeoutSeconds)
 	if err != nil {
 		return "", err
 	}

--- a/internal/install/license_key_fetcher_test.go
+++ b/internal/install/license_key_fetcher_test.go
@@ -1,0 +1,29 @@
+//go:build integration
+
+package install
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-cli/internal/config"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+)
+
+func TestLicenseKeyFetcher_FetchLicenseKey(t *testing.T) {
+	t.Parallel()
+
+	testAccountAPIKey := os.Getenv("NEW_RELIC_API_KEY")
+	testAccountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
+	if testAccountAPIKey == "" || testAccountID == "" {
+		t.Skip("New Relic internal testing account required")
+	}
+
+	licenseKeyFetcher := NewServiceLicenseKeyFetcher(config.DefaultMaxTimeoutSeconds)
+
+	result, err := licenseKeyFetcher.FetchLicenseKey(utils.SignalCtx)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+}

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/http/httpproxy"
 
 	"github.com/newrelic/newrelic-cli/internal/cli"
+	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/diagnose"
 	"github.com/newrelic/newrelic-cli/internal/install/discovery"
 	"github.com/newrelic/newrelic-cli/internal/install/execution"
@@ -77,7 +78,7 @@ func NewRecipeInstaller(ic types.InstallerContext, nrClient *newrelic.NewRelic) 
 		execution.NewTerminalStatusReporter(),
 		execution.NewInstallEventsReporter(&nrClient.InstallEvents),
 	}
-	lkf := NewServiceLicenseKeyFetcher(&nrClient.NerdGraph)
+	lkf := NewServiceLicenseKeyFetcher(config.DefaultMaxTimeoutSeconds)
 	slg := execution.NewPlatformLinkGenerator()
 	statusRollup := execution.NewInstallStatus(ic, ers, slg)
 

--- a/internal/profile/command.go
+++ b/internal/profile/command.go
@@ -295,6 +295,7 @@ func init() {
 func fetchLicenseKey() func() (string, error) {
 	accountID := configAPI.GetProfileInt(config.FlagProfileName, config.AccountID)
 	return func() (string, error) {
-		return client.FetchLicenseKey(accountID, config.FlagProfileName)
+		maxTimeoutSeconds := config.DefaultMaxTimeoutSeconds
+		return client.FetchLicenseKey(accountID, config.FlagProfileName, &maxTimeoutSeconds)
 	}
 }


### PR DESCRIPTION
To account for some license key generation lag with new customers, we are increasing the request retry timeout to ensure we can fetch the newly generated license key for new customers.

The changes in this PR are intended to be scoped to increasing the timeout only for fetching the license key. 