### PR TITLE
feat: entity deployment customattributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.19.6
+	github.com/newrelic/newrelic-client-go/v2 v2.20.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -131,10 +131,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/newrelic/newrelic-client-go/v2 v2.12.0 h1:w1gCmKkQqQtG/z4HNDs/5dT2lQAssMaJamTH+Vo2P8Y=
-github.com/newrelic/newrelic-client-go/v2 v2.12.0/go.mod h1:xDZ6IDWI6fpl7MhTI4Hk75alJLAIfXzOt/rINEolxhQ=
-github.com/newrelic/newrelic-client-go/v2 v2.19.6 h1:nKMVor/8ujdF37dipVzk+Tq13Mv3bEfGDDSW63C8PY0=
-github.com/newrelic/newrelic-client-go/v2 v2.19.6/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.20.0 h1:87aHvOCnv8MeZL6pm4VptjZKFxatmQq//35onHGBVic=
+github.com/newrelic/newrelic-client-go/v2 v2.20.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -19,16 +19,16 @@ import (
 )
 
 var (
-	attribute      string
-	changelog      string
-	commit         string
-	deepLink       string
-	deploymentType string
-	description    string
-	groupID        string
-	timestamp      int64
-	user           string
-	version        string
+	changelog       string
+	commit          string
+	customAttribute string
+	deepLink        string
+	deploymentType  string
+	description     string
+	groupID         string
+	timestamp       int64
+	user            string
+	version         string
 )
 
 var cmdEntityDeployment = &cobra.Command{
@@ -63,7 +63,7 @@ The deployment command marks a change for a New Relic entity
 			log.Fatal("--version cannot be empty")
 		}
 
-		customAttributes, err := parseAttributes(attribute)
+		customAttributes, err := parseCustomAttributes(customAttribute)
 
 		if err != nil {
 			log.Fatal(err)
@@ -97,9 +97,9 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVarP(&version, "version", "v", "", "the version of the deployed software, for example, something like v1.1. version is required.")
 	utils.LogIfError(cmdEntityDeploymentCreate.MarkFlagRequired("version"))
 
-	cmdEntityDeploymentCreate.Flags().StringVar(&attribute, "attribute", "", "(EARLY ACCESS) a comma separated list of key:value attributes to apply to the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&changelog, "changelog", "", "a URL for the changelog or list of changes if not linkable")
 	cmdEntityDeploymentCreate.Flags().StringVar(&commit, "commit", "", "the commit identifier, for example, a Git commit SHA")
+	cmdEntityDeploymentCreate.Flags().StringVar(&customAttribute, "customAttribute", "", "(EARLY ACCESS) a comma separated list of key:value custom attributes to apply to the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deepLink, "deepLink", "", "a link back to the system generating the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deploymentType, "deploymentType", "", "type of deployment, one of BASIC, BLUE_GREEN, CANARY, OTHER, ROLLING or SHADOW")
 	cmdEntityDeploymentCreate.Flags().StringVar(&description, "description", "", "a description of the deployment")
@@ -108,24 +108,24 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVarP(&user, "user", "u", "", "username of the deployer or bot")
 }
 
-func parseAttributes(a string) (*map[string]string, error) {
-	attributeMap := make(map[string]string)
+func parseCustomAttributes(a string) (*map[string]string, error) {
+	customAttributeMap := make(map[string]string)
 
 	if a == "" {
 		return nil, nil
 	}
 
-	attributes := strings.Split(a, ",")
+	customAttributeSlice := strings.Split(a, ",")
 
-	for _, v := range attributes {
+	for _, v := range customAttributeSlice {
 		pair := strings.Split(v, ":")
 
 		if len(pair) != 2 {
-			return nil, errors.New("invalid format, please use comma separated key-value pairs (--attribute key1,value1:key2,value2)")
+			return nil, errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
 		}
 
-		attributeMap[pair[0]] = pair[1]
+		customAttributeMap[pair[0]] = pair[1]
 	}
 
-	return &attributeMap, nil
+	return &customAttributeMap, nil
 }

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -121,7 +121,7 @@ func parseCustomAttributes(a string) (*map[string]string, error) {
 		pair := strings.Split(v, ":")
 
 		if len(pair) != 2 {
-			return nil, errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
+			return nil, errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1:value1,key2:value2)")
 		}
 
 		customAttributeMap[pair[0]] = pair[1]

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/newrelic/newrelic-cli/internal/testcobra"
@@ -20,4 +21,73 @@ func TestEntityDeploymentCreate(t *testing.T) {
 	testcobra.CheckCobraMetadata(t, cmdEntityDeploymentCreate)
 	testcobra.CheckCobraRequiredFlags(t, cmdEntityDeploymentCreate,
 		[]string{"guid", "version"})
+}
+
+func TestParseAttributesSingleKeyValue(t *testing.T) {
+	a := "key:value"
+
+	var want = map[string]string{
+		"key": "value",
+	}
+	var errWant error = nil
+
+	got, errGot := parseAttributes(a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesTwoKeyValues(t *testing.T) {
+	a := "key:value,key2:value2"
+
+	var want = map[string]string{
+		"key":  "value",
+		"key2": "value2",
+	}
+	var errWant error = nil
+
+	got, errGot := parseAttributes(a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesKeyNoValue(t *testing.T) {
+	a := "key"
+
+	want := nilPointerMapStringString()
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--attribute key1,value1:key2,value2)")
+
+	got, errGot := parseAttributes(a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, got)
+}
+
+func TestParseAttributesTooManyColons(t *testing.T) {
+	a := "key:value:extra"
+
+	want := nilPointerMapStringString()
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--attribute key1,value1:key2,value2)")
+
+	got, errGot := parseAttributes(a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, got)
+}
+
+func TestParseAttributesEmptyString(t *testing.T) {
+	a := ""
+
+	want := nilPointerMapStringString()
+	var errWant error = nil
+
+	got, errGot := parseAttributes(a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, got)
+}
+
+func nilPointerMapStringString() *map[string]string {
+	return nil
 }

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -29,7 +29,7 @@ func TestParseAttributesSingleKeyValue(t *testing.T) {
 	var want = map[string]string{
 		"key": "value",
 	}
-	var errWant error = nil
+	var errWant error
 
 	got, errGot := parseAttributes(a)
 
@@ -44,7 +44,7 @@ func TestParseAttributesTwoKeyValues(t *testing.T) {
 		"key":  "value",
 		"key2": "value2",
 	}
-	var errWant error = nil
+	var errWant error
 
 	got, errGot := parseAttributes(a)
 
@@ -80,7 +80,7 @@ func TestParseAttributesEmptyString(t *testing.T) {
 	a := ""
 
 	want := nilPointerMapStringString()
-	var errWant error = nil
+	var errWant error
 
 	got, errGot := parseAttributes(a)
 

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -31,7 +31,7 @@ func TestParseAttributesSingleKeyValue(t *testing.T) {
 	}
 	var errWant error
 
-	got, errGot := parseAttributes(a)
+	got, errGot := parseCustomAttributes(a)
 
 	assert.Equal(t, errWant, errGot)
 	assert.Equal(t, want, *got)
@@ -46,7 +46,7 @@ func TestParseAttributesTwoKeyValues(t *testing.T) {
 	}
 	var errWant error
 
-	got, errGot := parseAttributes(a)
+	got, errGot := parseCustomAttributes(a)
 
 	assert.Equal(t, errWant, errGot)
 	assert.Equal(t, want, *got)
@@ -56,9 +56,9 @@ func TestParseAttributesKeyNoValue(t *testing.T) {
 	a := "key"
 
 	want := nilPointerMapStringString()
-	errWant := errors.New("invalid format, please use comma separated key-value pairs (--attribute key1,value1:key2,value2)")
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
 
-	got, errGot := parseAttributes(a)
+	got, errGot := parseCustomAttributes(a)
 
 	assert.Equal(t, errWant, errGot)
 	assert.Equal(t, want, got)
@@ -68,9 +68,9 @@ func TestParseAttributesTooManyColons(t *testing.T) {
 	a := "key:value:extra"
 
 	want := nilPointerMapStringString()
-	errWant := errors.New("invalid format, please use comma separated key-value pairs (--attribute key1,value1:key2,value2)")
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
 
-	got, errGot := parseAttributes(a)
+	got, errGot := parseCustomAttributes(a)
 
 	assert.Equal(t, errWant, errGot)
 	assert.Equal(t, want, got)
@@ -82,7 +82,7 @@ func TestParseAttributesEmptyString(t *testing.T) {
 	want := nilPointerMapStringString()
 	var errWant error
 
-	got, errGot := parseAttributes(a)
+	got, errGot := parseCustomAttributes(a)
 
 	assert.Equal(t, errWant, errGot)
 	assert.Equal(t, want, got)

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -56,7 +56,7 @@ func TestParseAttributesKeyNoValue(t *testing.T) {
 	a := "key"
 
 	want := nilPointerMapStringString()
-	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1:value1,key2:value2)")
 
 	got, errGot := parseCustomAttributes(a)
 
@@ -68,7 +68,7 @@ func TestParseAttributesTooManyColons(t *testing.T) {
 	a := "key:value:extra"
 
 	want := nilPointerMapStringString()
-	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1,value1:key2,value2)")
+	errWant := errors.New("invalid format, please use comma separated key-value pairs (--customAttribute key1:value1,key2:value2)")
 
 	got, errGot := parseCustomAttributes(a)
 


### PR DESCRIPTION
Adds the --attribute flag to the entity deployment create command, allowing the user to optionally add custom attributes to deployment markers.