### PR TITLE
feat: Support Targeted Only Schema Update

### DIFF
--- a/internal/install/recipe_install_builder.go
+++ b/internal/install/recipe_install_builder.go
@@ -182,7 +182,7 @@ func (rib *RecipeInstallBuilder) Build() *RecipeInstall {
 	recipeInstall.progressIndicator = rib.progressIndicator
 	recipeInstall.agentValidator = rib.agentValidator
 	recipeInstall.recipeValidator = rib.recipeValidator
-	recipeInstall.recipeDetectorFactory = func(ctx context.Context, repo *recipes.RecipeRepository) RecipeStatusDetector {
+	recipeInstall.recipeDetectorFactory = func(ctx context.Context, repo *recipes.RecipeRepository, ic *types.InstallerContext) RecipeStatusDetector {
 		return rib.recipeDetector
 	}
 	mockProcessEvaluator := recipes.NewMockProcessEvaluator()

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -168,14 +168,15 @@ func TestInstallGuidedShouldNotSkipCoreInstall(t *testing.T) {
 	assert.Equal(t, 1, statusReporter.ReportInstalled[r.Recipe.Name], "Recipe1 Installed")
 	assert.Equal(t, 1, statusReporter.ReportInstalled[r2.Recipe.Name], "Recipe2 Installed")
 }
+
 func TestInstallGuidedShouldSkipOTEL(t *testing.T) {
 	r := &recipes.RecipeDetectionResult{
 		Recipe: recipes.NewRecipeBuilder().Name(types.InfraAgentRecipeName).Build(),
 		Status: execution.RecipeStatusTypes.AVAILABLE,
 	}
 	r2 := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name(types.OTELRecipeName).Build(),
-		Status: execution.RecipeStatusTypes.AVAILABLE,
+		Recipe: recipes.NewRecipeBuilder().Name("OTEL").WithRecipeTargetedOnly(true).Build(),
+		Status: execution.RecipeStatusTypes.NULL,
 	}
 	statusReporter := execution.NewMockStatusReporter()
 	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).WithRecipeDetectionResult(r2).WithStatusReporter(statusReporter).Build()
@@ -257,11 +258,11 @@ func TestInstallTargetedInstallShouldInstallWithRecomendataion(t *testing.T) {
 
 func TestInstallTargetedShouldNotSkipOTEL(t *testing.T) {
 	r := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name(types.OTELRecipeName).Build(),
+		Recipe: recipes.NewRecipeBuilder().Name("OTEL").Build(),
 		Status: execution.RecipeStatusTypes.AVAILABLE,
 	}
 	statusReporter := execution.NewMockStatusReporter()
-	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).WithTargetRecipeName(types.OTELRecipeName).WithStatusReporter(statusReporter).Build()
+	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).WithTargetRecipeName("OTEL").WithStatusReporter(statusReporter).Build()
 	recipeInstall.AssumeYes = true
 	err := recipeInstall.Install()
 
@@ -534,7 +535,6 @@ func TestInstallWhenInstallIsCancelled(t *testing.T) {
 }
 
 func TestInstallWhenInstallIsUnsupported(t *testing.T) {
-
 	expected := &types.UnsupportedOperatingSystemError{Err: errors.New("Unsupported")}
 	r := &recipes.RecipeDetectionResult{
 		Recipe: recipes.NewRecipeBuilder().Name("Other").Build(),
@@ -555,7 +555,6 @@ func TestInstallWhenInstallIsUnsupported(t *testing.T) {
 	assert.Equal(t, 0, statusReporter.RecipeRecommendedCallCount, "Recommendation Count")
 	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")
 	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
-
 }
 
 func TestExecuteAndValidateWithProgressWhenInstallWithNoValidationMethod(t *testing.T) {

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -175,7 +175,9 @@ func TestInstallGuidedShouldSkipOTEL(t *testing.T) {
 		Status: execution.RecipeStatusTypes.AVAILABLE,
 	}
 	r2 := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name("OTEL").WithRecipeTargetedOnly(true).Build(),
+		Recipe: recipes.NewRecipeBuilder().Name("OTEL").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{
+			types.OpenInstallationDiscoveryModeTypes.TARGETED,
+		}).Build(),
 		Status: execution.RecipeStatusTypes.NULL,
 	}
 	statusReporter := execution.NewMockStatusReporter()

--- a/internal/install/recipes/recipe_builder.go
+++ b/internal/install/recipes/recipe_builder.go
@@ -11,6 +11,7 @@ type RecipeBuilder struct {
 	id                  string
 	name                string
 	requireAtDiscovery  string
+	TargetInstallOnly   bool
 	goTaskInstallScript string
 	processMatches      []string
 	targets             []types.OpenInstallationRecipeInstallTarget
@@ -39,6 +40,11 @@ func (b *RecipeBuilder) Name(name string) *RecipeBuilder {
 
 func (b *RecipeBuilder) WithPreInstallScript(script string) *RecipeBuilder {
 	b.requireAtDiscovery = script
+	return b
+}
+
+func (b *RecipeBuilder) WithRecipeTargetedOnly(shouldInclude bool) *RecipeBuilder {
+	b.TargetInstallOnly = shouldInclude
 	return b
 }
 
@@ -89,7 +95,7 @@ func (b *RecipeBuilder) InstallGoTaskScript(script string) *RecipeBuilder {
 }
 
 func (b *RecipeBuilder) InstallShell(script string) *RecipeBuilder {
-	var goTaskWrap = fmt.Sprintf(`
+	goTaskWrap := fmt.Sprintf(`
 version: '3'
 tasks:
   default:
@@ -115,7 +121,8 @@ func (b *RecipeBuilder) Build() *types.OpenInstallationRecipe {
 		ID:   b.id,
 		Name: b.name,
 		PreInstall: types.OpenInstallationPreInstallConfiguration{
-			RequireAtDiscovery: b.requireAtDiscovery,
+			RequireAtDiscovery:  b.requireAtDiscovery,
+			TargetedInstallOnly: b.TargetInstallOnly,
 		},
 		Install: b.goTaskInstallScript,
 	}

--- a/internal/install/recipes/recipe_builder.go
+++ b/internal/install/recipes/recipe_builder.go
@@ -11,7 +11,7 @@ type RecipeBuilder struct {
 	id                  string
 	name                string
 	requireAtDiscovery  string
-	TargetInstallOnly   bool
+	DiscoveryMode       []types.OpenInstallationDiscoveryMode
 	goTaskInstallScript string
 	processMatches      []string
 	targets             []types.OpenInstallationRecipeInstallTarget
@@ -25,6 +25,10 @@ func NewRecipeBuilder() *RecipeBuilder {
 		id:   "id1",
 		name: "recipe1",
 		vars: make(map[string]string),
+		DiscoveryMode: []types.OpenInstallationDiscoveryMode{
+			types.OpenInstallationDiscoveryModeTypes.GUIDED,
+			types.OpenInstallationDiscoveryModeTypes.TARGETED,
+		},
 	}
 }
 
@@ -43,8 +47,8 @@ func (b *RecipeBuilder) WithPreInstallScript(script string) *RecipeBuilder {
 	return b
 }
 
-func (b *RecipeBuilder) WithRecipeTargetedOnly(shouldInclude bool) *RecipeBuilder {
-	b.TargetInstallOnly = shouldInclude
+func (b *RecipeBuilder) WithDiscoveryMode(discoveryMode []types.OpenInstallationDiscoveryMode) *RecipeBuilder {
+	b.DiscoveryMode = discoveryMode
 	return b
 }
 
@@ -121,8 +125,8 @@ func (b *RecipeBuilder) Build() *types.OpenInstallationRecipe {
 		ID:   b.id,
 		Name: b.name,
 		PreInstall: types.OpenInstallationPreInstallConfiguration{
-			RequireAtDiscovery:  b.requireAtDiscovery,
-			TargetedInstallOnly: b.TargetInstallOnly,
+			RequireAtDiscovery: b.requireAtDiscovery,
+			DiscoveryMode:      b.DiscoveryMode,
 		},
 		Install: b.goTaskInstallScript,
 	}

--- a/internal/install/recipes/recipe_detector.go
+++ b/internal/install/recipes/recipe_detector.go
@@ -85,15 +85,6 @@ func (dt *RecipeDetector) GetDetectedRecipes() (RecipeDetectionResults, RecipeDe
 }
 
 func (dt *RecipeDetector) shouldDiscover(recipe *types.OpenInstallationRecipe) bool {
-	// both modes, targeted and guided
-	if len(recipe.PreInstall.DiscoveryMode) >= 2 {
-		return true
-	}
-
-	if len(recipe.PreInstall.DiscoveryMode) == 0 {
-		return false
-	}
-
 	isTargeted := dt.installerContext.IsRecipeTargeted(recipe.Name)
 	if len(recipe.PreInstall.DiscoveryMode) == 1 &&
 		(recipe.PreInstall.DiscoveryMode[0] == types.OpenInstallationDiscoveryModeTypes.TARGETED) {

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -180,6 +180,7 @@ func NewRecipeDetectorTestBuilder() *RecipeDetectorTestBuilder {
 		processEvaluator: NewMockRecipeEvaluator(),
 		scriptEvaluator:  NewMockRecipeEvaluator(),
 		recipesFinder:    &MockRecipesFinder{},
+		installContext:   &types.InstallerContext{},
 	}
 }
 

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -147,7 +147,13 @@ func TestRecipeDetectorShouldDiscover(t *testing.T) {
 	require.False(t, detector.shouldDiscover(recipe), "Should not discover when targeted only and not targeted during install")
 
 	recipe = NewRecipeBuilder().Name("R1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
-	require.True(t, detector.shouldDiscover(recipe), "Should discover when targeted only and not targeted during install")
+	require.True(t, detector.shouldDiscover(recipe), "Should discover when targeted only and targeted during install")
+
+	recipe = NewRecipeBuilder().Name("C1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.GUIDED}).Build()
+	require.True(t, detector.shouldDiscover(recipe), "Should discover when guided mode")
+
+	recipe = NewRecipeBuilder().Name("C1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.GUIDED, types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
+	require.True(t, detector.shouldDiscover(recipe), "Should discover when targeted, and guided mode")
 }
 
 type MockRecipesFinder struct {

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -99,6 +99,41 @@ func TestDetectionResultsShouldSortByRecipeName(t *testing.T) {
 	require.Equal(t, detections[1].Recipe.Name, "b")
 }
 
+func TestRecipeDetectorShouldExcludeIfNotTargeted(t *testing.T) {
+	recipe := NewRecipeBuilder().WithRecipeTargetedOnly(true).Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithInstallContext(&types.InstallerContext{})
+	detector := b.Build()
+
+	_, ua, _ := detector.GetDetectedRecipes()
+	actual, ok := ua.GetRecipeDetection(recipe.Name)
+
+	require.True(t, ok)
+	require.Equal(t, execution.RecipeStatusTypes.NULL, actual.Status)
+}
+
+func TestRecipeDetectorShouldIncludeIfTargeted(t *testing.T) {
+	recipe := NewRecipeBuilder().Name("R1").WithRecipeTargetedOnly(true).Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{
+		"R1",
+		"D1",
+	}})
+	detector := b.Build()
+
+	a, _, _ := detector.GetDetectedRecipes()
+	actual, ok := a.GetRecipeDetection(recipe.Name)
+
+	require.True(t, ok)
+	require.Equal(t, execution.RecipeStatusTypes.AVAILABLE, actual.Status)
+}
+
 type MockRecipesFinder struct {
 	recipes []*types.OpenInstallationRecipe
 	err     error
@@ -115,6 +150,7 @@ type RecipeDetectorTestBuilder struct {
 	processEvaluator *MockRecipeEvaluator
 	scriptEvaluator  *MockRecipeEvaluator
 	recipesFinder    *MockRecipesFinder
+	installContext   *types.InstallerContext
 }
 
 func NewRecipeDetectorTestBuilder() *RecipeDetectorTestBuilder {
@@ -127,6 +163,11 @@ func NewRecipeDetectorTestBuilder() *RecipeDetectorTestBuilder {
 
 func (b *RecipeDetectorTestBuilder) WithRecipesFinderError(err error) *RecipeDetectorTestBuilder {
 	b.recipesFinder.err = err
+	return b
+}
+
+func (b *RecipeDetectorTestBuilder) WithInstallContext(ic *types.InstallerContext) *RecipeDetectorTestBuilder {
+	b.installContext = ic
 	return b
 }
 
@@ -148,5 +189,6 @@ func (b *RecipeDetectorTestBuilder) Build() *RecipeDetector {
 		repo:             b.recipesFinder,
 		processEvaluator: b.processEvaluator,
 		scriptEvaluator:  b.scriptEvaluator,
+		installerContext: b.installContext,
 	}
 }

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -100,7 +100,7 @@ func TestDetectionResultsShouldSortByRecipeName(t *testing.T) {
 }
 
 func TestRecipeDetectorShouldExcludeIfNotTargeted(t *testing.T) {
-	recipe := NewRecipeBuilder().WithRecipeTargetedOnly(true).Build()
+	recipe := NewRecipeBuilder().WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
 
 	b := NewRecipeDetectorTestBuilder()
 	b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
@@ -116,7 +116,7 @@ func TestRecipeDetectorShouldExcludeIfNotTargeted(t *testing.T) {
 }
 
 func TestRecipeDetectorShouldIncludeIfTargeted(t *testing.T) {
-	recipe := NewRecipeBuilder().Name("R1").WithRecipeTargetedOnly(true).Build()
+	recipe := NewRecipeBuilder().Name("R1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
 
 	b := NewRecipeDetectorTestBuilder()
 	b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
@@ -132,6 +132,22 @@ func TestRecipeDetectorShouldIncludeIfTargeted(t *testing.T) {
 
 	require.True(t, ok)
 	require.Equal(t, execution.RecipeStatusTypes.AVAILABLE, actual.Status)
+}
+
+func TestRecipeDetectorShouldDiscover(t *testing.T) {
+	recipe := NewRecipeBuilder().Build()
+	b := NewRecipeDetectorTestBuilder()
+	b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{
+		"R1",
+	}})
+	detector := b.Build()
+	require.True(t, detector.shouldDiscover(recipe), "Should discover when attribute is omittd")
+
+	recipe = NewRecipeBuilder().Name("C1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
+	require.False(t, detector.shouldDiscover(recipe), "Should not discover when targeted only and not targeted during install")
+
+	recipe = NewRecipeBuilder().Name("R1").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{types.OpenInstallationDiscoveryModeTypes.TARGETED}).Build()
+	require.True(t, detector.shouldDiscover(recipe), "Should discover when targeted only and not targeted during install")
 }
 
 type MockRecipesFinder struct {

--- a/internal/install/types/install_context.go
+++ b/internal/install/types/install_context.go
@@ -30,7 +30,15 @@ func (i *InstallerContext) RecipePathsProvided() bool {
 
 func (i *InstallerContext) RecipeNamesProvided() bool {
 	return len(i.RecipeNames) > 0
+}
 
+func (i *InstallerContext) IsRecipeTargeted(name string) bool {
+	for _, r := range i.RecipeNames {
+		if r == name {
+			return true
+		}
+	}
+	return false
 }
 
 func (i *InstallerContext) SetTags(tags []string) {

--- a/internal/install/types/install_context_test.go
+++ b/internal/install/types/install_context_test.go
@@ -15,6 +15,14 @@ func TestRecipeNamesProvided(t *testing.T) {
 	require.True(t, ic.RecipeNamesProvided())
 }
 
+func TestIsRecipeTargeted(t *testing.T) {
+	ic := InstallerContext{}
+	ic.RecipeNames = []string{"testName"}
+
+	require.True(t, ic.IsRecipeTargeted("testName"))
+	require.False(t, ic.IsRecipeTargeted("badName"))
+}
+
 func TestRecipePathsProvided(t *testing.T) {
 	ic := InstallerContext{}
 	require.False(t, ic.RecipePathsProvided())

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -195,9 +195,10 @@ func expandPreInstall(recipe map[string]interface{}) OpenInstallationPreInstallC
 	}
 
 	return OpenInstallationPreInstallConfiguration{
-		Info:               toStringByFieldName("info", infoOut),
-		Prompt:             toStringByFieldName("prompt", infoOut),
-		RequireAtDiscovery: toStringByFieldName("requireAtDiscovery", infoOut),
+		Info:                toStringByFieldName("info", infoOut),
+		Prompt:              toStringByFieldName("prompt", infoOut),
+		RequireAtDiscovery:  toStringByFieldName("requireAtDiscovery", infoOut),
+		TargetedInstallOnly: toBoolByFieldName("targetedInstallOnly", infoOut),
 	}
 }
 

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -195,11 +195,32 @@ func expandPreInstall(recipe map[string]interface{}) OpenInstallationPreInstallC
 	}
 
 	return OpenInstallationPreInstallConfiguration{
-		Info:                toStringByFieldName("info", infoOut),
-		Prompt:              toStringByFieldName("prompt", infoOut),
-		RequireAtDiscovery:  toStringByFieldName("requireAtDiscovery", infoOut),
-		TargetedInstallOnly: toBoolByFieldName("targetedInstallOnly", infoOut),
+		Info:               toStringByFieldName("info", infoOut),
+		Prompt:             toStringByFieldName("prompt", infoOut),
+		RequireAtDiscovery: toStringByFieldName("requireAtDiscovery", infoOut),
+		DiscoveryMode:      expandDiscoveryMode(infoOut),
 	}
+}
+
+func expandDiscoveryMode(pi map[string]interface{}) []OpenInstallationDiscoveryMode {
+	v, ok := pi["discoveryMode"]
+	if !ok {
+		return []OpenInstallationDiscoveryMode{
+			OpenInstallationDiscoveryModeTypes.GUIDED,
+			OpenInstallationDiscoveryModeTypes.TARGETED,
+		}
+	}
+
+	dmIn := v.([]interface{})
+	dmOut := make([]OpenInstallationDiscoveryMode, 0)
+
+	for _, m := range dmIn {
+		if m, ok := ValidDiscoveryModes[strings.ToUpper(m.(string))]; ok {
+			dmOut = append(dmOut, m)
+		}
+	}
+
+	return dmOut
 }
 
 func expandPostInstall(recipe map[string]interface{}) OpenInstallationPostInstallConfiguration {

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -12,12 +12,9 @@ const (
 	InfraAgentRecipeName = "infrastructure-agent-installer"
 	LoggingRecipeName    = "logs-integration"
 	GoldenRecipeName     = "alerts-golden-signal"
-	OTELRecipeName       = "newrelic-opentelemetry-collector"
 )
 
-var (
-	RecipeVariables = map[string]string{}
-)
+var RecipeVariables = map[string]string{}
 
 // RecipeVars is used to pass dynamic data to recipes and go-task.
 type RecipeVars map[string]string

--- a/internal/install/types/recipe_test.go
+++ b/internal/install/types/recipe_test.go
@@ -85,9 +85,31 @@ func Test_shouldExpandPreInstall(t *testing.T) {
 	require.Equal(t, "A", c.Info, "Preinstall info should equal")
 	require.Equal(t, "B", c.Prompt, "Preinstall prompt should equal")
 	require.Equal(t, "C", c.RequireAtDiscovery, "Preinstall requiredAtDiscovery should equal")
-	require.Equal(t, false, c.TargetedInstallOnly, "Preinstall targetedInstallOnly should equal")
+}
 
-	mm["targetedInstallOnly"] = true
-	c = expandPreInstall(m)
-	require.Equal(t, true, c.TargetedInstallOnly, "Preinstall targetedInstallOnly should equal")
+func Test_shouldExpandDiscoveryMode(t *testing.T) {
+	m := make(map[string]interface{})
+	dm := expandDiscoveryMode(m)
+
+	require.Equal(t, 2, len(dm), "Omit discovery mode should return both guided and targeted")
+	require.Equal(t, OpenInstallationDiscoveryModeTypes.GUIDED, dm[0], "Omit discovery mode should return both guided and targeted")
+	require.Equal(t, OpenInstallationDiscoveryModeTypes.TARGETED, dm[1], "Omit discovery mode should return both guided and targeted")
+
+	m["discoveryMode"] = []interface{}{"guided"}
+	dm = expandDiscoveryMode(m)
+	require.Equal(t, 1, len(dm), "Omit discovery mode should return both guided and targeted")
+	require.Equal(t, OpenInstallationDiscoveryModeTypes.GUIDED, dm[0], "Only guided mode")
+
+	m["discoveryMode"] = []interface{}{"targeted"}
+	dm = expandDiscoveryMode(m)
+	require.Equal(t, 1, len(dm), "Omit discovery mode should return both guided and targeted")
+	require.Equal(t, OpenInstallationDiscoveryModeTypes.TARGETED, dm[0], "Only target mode")
+
+	m["discoveryMode"] = []interface{}{"badMode"}
+	dm = expandDiscoveryMode(m)
+	require.Equal(t, 0, len(dm), "Bad value should return nothing")
+
+	m["discoveryMode"] = []interface{}{"badMode", "guided"}
+	dm = expandDiscoveryMode(m)
+	require.Equal(t, 1, len(dm), "One good value should be parsed")
 }

--- a/internal/install/types/recipe_test.go
+++ b/internal/install/types/recipe_test.go
@@ -1,6 +1,3 @@
-//go:build unit
-// +build unit
-
 package types
 
 import (
@@ -28,7 +25,6 @@ func TestToStringByFieldName(t *testing.T) {
 }
 
 func Test_shouldDisplayShortString(t *testing.T) {
-
 	recipe := OpenInstallationRecipe{
 		Name:           "test-recipe",
 		DisplayName:    "my verbose looking recipe name",
@@ -49,7 +45,6 @@ func Test_shouldDisplayShortString(t *testing.T) {
 }
 
 func Test_shouldDisplayShortStringMultipleTargets(t *testing.T) {
-
 	recipe := OpenInstallationRecipe{
 		Name:           "test-recipe",
 		DisplayName:    "my verbose looking recipe name",
@@ -76,4 +71,23 @@ func Test_shouldDisplayShortStringMultipleTargets(t *testing.T) {
 	require.True(t, strings.Contains(output, "test-recipe"))
 	require.True(t, strings.Contains(output, "darwin/amazon/2/x86"))
 	require.True(t, strings.Contains(output, "linux/redhat/8/arm"))
+}
+
+func Test_shouldExpandPreInstall(t *testing.T) {
+	m := make(map[string]interface{})
+	mm := make(map[interface{}]interface{})
+	m["preInstall"] = mm
+	mm["info"] = "A"
+	mm["prompt"] = "B"
+	mm["requireAtDiscovery"] = "C"
+
+	c := expandPreInstall(m)
+	require.Equal(t, "A", c.Info, "Preinstall info should equal")
+	require.Equal(t, "B", c.Prompt, "Preinstall prompt should equal")
+	require.Equal(t, "C", c.RequireAtDiscovery, "Preinstall requiredAtDiscovery should equal")
+	require.Equal(t, false, c.TargetedInstallOnly, "Preinstall targetedInstallOnly should equal")
+
+	mm["targetedInstallOnly"] = true
+	c = expandPreInstall(m)
+	require.Equal(t, true, c.TargetedInstallOnly, "Preinstall targetedInstallOnly should equal")
 }

--- a/internal/install/types/types.go
+++ b/internal/install/types/types.go
@@ -135,6 +135,22 @@ var OpenInstallationTargetTypeTypes = struct {
 	SERVERLESS: "SERVERLESS",
 }
 
+type OpenInstallationDiscoveryMode string
+
+var ValidDiscoveryModes = map[string]OpenInstallationDiscoveryMode{
+	"GUIDED":   OpenInstallationDiscoveryModeTypes.GUIDED,
+	"TARGETED": OpenInstallationDiscoveryModeTypes.TARGETED,
+}
+
+var OpenInstallationDiscoveryModeTypes = struct {
+	GUIDED     OpenInstallationDiscoveryMode
+	TARGETED   OpenInstallationDiscoveryMode
+	FromString map[string]OpenInstallationDiscoveryMode
+}{
+	GUIDED:   "GUIDED",
+	TARGETED: "TARGETED",
+}
+
 // OpenInstallationAttributes - Custom event data attributes
 type OpenInstallationAttributes struct {
 	// Built-in parsing rulesets
@@ -197,8 +213,8 @@ type OpenInstallationPreInstallConfiguration struct {
 	Prompt string `json:"prompt,omitempty"`
 	// Script block to be executed during system discovery, a successful exit status will mark the recipe for execution
 	RequireAtDiscovery string `json:"requireAtDiscovery,omitempty"`
-	// False if omit, exclude recipe unless is targeted
-	TargetedInstallOnly bool `json:"TargetedInstallOnly,omitempty"`
+	// Possible values, guided, targeted. Both are included if omitted.
+	DiscoveryMode []OpenInstallationDiscoveryMode `json:"discoveryMode,omitempty"`
 }
 
 // OpenInstallationProcessDetailInput - Process details

--- a/internal/install/types/types.go
+++ b/internal/install/types/types.go
@@ -197,6 +197,8 @@ type OpenInstallationPreInstallConfiguration struct {
 	Prompt string `json:"prompt,omitempty"`
 	// Script block to be executed during system discovery, a successful exit status will mark the recipe for execution
 	RequireAtDiscovery string `json:"requireAtDiscovery,omitempty"`
+	// False if omit, exclude recipe unless is targeted
+	TargetedInstallOnly bool `json:"TargetedInstallOnly,omitempty"`
 }
 
 // OpenInstallationProcessDetailInput - Process details


### PR DESCRIPTION
- Allow new attribute `discoveryMode` in recipe pre-install section. 
- Accepts an one or many of possible value from [targeted, guided]
- If set to targeted, This will only detect the recipe if it's a target in the targeted install
- If Omit, default behavior is assume both (What we have today)