### PR TITLE
chore(synthetics_draft): parsing query results of `automatedTestResults`

### DIFF
--- a/internal/synthetics/command_monitor_test.go
+++ b/internal/synthetics/command_monitor_test.go
@@ -1,10 +1,12 @@
-//go:build unit
-// +build unit
-
 package synthetics
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -37,4 +39,106 @@ func TestSyntheticsMonitorList(t *testing.T) {
 
 	testcobra.CheckCobraMetadata(t, cmdMonList)
 	testcobra.CheckCobraRequiredFlags(t, cmdMonList, []string{})
+}
+
+// CHANGE THIS VARIABLE to use the three mock JSON scenarios
+var scenario = 1
+
+func TestNewFunctionality(t *testing.T) {
+	//original : batchID would come from the result of the syntheticsStartAutomationTest mutation
+	batchID := "36488dff-9a8a-4358-8ef2-e73da3c118e0"
+	apiTimeout := time.Minute * 5
+
+	start := time.Now()
+	i := 0
+	for {
+		if time.Since(start) > apiTimeout {
+			fmt.Println("Halting execution : reached timeout.")
+			break
+		}
+
+		i++
+
+		//result, err := functionInClientGo(automatedTestResultQueryInput{batchID: batchID})
+		root := fakeAutomatedTestResultQuery(batchID, i)
+		//if err != nil {
+		//	return fmt.Errorf("Some error")
+		//}
+
+		if root.Status == "TIMED_OUT" || root.Status == "PASSED" || root.Status == "FAILED" {
+			fmt.Printf("Execution stopped - Status: %s\n", root.Status)
+			fakePrintMonitorStatus(root)
+			break
+		} else if root.Status == "IN_PROGRESS" {
+			fmt.Println("Status still IN_PROGRESS, calling API again in 15 seconds")
+			fakePrintMonitorStatus(root)
+			fmt.Println()
+			time.Sleep(time.Second * 15)
+		} else {
+			fmt.Printf("Unexpected status: %s\n", root.Status)
+			break
+		}
+	}
+
+}
+
+func fakeAutomatedTestResultQuery(batchID string, index int) (r Root) {
+	directory := fmt.Sprintf("mock_json/Scenario %d", scenario)
+	filePath := fmt.Sprintf("%s/response_%d.json", directory, index)
+	jsonFile, err := os.Open(filePath)
+	if err != nil {
+		fmt.Println("Error opening file:", err)
+		return
+	}
+	defer jsonFile.Close()
+
+	byteValue, err := ioutil.ReadAll(jsonFile)
+	if err != nil {
+		fmt.Println("Error reading file:", err)
+		return
+	}
+
+	var root Root
+	if err := json.Unmarshal(byteValue, &root); err != nil {
+		fmt.Println("Error unmarshaling JSON:", err)
+		return
+	}
+
+	return root
+}
+
+func fakePrintMonitorStatus(root Root) {
+	countSuccess := 0
+	countFailure := 0
+	countProgress := 0
+	tests := root.Tests
+
+	for _, test := range tests {
+		if test.Result == "SUCCESS" {
+			countSuccess++
+		} else if test.Result == "FAILED" {
+			countFailure++
+		} else if test.Result == "IN_PROGRESS" || test.Result == "" {
+			countProgress++
+		}
+	}
+
+	fmt.Println("Successful Tests: ", countSuccess)
+	fmt.Println("Failed Tests: ", countFailure)
+}
+
+// Temporary Data Structures
+type Test struct {
+	Id          string `json:"id"`
+	BatchID     string `json:"batchId"`
+	MonitorID   string `json:"monitorId"`
+	MonitorGUID string `json:"monitorGuid"`
+	MonitorName string `json:"monitorName"`
+	Result      string `json:"result"`
+}
+
+type Root struct {
+	Tests  []Test                 `json:"tests"`
+	Config map[string]interface{} `json:"config"`
+	Status string                 `json:"status"`
 }

--- a/internal/synthetics/mock_json/Scenario 1/response_1.json
+++ b/internal/synthetics/mock_json/Scenario 1/response_1.json
@@ -1,0 +1,68 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZz",
+            "monitorName":"Test Monitor 2",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"IN_PROGRESS"
+}

--- a/internal/synthetics/mock_json/Scenario 1/response_2.json
+++ b/internal/synthetics/mock_json/Scenario 1/response_2.json
@@ -1,0 +1,68 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZz",
+            "monitorName":"Test Monitor 2",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"PASSED"
+}

--- a/internal/synthetics/mock_json/Scenario 2/response_1.json
+++ b/internal/synthetics/mock_json/Scenario 2/response_1.json
@@ -1,0 +1,94 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZZ",
+            "monitorName":"Test Monitor 2",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        },
+        {
+            "id":"1b3cb04e-5c1e-4613-b864-656eb19b991f",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"61a02139-eda5-47ee-aaaa-1fca1e6ed43f",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTWW",
+            "monitorName":"Test Monitor 3",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"IN_PROGRESS"
+}

--- a/internal/synthetics/mock_json/Scenario 2/response_2.json
+++ b/internal/synthetics/mock_json/Scenario 2/response_2.json
@@ -1,0 +1,94 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZZ",
+            "monitorName":"Test Monitor 2",
+            "result":"FAILED",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        },
+        {
+            "id":"1b3cb04e-5c1e-4613-b864-656eb19b991f",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"61a02139-eda5-47ee-aaaa-1fca1e6ed43f",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTWW",
+            "monitorName":"Test Monitor 3",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"IN_PROGRESS"
+}

--- a/internal/synthetics/mock_json/Scenario 2/response_3.json
+++ b/internal/synthetics/mock_json/Scenario 2/response_3.json
@@ -1,0 +1,94 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZZ",
+            "monitorName":"Test Monitor 2",
+            "result":"FAILED",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        },
+        {
+            "id":"1b3cb04e-5c1e-4613-b864-656eb19b991f",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"61a02139-eda5-47ee-aaaa-1fca1e6ed43f",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTWW",
+            "monitorName":"Test Monitor 3",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"PASSED"
+}

--- a/internal/synthetics/mock_json/Scenario 3/response_1.json
+++ b/internal/synthetics/mock_json/Scenario 3/response_1.json
@@ -1,0 +1,94 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZZ",
+            "monitorName":"Test Monitor 2",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        },
+        {
+            "id":"1b3cb04e-5c1e-4613-b864-656eb19b991f",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"61a02139-eda5-47ee-aaaa-1fca1e6ed43f",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTWW",
+            "monitorName":"Test Monitor 3",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"IN_PROGRESS"
+}

--- a/internal/synthetics/mock_json/Scenario 3/response_2.json
+++ b/internal/synthetics/mock_json/Scenario 3/response_2.json
@@ -1,0 +1,94 @@
+{
+    "tests":[
+        {
+            "id":"6cd8e447-7af6-4885-9749-4029f7c5a9b6",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"8bb289b9-8dc7-4f3e-b759-3cb84ed3ae62",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTYy",
+            "monitorName":"Test Monitor 1",
+            "result":"FAILED",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        },
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":true
+            }
+        },
+        {
+            "id":"102d76ea-6b80-4aab-93b1-43fdf779afc5",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"f30a1a3f-9c7e-48b3-8dfb-c78164a14979",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTZZ",
+            "monitorName":"Test Monitor 2",
+            "result":"IN_PROGRESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        },
+        {
+            "id":"1b3cb04e-5c1e-4613-b864-656eb19b991f",
+            "batchId":"36488dff-9a8a-4358-8ef2-e73da3c118e0",
+            "monitorId":"61a02139-eda5-47ee-aaaa-1fca1e6ed43f",
+            "monitorGuid":"MTIzfFNZTlRIfE1PTklUT1J8OGJiMjg5YjktOGRjNy00ZjNlLWI3NTktM2NiODRlZDNhZTWW",
+            "monitorName":"Test Monitor 3",
+            "result":"SUCCESS",
+            "type":"SCRIPT_API",
+            "typeLabel":"Scripted Api",
+            "duration":100,
+            "location":"AWS_US_EAST_1",
+            "locationLabel":"Washington DC",
+            "resultsUrl":"https://theresultsurl.com",
+            "automatedTestMonitorConfig":{
+                "overrides":{
+                    "secureCredential":[
+                        {
+                            "key":"TARGETKEY",
+                            "overrideKey":"OVERRIDEKEY"
+                        }
+                    ],
+                    "location":"LOCALHOST"
+                },
+                "isBlocking":false
+            }
+        }
+    ],
+    "config":{
+        "branch":"random/test-branch",
+        "commit":"thecommitshaAD325493GSH",
+        "platform":"exampleplatform",
+        "deepLink":"https://vertasvalbit.com",
+        "batchName":"Test Batch Name"
+    },
+    "status":"FAILED"
+}


### PR DESCRIPTION
**DO NOT MERGE**

This is a bare experimentation of implementing the second part of the CLI feature for Synthetics, to loop across the results of the `automatedTestResults` API based on the consolidated status and status of monitors.

The implementation relies on mock JSON responses as the API is not yet public.

cc @NSSPKrishna (this can be added after the YAML interpretation part - after the `batchId` is obtained from the result of `syntheticsCreateAutomatedTest`. Also, this is a lot of rough work and experimentation, may not be good enough for sure but the looping logic is what might remain common in the real API-based implementation)

This was written in a file with test cases in order to be able to run the added functions, and can be tested by changing the variable `scenario` to 1 or 2 or 3 and running the test `TestNewFunctionality`