### PR TITLE
feat(install): validate user API key format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,8 +76,9 @@ require (
 	github.com/valyala/fastjson v1.6.3 // indirect
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.5.0 // indirect
+	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -222,6 +222,8 @@ github.com/yusufpapurcu/wmi v1.2.2/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQ
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9 h1:GoHiUyI/Tp2nVkLI2mCxVkOjsbSXD66ic0XW0js0R9g=
+golang.org/x/exp v0.0.0-20230905200255-921286631fa9/go.mod h1:S2oDrQGGwySpoQPVqRShND87VCbxmc6bL1Yd2oYrm6k=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -264,6 +266,8 @@ golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
+golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=
 golang.org/x/term v0.0.0-20210916214954-140adaaadfaf/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package install
 
 import (
@@ -22,8 +24,7 @@ func TestInstallCommand(t *testing.T) {
 	testcobra.CheckCobraMetadata(t, Command)
 	testcobra.CheckCobraRequiredFlags(t, Command, []string{})
 }
-func TestCommandValiProfile(t *testing.T) {
-
+func TestCommandValidProfile(t *testing.T) {
 	accountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	region := os.Getenv("NEW_RELIC_REGION")
@@ -50,11 +51,20 @@ func TestCommandValiProfile(t *testing.T) {
 	os.Setenv("NEW_RELIC_API_KEY", "")
 	err = validateProfile(5, c)
 	assert.Equal(t, types.EventTypes.APIKeyMissing, err.EventName)
+
+	os.Setenv("NEW_RELIC_API_KEY", "67890")
+	err = validateProfile(5, c)
+	assert.Equal(t, types.EventTypes.InvalidUserAPIKeyFormat, err.EventName)
+
 	if apiKey == "" {
-		os.Setenv("NEW_RELIC_API_KEY", "67890")
+		os.Setenv("NEW_RELIC_API_KEY", "NRAK-67890")
 	} else {
 		os.Setenv("NEW_RELIC_API_KEY", apiKey)
 	}
+
+	os.Setenv("NEW_RELIC_REGION", "au")
+	err = validateProfile(5, c)
+	assert.Equal(t, types.EventTypes.InvalidRegion, err.EventName)
 
 	os.Setenv("NEW_RELIC_REGION", "")
 	err = validateProfile(5, c)

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -37,6 +37,8 @@ var EventTypes = struct {
 	NrIntegrationPollingErrror EventType
 	OtherError                 EventType
 	UnableToLocatePostedData   EventType
+	InvalidUserAPIKeyFormat    EventType
+	InvalidRegion              EventType
 }{
 	InstallStarted:             "InstallStarted",
 	AccountIDMissing:           "AccountIDMissing",
@@ -54,6 +56,8 @@ var EventTypes = struct {
 	UnableToDiscover:           "UnableToDiscover",
 	NrIntegrationPollingErrror: "NrIntegrationPollingErrror",
 	OtherError:                 "OtherError",
+	InvalidUserAPIKeyFormat:    "InvalidUserAPIKeyFormat",
+	InvalidRegion:              "InvalidRegion",
 }
 
 func TryParseEventType(e string) (EventType, bool) {
@@ -84,7 +88,12 @@ func TryParseEventType(e string) (EventType, bool) {
 		return EventTypes.UnableToDiscover, true
 	case "NrIntegrationPollingErrror":
 		return EventTypes.NrIntegrationPollingErrror, true
+	case "InvalidUserAPIKeyFormat":
+		return EventTypes.InvalidUserAPIKeyFormat, true
+	case "InvalidRegion":
+		return EventTypes.InvalidRegion, true
 	}
+
 	return "", false
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -8,14 +8,15 @@ import (
 	"os"
 	"os/signal"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/mitchellh/go-homedir"
-
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -184,4 +185,22 @@ func IsAbsoluteURL(rawURL string) bool {
 func IsExitStatusCode(exitCode int, err error) bool {
 	exitCodeString := fmt.Sprintf("exit status %d", exitCode)
 	return strings.Contains(err.Error(), exitCodeString)
+}
+
+func IsValidUserAPIKeyFormat(key string) bool {
+	validUserAPIKeyPrefixes := []string{"NRAK", "NRAA"}
+	prefix, keyString, found := strings.Cut(key, "-")
+
+	// If no hyphen was found, we don't have a user API key.
+	if !found {
+		return false
+	}
+
+	if !slices.Contains(validUserAPIKeyPrefixes, prefix) {
+		return false
+	}
+
+	var isAlphanumeric = regexp.MustCompile("^[a-zA-Z0-9_]*$").MatchString(keyString)
+
+	return isAlphanumeric
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,3 +1,5 @@
+//go:build unit
+
 package utils
 
 import (
@@ -101,4 +103,23 @@ func TestLogIfFatal(t *testing.T) {
 		LogIfFatal(c.param)
 		require.Equal(t, c.expectFatal, fatal)
 	}
+}
+
+func TestIsValidUserAPIKeyFormat_Valid(t *testing.T) {
+	result := IsValidUserAPIKeyFormat("NRAK-ABCDEBFGJIJKLMNOPQRSTUVWXYZ")
+	assert.True(t, result)
+}
+
+func TestIsValidUserAPIKeyFormat_Invalid(t *testing.T) {
+	// Invalid prefix
+	result := IsValidUserAPIKeyFormat("NRBR-ABCDEBFGJIJKLMNOPQRSTUVWXYZ")
+	assert.False(t, result)
+
+	// A license key is not a valid User API key (note, this is not a real license key)
+	result = IsValidUserAPIKeyFormat("4321abcsksd344ndlsdm20231mwd21230md12cbsdhk2")
+	assert.False(t, result)
+
+	// Special characters are invaid after the prefix hyphen
+	result = IsValidUserAPIKeyFormat("NRAK-@$%^!")
+	assert.False(t, result)
 }


### PR DESCRIPTION
This PR introduces some light input validation to capture when customers might be using the wrong API key format and/or an invalid New Relic region during agent installation. Messaging has also been updated in hopes of providing a more helpful, descriptive error message.