### PR TITLE
fix(install): Segment complete report and nil error when segment file missing

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -104,7 +104,7 @@ func initSegment() *segment.Segment {
 	writeKey, err := recipes.NewEmbeddedRecipeFetcher().GetSegmentWriteKey()
 	if err != nil {
 		log.Debug("segment: error reading write key, cannot write to segment", err)
-		return nil
+		return segment.NewNoOp()
 	}
 
 	return segment.New(writeKey, accountID, region, isProxyConfigured)

--- a/internal/install/execution/install_status.go
+++ b/internal/install/execution/install_status.go
@@ -32,10 +32,12 @@ type InstallStatus struct {
 	HasSkippedRecipes     bool                    `json:"hasSkippedRecipes"`
 	HasFailedRecipes      bool                    `json:"hasFailedRecipes"`
 	HasUnsupportedRecipes bool                    `json:"hasUnsupportedRecipes"`
+	Detected              []*RecipeStatus         `json:"recipesDetected"`
 	Skipped               []*RecipeStatus         `json:"recipesSkipped"`
 	Canceled              []*RecipeStatus         `json:"recipesCanceled"`
 	Failed                []*RecipeStatus         `json:"recipesFailed"`
 	Installed             []*RecipeStatus         `json:"recipesInstalled"`
+	Unsupported           []*RecipeStatus         `json:"recipesUnsupported"`
 	RedirectURL           string                  `json:"redirectUrl"`
 	HTTPSProxy            string                  `json:"httpsProxy"`
 	UpdateRequired        bool                    `json:"updateRequired"`
@@ -129,6 +131,12 @@ func (s *InstallStatus) DiscoveryComplete(dm types.DiscoveryManifest) {
 // the process match and the pre-install steps of recipe execution.
 func (s *InstallStatus) RecipeDetected(event RecipeStatusEvent) {
 	s.withRecipeEvent(event, RecipeStatusTypes.DETECTED)
+	s.Detected = append(s.Detected, &RecipeStatus{
+		Name:        event.Recipe.Name,
+		DisplayName: event.Recipe.DisplayName,
+		Status:      RecipeStatusTypes.DETECTED,
+	})
+
 	for _, r := range s.statusSubscriber {
 		if err := r.RecipeDetected(s, event); err != nil {
 			log.Debugf("Could not report recipe execution status: %s", err)
@@ -211,6 +219,11 @@ func (s *InstallStatus) RecipeSkipped(event RecipeStatusEvent) {
 
 func (s *InstallStatus) RecipeUnsupported(event RecipeStatusEvent) {
 	s.withRecipeEvent(event, RecipeStatusTypes.UNSUPPORTED)
+	s.Unsupported = append(s.Unsupported, &RecipeStatus{
+		Name:        event.Recipe.Name,
+		DisplayName: event.Recipe.DisplayName,
+		Status:      RecipeStatusTypes.UNSUPPORTED,
+	})
 
 	for _, r := range s.statusSubscriber {
 		if err := r.RecipeUnsupported(s, event); err != nil {

--- a/internal/install/execution/install_status_test.go
+++ b/internal/install/execution/install_status_test.go
@@ -1,6 +1,3 @@
-//go:build unit
-// +build unit
-
 package execution
 
 import (
@@ -189,11 +186,16 @@ func TestInstallStatus_multipleRecipeStatuses(t *testing.T) {
 	recipeCanceled := types.OpenInstallationRecipe{Name: "installing"}
 	canceledRecipeEvent := RecipeStatusEvent{Recipe: recipeCanceled, EntityGUID: "erroredGUID"}
 
+	recipeUnsupporteded := types.OpenInstallationRecipe{Name: "unsupported"}
+	unsupportRecipeEvent := RecipeStatusEvent{Recipe: recipeUnsupporteded, EntityGUID: "erroredGUID"}
+
 	s.RecipeAvailable(NewRecipeStatusEvent(&recipeInstalled))
 	s.RecipeInstalling(canceledRecipeEvent)
+	s.RecipeDetected(installedRecipeEvent)
 	s.RecipeInstalled(installedRecipeEvent)
 	s.RecipeSkipped(skippedRecipeEvent)
 	s.RecipeFailed(erroredRecipeEvent)
+	s.RecipeUnsupported(unsupportRecipeEvent)
 
 	s.InstallCanceled()
 
@@ -201,6 +203,11 @@ func TestInstallStatus_multipleRecipeStatuses(t *testing.T) {
 	require.True(t, s.HasSkippedRecipes)
 	require.True(t, s.HasCanceledRecipes)
 	require.True(t, s.HasFailedRecipes)
+	require.Equal(t, 1, len(s.Installed), "Install count")
+	require.Equal(t, 1, len(s.Skipped), "Skipped count")
+	require.Equal(t, 1, len(s.Detected), "Detected count")
+	require.Equal(t, 1, len(s.Canceled), "Canceled count")
+	require.Equal(t, 1, len(s.Unsupported), "Unsupported count")
 }
 
 func TestStatus_HTTPSProxy(t *testing.T) {

--- a/internal/install/execution/segment_report_test.go
+++ b/internal/install/execution/segment_report_test.go
@@ -134,6 +134,26 @@ func TestSegmentReporter_ShouldNoOp(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSegmentReporter_ShouldBuildCompleteEvent(t *testing.T) {
+	is := InstallStatus{}
+	is.Detected = append(is.Detected, &RecipeStatus{})
+	is.Skipped = append(is.Skipped, &RecipeStatus{})
+	is.Skipped = append(is.Skipped, &RecipeStatus{})
+	is.Canceled = append(is.Canceled, &RecipeStatus{})
+	is.Canceled = append(is.Canceled, &RecipeStatus{})
+	is.Canceled = append(is.Canceled, &RecipeStatus{})
+	is.Failed = append(is.Failed, &RecipeStatus{})
+	is.Installed = append(is.Installed, &RecipeStatus{})
+
+	ei := buildInstallCompleteEvent(&is, types.EventTypes.InstallCompleted)
+	require.Equal(t, 1, ei.AdditionalInfo["countDetected"], "Detect count")
+	require.Equal(t, 2, ei.AdditionalInfo["countSkipped"], "Skipped count")
+	require.Equal(t, 3, ei.AdditionalInfo["countCanceled"], "Canceled count")
+	require.Equal(t, 1, ei.AdditionalInfo["countFailed"], "Failed count")
+	require.Equal(t, 1, ei.AdditionalInfo["countInstalled"], "Installed count")
+	require.Equal(t, 0, ei.AdditionalInfo["countUnsupported"], "Unsupported count")
+}
+
 func initSegmentMockServer() *httptest.Server {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)

--- a/internal/install/execution/segment_reporter.go
+++ b/internal/install/execution/segment_reporter.go
@@ -85,20 +85,14 @@ func (r *SegmentReporter) InstallCanceled(status *InstallStatus) error {
 }
 
 func buildInstallCompleteEvent(status *InstallStatus, et types.EventType) *segment.EventInfo {
-	m := make(map[string]int)
-	for _, s := range status.Statuses {
-		k := string("count" + s.Status)
-		if v, ok := m[k]; ok {
-			m[k] = v + 1
-		} else {
-			m[k] = 1
-		}
-	}
 
 	ei := segment.NewEventInfo(et, "")
-	for key, v := range m {
-		ei.WithAdditionalInfo(key, v)
-	}
+	ei.WithAdditionalInfo("countDetected", len(status.Detected))
+	ei.WithAdditionalInfo("countSkipped", len(status.Skipped))
+	ei.WithAdditionalInfo("countCanceled", len(status.Canceled))
+	ei.WithAdditionalInfo("countFailed", len(status.Failed))
+	ei.WithAdditionalInfo("countInstalled", len(status.Installed))
+	ei.WithAdditionalInfo("countUnsupported", len(status.Unsupported))
 	return ei
 }
 


### PR DESCRIPTION
1. The complete count for Segment reporter reports an incorrect count since the detected status gets overwritten by other status, added a new slice to track detected and unsupported status.
2.  fix nil exception when local debugging without segment key file by returning no-op instead of nil