### PR TITLE
chore(release): create separate release workflows for post-release jobs

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,47 @@
+name: Release - Homebrew
+
+permissions: write-all
+
+# Release workflow calls this workflow
+on:
+  workflow_call:
+    secrets:
+      RELEASE_TOKEN:
+        required: true
+      DEV_TOOLKIT_TOKEN:
+        required: true
+
+jobs:
+  release-homebrew:
+    name: Create Homebrew Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.18.x
+
+      - name: Add GOBIN to PATH
+        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        shell: bash
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Needed for release notes
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Checkout newrelic-forks/homebrew-core
+        uses: actions/checkout@v3
+        with:
+          repository: newrelic-forks/homebrew-core
+          path: homebrew-core
+          token: ${{ secrets.DEV_TOOLKIT_TOKEN }}
+
+      - name: Create homebrew-core pull request
+        shell: bash
+        run: ./scripts/brew_formula_pull_request.sh
+        env:
+          GH_USER_EMAIL: developer-toolkit-team@newrelic.com
+          GH_USER_NAME: 'New Relic Developer Toolkit Bot'

--- a/.github/workflows/release-publish-windows.yml
+++ b/.github/workflows/release-publish-windows.yml
@@ -1,0 +1,136 @@
+name: Release - Homebrew
+
+permissions: write-all
+
+# Release workflow calls this workflow
+on:
+  workflow_call:
+    secrets:
+      RELEASE_TOKEN:
+        required: true
+      DEV_TOOLKIT_TOKEN:
+        required: true
+      CHOCOLATEY_API_KEY:
+        required: true
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      AWS_ROLE_ARN:
+        required: true
+      AWS_DEFAULT_REGION:
+        required: true
+
+jobs:
+  release-windows:
+    name: Publish Windows Release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Output latest tag
+        id: latest-tag
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+
+          echo " "
+          echo "Latest tag - before: ${tag}"
+          echo " "
+
+          git fetch origin
+          git fetch --tags
+
+          latestTag=$(git describe --tags --abbrev=0)
+
+          echo " "
+          echo "Latest tag - after:  ${latestTag}"
+          echo " "
+
+          echo '::set-output name=NEW_RELIC_CLI_VERSION::${latestTag}'
+
+      - name: Install aws cli
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install awscli -y
+
+      - name: Write AWS config 1
+        uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: /home/runner/.aws/credentials
+          contents:  |
+            [virtuoso_user]
+            aws_access_key_id=${{ secrets.AWS_ACCESS_KEY_ID }}
+            aws_secret_access_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          write-mode: overwrite
+
+      - name: Write AWS config 2
+        uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: /home/runner/.aws/config
+          contents:  |
+            [profile virtuoso]
+            role_arn = ${{ secrets.AWS_ROLE_ARN }}
+            region = ${{ secrets.AWS_DEFAULT_REGION }}
+            source_profile = virtuoso_user
+          write-mode: overwrite
+
+      - name: Get latest tag
+        id: get-latest-tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+
+      - name: Fetch Github Release Asset - NewRelicCLIInstaller.msi
+        uses: dsaltares/fetch-gh-release-asset@0.06
+        with:
+          repo: "newrelic/newrelic-cli"
+          version: "tags/${{ steps.get-latest-tag.outputs.tag }}"
+          file: "NewRelicCLIInstaller.msi"
+          target: "NewRelicCLIInstaller.msi"
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Fetch Github Release Asset - install.ps1
+        uses: dsaltares/fetch-gh-release-asset@0.06
+        with:
+          repo: "newrelic/newrelic-cli"
+          version: "tags/${{ steps.get-latest-tag.outputs.tag }}"
+          file: "install.ps1"
+          target: "./scripts/install.ps1"
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Upload Windows install script to AWS S3
+        id: upload-install-script-windows
+        run: |
+          aws s3 cp ./scripts/install.ps1 s3://nr-downloads-main/install/newrelic-cli/scripts/install.ps1 --profile virtuoso
+
+      - name: Upload Windows MSI
+        id: upload-windows-msi
+        run: |
+          aws s3 cp NewRelicCLIInstaller.msi s3://nr-downloads-main/install/newrelic-cli/${{ steps.get-latest-tag.outputs.tag }}/NewRelicCLIInstaller.msi --profile virtuoso
+
+      - name: Create currentVersion.txt
+        id: create-current-version
+        uses: "finnp/create-file-action@v1"
+        env:
+          FILE_NAME: "currentVersion.txt"
+          FILE_DATA: "${{ steps.get-latest-tag.outputs.tag }}"
+
+      - name: Upload currentVersion.txt
+        id: upload-current-version
+        run: |
+          aws s3 cp currentVersion.txt s3://nr-downloads-main/install/newrelic-cli/currentVersion.txt --profile virtuoso --cache-control no-cache
+
+      - name: Upload chocolatey package
+        shell: bash
+        continue-on-error: true
+        run: make chocolatey-publish
+        env:
+          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+
+      - name: Cleanup configs
+        run: |
+          rm -rf /home/runner/.aws/credentials
+          rm -rf /home/runner/.aws/config

--- a/.github/workflows/release-windows-installer.yml
+++ b/.github/workflows/release-windows-installer.yml
@@ -1,0 +1,94 @@
+name: Release - Windows Installer
+
+permissions: write-all
+
+# Release workflow calls this workflow
+on:
+  workflow_call:
+    secrets:
+      RELEASE_TOKEN:
+        required: true
+      PFX_BASE64_CONTENT:
+        required: true
+      PFX_CERT_PASSWORD:
+        required: true
+
+jobs:
+  release-windows-installer:
+    name: Create Windows Release
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.3
+
+      - name: Download Windows binary
+        uses: actions/download-artifact@v3
+        with:
+          name: windows-binary
+          path: .\dist\newrelic_windows_amd64_v1
+
+      - name: Compile installer
+        run: msbuild .\build\package\msi\NewRelicCLIInstaller.sln
+
+      - name: Create PFX certificate
+        id: create-pfx
+        env:
+          PFX_CONTENT: ${{ secrets.PFX_BASE64_CONTENT }}
+        run: |
+          $pfxPath = Join-Path -Path $env:RUNNER_TEMP -ChildPath "cert.pfx";
+          $encodedBytes = [System.Convert]::FromBase64String($env:PFX_CONTENT);
+          Set-Content $pfxPath -Value $encodedBytes -AsByteStream;
+          Write-Output "::set-output name=PFX_PATH::$pfxPath";
+
+      - name: Sign installer
+        env:
+          PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
+        working-directory: .\build\package\msi\NewRelicCLIInstaller
+        run: .\SignMSI.cmd
+
+      - name: Sign install script
+        env:
+          PFX_PASSWORD: ${{ secrets.PFX_CERT_PASSWORD }}
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
+        working-directory: .\
+        run: .\build\package\msi\NewRelicCLIInstaller\SignPS1.cmd
+
+      - name: Delete PFX certificate
+        env:
+          PFX_PATH: ${{ steps.create-pfx.outputs.PFX_PATH }}
+        run: |
+          Remove-Item -Path $env:PFX_PATH;
+
+      - name: Get latest release upload URL
+        id: get-latest-release-upload-url
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: echo "::set-output name=upload_url::$(./scripts/get_latest_release_upload_url.sh)"
+
+      - name: Upload Windows installer
+        id: upload-windows-installer
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
+          asset_path: .\build\package\msi\NewRelicCLIInstaller\bin\x64\Release\NewRelicCLIInstaller.msi
+          asset_name: NewRelicCLIInstaller.msi
+          asset_content_type: application/octet-stream
+
+      - name: Upload windows install script
+        id: upload-windows-install-script
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        with:
+          upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
+          asset_path: .\scripts\install.ps1
+          asset_name: install.ps1
+          asset_content_type: application/octet-stream
+


### PR DESCRIPTION
This PR is just to add the new release workflow files. A follow-up PR will created to wire them up.

Note: These new files are not wired up and do not affect our release workflow until the follow-up PR is merged.