### PR TITLE
refactor(install): include validationNRQL as install validation fallback to validationIntegration

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -630,7 +630,9 @@ func (i *RecipeInstall) validateRecipeViaAllMethods(ctx context.Context, r *type
 		validationFuncs = append(validationFuncs, func() (string, error) {
 			return validation.ValidateIntegration(integrationName)
 		})
-	} else if hasValidationNRQL {
+	}
+
+	if hasValidationNRQL {
 		validationFuncs = append(validationFuncs, func() (string, error) {
 			return i.recipeValidator.ValidateRecipe(timeoutCtx, *m, *r, vars)
 		})


### PR DESCRIPTION
After discovering a weird local validation bug with MongoDB, we need to be defensive with how we validation installations until we can figure out the oddity with the hanging execution on Windows environments. 