### PR TITLE
fix(nrql): addition of a command to retrieve nrql droprules

### DIFF
--- a/docs/cli/newrelic_nrql_droprules.md
+++ b/docs/cli/newrelic_nrql_droprules.md
@@ -1,0 +1,43 @@
+## newrelic nrql droprules
+
+Retrieves NRQL drop rules
+
+### Synopsis
+
+Retrieve NRQL drop rules
+
+The droprules command will fetch a list of NRQL drop rules linked to your account.
+
+```
+newrelic nrql droprules [flags]
+```
+
+### Examples
+
+```
+newrelic nrql droprules
+newrelic nrql droprules --limit 2
+```
+
+### Options
+
+```
+  -h, --help        help for droprules
+  -l, --limit int   number of droprules to return (default 10)
+```
+
+### Options inherited from parent commands
+
+```
+  -a, --accountId int    the account ID to use. Can be overridden by setting NEW_RELIC_ACCOUNT_ID
+      --debug            debug level logging
+      --format string    output text format [JSON, Text, YAML] (default "JSON")
+      --plain            output compact text
+      --profile string   the authentication profile to use
+      --trace            trace level logging
+```
+
+### SEE ALSO
+
+* [newrelic nrql](newrelic_nrql.md)	 - Commands for interacting with the New Relic Database
+

--- a/internal/nrql/command_droprules.go
+++ b/internal/nrql/command_droprules.go
@@ -1,0 +1,66 @@
+package nrql
+
+import (
+	"github.com/newrelic/newrelic-cli/internal/client"
+	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	dropRulesLimit int
+)
+
+var cmdDropRules = &cobra.Command{
+	Use:   "droprules",
+	Short: "Retrieve NRQL Drop Rules",
+	Long: `Retrieve NRQL Drop Rules
+
+The 'droprules' command helps fetch NRQL droprules associated with your account.
+`,
+	Example: `newrelic nrql droprules --limit <limit>`,
+	PreRun:  client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		accountID := configAPI.RequireActiveProfileAccountID()
+		result, err := client.NRClient.Nrqldroprules.GetList(accountID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if result == nil {
+			log.Info("No drop rules found, associated with your account.")
+			return
+		}
+		rulesResult := *result
+		dropRules := rulesResult.Rules
+		lengthOfDropRules := len(dropRules)
+
+		if lengthOfDropRules == 0 {
+			log.Info("No drop rules found, associated with your account.")
+			return
+		}
+
+		if dropRulesLimit == 0 {
+			log.Info("A minimum of '1' needs to be specified with the --limit flag. If not specified, the limit defaults to 10.")
+			return
+		}
+
+		if lengthOfDropRules < dropRulesLimit {
+			dropRulesLimit = lengthOfDropRules
+		}
+		dropRulesSliced := (dropRules)[0:dropRulesLimit]
+
+		outputErr := output.Print(dropRulesSliced)
+		if outputErr != nil {
+			utils.LogIfFatal(err)
+		}
+
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdDropRules)
+	cmdDropRules.Flags().IntVarP(&dropRulesLimit, "limit", "l", 10, "Number of NRQL Drop Rules to return")
+}

--- a/internal/nrql/command_droprules_test.go
+++ b/internal/nrql/command_droprules_test.go
@@ -1,0 +1,16 @@
+//go:build unit
+// +build unit
+
+package nrql
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDropRulesQuery(t *testing.T) {
+	assert.Equal(t, "droprules", cmdDropRules.Name())
+	testcobra.CheckCobraMetadata(t, cmdDropRules)
+}


### PR DESCRIPTION
Addition of a command to the CLI, `newrelic nrql droprules` to fetch droprules.

Arguments:
`--limit` to specify the number of rules to be printed, that defaults to 10

