### PR TITLE
fix(install): Incorrect final recipe status if cancel during target install

### DIFF
--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -79,9 +79,6 @@ func (r TerminalStatusReporter) InstallStarted(status *InstallStatus) error {
 }
 
 func (r TerminalStatusReporter) InstallComplete(status *InstallStatus) error {
-	if status.hasAnyRecipeStatus(RecipeStatusTypes.CANCELED) {
-		return nil
-	}
 
 	linkToData := ""
 	if status.PlatformLinkGenerator != nil {
@@ -176,6 +173,10 @@ func (r TerminalStatusReporter) printInstallationSummary(status *InstallStatus) 
 
 		if s.Status == RecipeStatusTypes.FAILED {
 			statusSuffix = color.YellowString("incomplete")
+		}
+
+		if s.Status == RecipeStatusTypes.CANCELED {
+			statusSuffix = color.YellowString(statusSuffix)
 		}
 
 		if s.Status == RecipeStatusTypes.UNSUPPORTED {

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -2,6 +2,8 @@ package execution
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/fatih/color"
@@ -96,7 +98,7 @@ func (r TerminalStatusReporter) InstallComplete(status *InstallStatus) error {
 		fmt.Println("  --------------------")
 		fmt.Println("  Installation Summary")
 		fmt.Println("")
-		r.printInstallationSummary(status)
+		r.printInstallationSummary(os.Stdout, status)
 
 		msg := "View your data at the link below:\n"
 		followInstructionsMsg := "Follow the instructions at the URL below to complete the installation process."
@@ -161,7 +163,7 @@ func (r TerminalStatusReporter) printLoggingLink(status *InstallStatus) {
 	}
 }
 
-func (r TerminalStatusReporter) printInstallationSummary(status *InstallStatus) {
+func (r TerminalStatusReporter) printInstallationSummary(w io.Writer, status *InstallStatus) {
 	statusesToDisplay := r.getRecipesStatusesForInstallationSummary(status)
 
 	for _, s := range statusesToDisplay {
@@ -183,7 +185,7 @@ func (r TerminalStatusReporter) printInstallationSummary(status *InstallStatus) 
 			statusSuffix = color.RedString(statusSuffix)
 		}
 
-		fmt.Printf("  %s  %s  (%s)  \n", StatusIconMap[s.Status], s.DisplayName, statusSuffix)
+		fmt.Fprintf(w, "  %s  %s  (%s)  \n", StatusIconMap[s.Status], s.DisplayName, statusSuffix)
 	}
 }
 

--- a/internal/install/execution/terminal_reporter_test.go
+++ b/internal/install/execution/terminal_reporter_test.go
@@ -1,9 +1,8 @@
-//go:build unit
-// +build unit
-
 package execution
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -185,4 +184,41 @@ func TestTerminalStatusReporter_ShouldNotIncludeDetectedRecipeInSummary(t *testi
 	require.Equal(t, len(expected), len(recipesToSummarize))
 	require.Equal(t, expected[0].Name, recipesToSummarize[0].Name)
 	require.Equal(t, expected[1].Name, recipesToSummarize[1].Name)
+}
+
+func TestPrintInstallationSummaryShouldPrint(t *testing.T) {
+
+	r := NewTerminalStatusReporter()
+	var output bytes.Buffer
+
+	status := &InstallStatus{}
+	recipeInstalled := &RecipeStatus{
+		Name:        "test-recipe-installed",
+		DisplayName: "Test Recipe Installed",
+		Status:      RecipeStatusTypes.INSTALLED,
+	}
+	recipeDetected := &RecipeStatus{
+		Name:        "test-recipe-detected",
+		DisplayName: "Test Recipe Detected",
+		Status:      RecipeStatusTypes.DETECTED,
+	}
+	recipeCanceled := &RecipeStatus{
+		Name:        "test-recipe-canceld",
+		DisplayName: "Test Recipe Canceled",
+		Status:      RecipeStatusTypes.CANCELED,
+	}
+
+	status.Statuses = []*RecipeStatus{
+		recipeInstalled,
+		recipeDetected,
+		recipeCanceled,
+	}
+
+	r.printInstallationSummary(&output, status)
+	s := output.String()
+	fmt.Print(s)
+
+	require.Contains(t, s, "Test Recipe Installed  (installed)")
+	require.NotContains(t, s, "Detected")
+	require.Contains(t, s, "Test Recipe Canceled  (canceled)")
 }

--- a/internal/install/execution/terminal_reporter_test.go
+++ b/internal/install/execution/terminal_reporter_test.go
@@ -163,18 +163,26 @@ func TestTerminalStatusReporter_ShouldNotIncludeDetectedRecipeInSummary(t *testi
 		DisplayName: "Test Recipe Detected",
 		Status:      RecipeStatusTypes.DETECTED,
 	}
+	recipeCanceled := &RecipeStatus{
+		Name:        "test-recipe-canceld",
+		DisplayName: "Test Recipe Canceled",
+		Status:      RecipeStatusTypes.CANCELED,
+	}
 
 	status.Statuses = []*RecipeStatus{
 		recipeInstalled,
 		recipeDetected,
+		recipeCanceled,
 	}
 
 	expected := []*RecipeStatus{
 		recipeInstalled,
+		recipeCanceled,
 	}
 
 	recipesToSummarize := r.getRecipesStatusesForInstallationSummary(status)
 
 	require.Equal(t, len(expected), len(recipesToSummarize))
 	require.Equal(t, expected[0].Name, recipesToSummarize[0].Name)
+	require.Equal(t, expected[1].Name, recipesToSummarize[1].Name)
 }

--- a/internal/install/recipe_install_builder.go
+++ b/internal/install/recipe_install_builder.go
@@ -73,8 +73,10 @@ func (rib *RecipeInstallBuilder) WithFetchRecipesVal(fetchRecipesVal []*types.Op
 	return rib
 }
 
-func (rib *RecipeInstallBuilder) WithRecipeDetectionResult(detectionResult *recipes.RecipeDetectionResult) *RecipeInstallBuilder {
-	rib.recipeDetector.AddRecipeDetectionResult(detectionResult)
+func (rib *RecipeInstallBuilder) WithRecipeDetectionResult(detectionResults ...*recipes.RecipeDetectionResult) *RecipeInstallBuilder {
+	for _, detectionResult := range detectionResults {
+		rib.recipeDetector.AddRecipeDetectionResult(detectionResult)
+	}
 	return rib
 }
 
@@ -92,6 +94,11 @@ func (rib *RecipeInstallBuilder) WithConfigValidatorError(err error) *RecipeInst
 
 func (rib *RecipeInstallBuilder) WithDiscovererError(err error) *RecipeInstallBuilder {
 	rib.discoverer.Error = err
+	return rib
+}
+
+func (rib *RecipeInstallBuilder) WithRecipeStatus(rss ...*execution.RecipeStatus) *RecipeInstallBuilder {
+	rib.status.Statuses = append(rib.status.Statuses, rss...)
 	return rib
 }
 

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -382,8 +382,9 @@ func (i *RecipeInstall) getRecipeRecommendations(availableRecipes recipes.Recipe
 			installed := i.status.RecipeHasStatus(recipeName, execution.RecipeStatusTypes.INSTALLED)
 			failed := i.status.RecipeHasStatus(recipeName, execution.RecipeStatusTypes.FAILED)
 			unsupported := i.status.RecipeHasStatus(recipeName, execution.RecipeStatusTypes.UNSUPPORTED)
+			canceled := i.status.RecipeHasStatus(recipeName, execution.RecipeStatusTypes.CANCELED)
 
-			if installed || failed || unsupported {
+			if installed || failed || unsupported || canceled {
 				continue
 			}
 			e := execution.RecipeStatusEvent{Recipe: *d.Recipe, ValidationDurationMs: d.DurationMs}
@@ -715,6 +716,7 @@ func (i *RecipeInstall) executeAndValidateWithProgress(ctx context.Context, m *t
 		case err := <-errorChan:
 			if errors.Is(err, types.ErrInterrupt) {
 				i.progressIndicator.Canceled("Installing " + r.DisplayName)
+				i.status.RecipeCanceled(execution.RecipeStatusEvent{Recipe: *r})
 			} else {
 				// progressIndicator has already been called; we need to finish i.e. message about logs being sent
 				// and actually post logs to NR if the user has opted-in


### PR DESCRIPTION
Summary: Node agent prompt the user if they want to install during installation. If the user answers no, the install recipe will cancel out. CLI is currently not recording the cancel status for this event.
Fix: Report cancels the event for the recipe when they cancel inside recipe install.

Also, the terminal reporter does not print a summary if there are any recipes that are canceled. Updated to output install result even if there are some recipe that was canceled.