### PR TITLE
fix(install): remove duplicate tracking event and simplify error message

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -50,7 +50,6 @@ var Command = &cobra.Command{
 
 		detailErr := validateProfile(config.DefaultMaxTimeoutSeconds, sg)
 		if detailErr != nil {
-			sg.Track(detailErr.EventName)
 			log.Fatal(detailErr)
 		}
 
@@ -165,8 +164,9 @@ func validateProfile(maxTimeoutSeconds int, sg *segment.Segment) *types.DetailEr
 	licenseKey, err := client.FetchLicenseKey(accountID, config.FlagProfileName, &maxTimeoutSeconds)
 	if err != nil {
 		errorOccured = true
-		details := fmt.Sprintf("could not fetch license key for account %d:, license key: %v %s", accountID, utils.Obfuscate(licenseKey), err)
-		detailErr = types.NewDetailError(types.EventTypes.UnableToFetchLicenseKey, details)
+		message := fmt.Sprintf("could not fetch license key for account %d:, license key: %v %s", accountID, utils.Obfuscate(licenseKey), err)
+		log.Debug(message)
+		detailErr = types.NewDetailError(types.EventTypes.UnableToFetchLicenseKey, fmt.Sprintf("%s", err))
 		return detailErr
 	}
 

--- a/internal/synthetics/command_batch_run.go
+++ b/internal/synthetics/command_batch_run.go
@@ -5,15 +5,16 @@ import (
 	"os"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
 	"github.com/newrelic/newrelic-cli/internal/client"
 	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
 	"github.com/newrelic/newrelic-cli/internal/install/ux"
 	"github.com/newrelic/newrelic-cli/internal/output"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/synthetics"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 )
 
 var (

--- a/internal/synthetics/command_monitor_test.go
+++ b/internal/synthetics/command_monitor_test.go
@@ -6,8 +6,9 @@ package synthetics
 import (
 	"testing"
 
-	"github.com/newrelic/newrelic-cli/internal/testcobra"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
 )
 
 func TestSyntheticsMonitor(t *testing.T) {


### PR DESCRIPTION
Duplicate events were tracked during the validateProfile( ), this PR remove the duplicate.
Also simplified the user facing error message to avoid confusing with license key, new user message below.

`FATAL 401 response returned: Invalid credentials provided. Missing API key or an invalid API key was provided. `