### PR TITLE
fix: Validation nrql backup functionality

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -630,12 +630,16 @@ func (i *RecipeInstall) validateRecipeViaAllMethods(ctx context.Context, r *type
 		validationFuncs = append(validationFuncs, func() (string, error) {
 			return validation.ValidateIntegration(integrationName)
 		})
-	} else if hasValidationNRQL {
+	} else {
+		log.Debugf("no validationIntegration defined, skipping")
+	}
+
+	if hasValidationNRQL {
 		validationFuncs = append(validationFuncs, func() (string, error) {
 			return i.recipeValidator.ValidateRecipe(timeoutCtx, *m, *r, vars)
 		})
 	} else {
-		log.Debugf("no validationIntegration or validationNRQL defined, skipping")
+		log.Debugf("no validationNRQL defined, skipping")
 	}
 
 	if len(validationFuncs) == 0 {


### PR DESCRIPTION
Makes validationNrql an additional method of validating OHI installation. The result is that the first successful method of validation will count as a successful installation. If all methods fail, the installation is considered to have failed.