### PR TITLE
feat(entities): Support custom attributes JSON

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.21.0
+	github.com/newrelic/newrelic-client-go/v2 v2.22.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGgCcyj8cs=
-github.com/newrelic/newrelic-client-go/v2 v2.21.0 h1:SZ6FEwbLG7nzCJaT402dWPSDvqVegBoCEX7XsAEd3y8=
-github.com/newrelic/newrelic-client-go/v2 v2.21.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
+github.com/newrelic/newrelic-client-go/v2 v2.22.0 h1:8+CS3FWCG0uHz9ApVlwaufoSdYKD474/rfM1De1FdSQ=
+github.com/newrelic/newrelic-client-go/v2 v2.22.0/go.mod h1:VPWTvEfKvnTZLunAC7fiW33y4e0srznNfN5HJH2cOp8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -3,6 +3,7 @@ package entities
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -43,6 +44,8 @@ The deployment command manages deployments for a New Relic entity. Use --help fo
 	Example: "newrelic entity deployment create --guid <GUID> --version <0.0.1>",
 }
 
+var cmdEntityDeploymentCreateExample = fmt.Sprintf("newrelic entity deployment create --guid <GUID> --version <0.0.1> --changelog 'what changed' --commit '12345e' --customAttribute test1:123,test2:456 --deepLink <link back to deployer> --deploymentType 'BASIC' --description 'about' --timestamp %v --user 'jenkins-bot'", time.Now().Unix())
+
 var cmdEntityDeploymentCreate = &cobra.Command{
 	Use:   "create",
 	Short: "Create a New Relic entity deployment marker",
@@ -50,7 +53,7 @@ var cmdEntityDeploymentCreate = &cobra.Command{
 
 The deployment command marks a change for a New Relic entity
 	`,
-	Example: "newrelic entity deployment create --guid <GUID> --version <0.0.1> --changelog 'what changed' --commit '12345e' --customAttribute test1:123,test2:456 --deepLink <link back to deployer> --deploymentType 'BASIC' --description 'about' --timestamp <1668446197100> --user 'jenkins-bot'",
+	Example: cmdEntityDeploymentCreateExample,
 	PreRun:  client.RequireClient,
 	Run: func(cmd *cobra.Command, args []string) {
 		params := changetracking.ChangeTrackingDeploymentInput{}

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -68,15 +68,16 @@ The deployment command marks a change for a New Relic entity
 			log.Fatal("--version cannot be empty")
 		}
 
-		attrs, err := getCustomAttributes(customAttribute, customAttributes)
-		if err != nil {
-			log.Fatal(err)
-		}
-		switch t := attrs.(type) {
-		case *map[string]interface{}:
-			params.CustomAttributes = *t
-		case map[string]interface{}:
-			params.CustomAttributes = t
+		var (
+			attrs map[string]interface{}
+			err   error
+		)
+		if len(customAttribute) > 0 || customAttributes != "" {
+			attrs, err = getCustomAttributes(customAttribute, customAttributes)
+			if err != nil {
+				log.Fatal(err)
+			}
+			params.CustomAttributes = attrs
 		}
 
 		params.Changelog = changelog
@@ -143,22 +144,22 @@ func parseCustomAttributes(a *[]string) (*map[string]interface{}, error) {
 	return &customAttributeMap, nil
 }
 
-func getCustomAttributes(a []string, b string) (interface{}, error) {
-	var result interface{}
+func getCustomAttributes(a []string, b string) (map[string]interface{}, error) {
+	var result *map[string]interface{}
 	if len(a) > 0 && b == "" {
 		attrsMap, err := parseCustomAttributes(&a)
 		if err != nil {
 			return nil, errors.New("unable to parse custom attributes")
 		}
-		result = *attrsMap
+		result = attrsMap
 	}
 	if b != "" {
-		attrsJSON := make(map[string]interface{})
+		var attrsJSON *map[string]interface{}
 		err := json.Unmarshal([]byte(b), &attrsJSON)
 		if err != nil {
 			return nil, errors.New("unable to unmarshal custom attributes")
 		}
 		result = attrsJSON
 	}
-	return result, nil
+	return *result, nil
 }

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"encoding/json"
 	"errors"
 	"log"
 	"strings"
@@ -64,15 +65,24 @@ The deployment command marks a change for a New Relic entity
 			log.Fatal("--version cannot be empty")
 		}
 
-		customAttributes, err := parseCustomAttributes(&customAttribute)
-
-		if err != nil {
-			log.Fatal(err)
+		// If both used, prefer to use 'customAttributes' (plural) as 'customAttribute' (singular) is mark as deprecated
+		if customAttribute != nil && customAttributes == "" {
+			customAttribute, err := parseCustomAttributes(&customAttribute)
+			if err != nil {
+				log.Fatal(err)
+			}
+			params.CustomAttributes = *customAttribute
+		} else {
+			attrs := make(map[string]interface{})
+			err := json.Unmarshal([]byte(customAttributes), &attrs)
+			if err != nil {
+				log.Fatal(err)
+			}
+			params.CustomAttributes = attrs
 		}
 
 		params.Changelog = changelog
 		params.Commit = commit
-		params.CustomAttributes = customAttributes
 		params.DeepLink = deepLink
 		params.DeploymentType = changetracking.ChangeTrackingDeploymentType(deploymentType)
 		params.Description = description
@@ -81,7 +91,11 @@ The deployment command marks a change for a New Relic entity
 		params.User = user
 		params.Version = version
 
-		result, err := client.NRClient.ChangeTracking.ChangeTrackingCreateDeploymentWithContext(utils.SignalCtx, params)
+		result, err := client.NRClient.ChangeTracking.ChangeTrackingCreateDeploymentWithContext(
+			utils.SignalCtx,
+			changetracking.ChangeTrackingDataHandlingRules{ValidationFlags: []changetracking.ChangeTrackingValidationFlag{changetracking.ChangeTrackingValidationFlagTypes.FAIL_ON_FIELD_LENGTH}},
+			params,
+		)
 		utils.LogIfFatal(err)
 
 		utils.LogIfFatal(output.Print(result))
@@ -102,6 +116,7 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVar(&commit, "commit", "", "the commit identifier, for example, a Git commit SHA")
 	cmdEntityDeploymentCreate.Flags().StringSliceVar(&customAttribute, "customAttribute", []string{}, "(EARLY ACCESS) a comma separated list of key:value custom attributes to apply to the deployment")
 	cmdEntityDeploymentCreate.Flags().MarkDeprecated("customAttribute", "please use 'customAttributes'")
+	cmdEntityDeploymentCreate.Flags().StringVar(&customAttributes, "customAttributes", "", "(EARLY ACCESS) key-value pairs of custom attributes in JSON format to apply to the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deepLink, "deepLink", "", "a link back to the system generating the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deploymentType, "deploymentType", "", "type of deployment, one of BASIC, BLUE_GREEN, CANARY, OTHER, ROLLING or SHADOW")
 	cmdEntityDeploymentCreate.Flags().StringVar(&description, "description", "", "a description of the deployment")
@@ -110,12 +125,12 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVarP(&user, "user", "u", "", "username of the deployer or bot")
 }
 
-func parseCustomAttributes(a *[]string) (*map[string]string, error) {
-	customAttributeMap := make(map[string]string)
-
+func parseCustomAttributes(a *[]string) (*map[string]interface{}, error) {
 	if len(*a) < 1 {
 		return nil, nil
 	}
+
+	customAttributeMap := make(map[string]interface{})
 
 	for _, v := range *a {
 		pair := strings.Split(v, ":")

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -68,14 +68,15 @@ The deployment command marks a change for a New Relic entity
 			log.Fatal("--version cannot be empty")
 		}
 
-		// If both used, prefer to use 'customAttributes' (plural) as 'customAttribute' (singular) is mark as deprecated
-		if customAttribute != nil && customAttributes == "" {
+		// If both are simultaneously used, prefer to use 'customAttributes' (plural) as 'customAttribute' (singular) is mark as deprecated
+		if len(customAttribute) > 0 && customAttributes == "" {
 			customAttribute, err := parseCustomAttributes(&customAttribute)
 			if err != nil {
 				log.Fatal(err)
 			}
 			params.CustomAttributes = *customAttribute
-		} else {
+		}
+		if customAttributes != "" {
 			attrs := make(map[string]interface{})
 			err := json.Unmarshal([]byte(customAttributes), &attrs)
 			if err != nil {

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -19,16 +19,17 @@ import (
 )
 
 var (
-	changelog       string
-	commit          string
-	customAttribute []string
-	deepLink        string
-	deploymentType  string
-	description     string
-	groupID         string
-	timestamp       int64
-	user            string
-	version         string
+	changelog        string
+	commit           string
+	customAttribute  []string
+	customAttributes string
+	deepLink         string
+	deploymentType   string
+	description      string
+	groupID          string
+	timestamp        int64
+	user             string
+	version          string
 )
 
 var cmdEntityDeployment = &cobra.Command{
@@ -100,6 +101,7 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVar(&changelog, "changelog", "", "a URL for the changelog or list of changes if not linkable")
 	cmdEntityDeploymentCreate.Flags().StringVar(&commit, "commit", "", "the commit identifier, for example, a Git commit SHA")
 	cmdEntityDeploymentCreate.Flags().StringSliceVar(&customAttribute, "customAttribute", []string{}, "(EARLY ACCESS) a comma separated list of key:value custom attributes to apply to the deployment")
+	cmdEntityDeploymentCreate.Flags().MarkDeprecated("customAttribute", "please use 'customAttributes'")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deepLink, "deepLink", "", "a link back to the system generating the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deploymentType, "deploymentType", "", "type of deployment, one of BASIC, BLUE_GREEN, CANARY, OTHER, ROLLING or SHADOW")
 	cmdEntityDeploymentCreate.Flags().StringVar(&description, "description", "", "a description of the deployment")

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -119,7 +119,7 @@ func init() {
 	cmdEntityDeploymentCreate.Flags().StringVar(&changelog, "changelog", "", "a URL for the changelog or list of changes if not linkable")
 	cmdEntityDeploymentCreate.Flags().StringVar(&commit, "commit", "", "the commit identifier, for example, a Git commit SHA")
 	cmdEntityDeploymentCreate.Flags().StringSliceVar(&customAttribute, "customAttribute", []string{}, "(EARLY ACCESS) a comma separated list of key:value custom attributes to apply to the deployment")
-	cmdEntityDeploymentCreate.Flags().MarkDeprecated("customAttribute", "please use 'customAttributes'")
+	_ = cmdEntityDeploymentCreate.Flags().MarkDeprecated("customAttribute", "please use 'customAttributes'")
 	cmdEntityDeploymentCreate.Flags().StringVar(&customAttributes, "customAttributes", "", "(EARLY ACCESS) key-value pairs of custom attributes in JSON format to apply to the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deepLink, "deepLink", "", "a link back to the system generating the deployment")
 	cmdEntityDeploymentCreate.Flags().StringVar(&deploymentType, "deploymentType", "", "type of deployment, one of BASIC, BLUE_GREEN, CANARY, OTHER, ROLLING or SHADOW")

--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -44,7 +44,7 @@ The deployment command manages deployments for a New Relic entity. Use --help fo
 	Example: "newrelic entity deployment create --guid <GUID> --version <0.0.1>",
 }
 
-var cmdEntityDeploymentCreateExample = fmt.Sprintf("newrelic entity deployment create --guid <GUID> --version <0.0.1> --changelog 'what changed' --commit '12345e' --customAttribute test1:123,test2:456 --deepLink <link back to deployer> --deploymentType 'BASIC' --description 'about' --timestamp %v --user 'jenkins-bot'", time.Now().Unix())
+var cmdEntityDeploymentCreateExample = fmt.Sprintf(`newrelic entity deployment create --guid <GUID> --version <0.0.1> --changelog 'what changed' --commit '12345e' --customAttributes '{"region": "east", "env": "staging"}' --deepLink <link back to deployer> --deploymentType 'BASIC' --description 'about' --timestamp %v --user 'jenkins-bot'`, time.Now().Unix())
 
 var cmdEntityDeploymentCreate = &cobra.Command{
 	Use:   "create",

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -1,6 +1,7 @@
 package entities
 
 import (
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -169,4 +170,38 @@ func TestParseAttributesEmptyStringSlice(t *testing.T) {
 
 func nilPointerMapStringString() *map[string]interface{} {
 	return nil
+}
+
+func TestReturningMapOverStringIfBothCustomAttributesFlagsAreInadvertentlyUsedSimultaneously(t *testing.T) {
+	a := []string{"a:true"}
+	b := ""
+	var want = map[string]interface{}{"a": "true"}
+
+	got, _ := getCustomAttributes(a, b)
+	assert.Equal(t, want, got)
+}
+
+func TestReturningJsonOverStringIfBothCustomAttributesFlagsAreInadvertentlyUsedSimultaneously(t *testing.T) {
+	a := []string{"a:1", "b:2"}
+	b := `{"a":"true"}`
+
+	want := make(map[string]interface{})
+	_ = json.Unmarshal([]byte(b), &want)
+
+	got, _ := getCustomAttributes(a, b)
+
+	assert.Equal(t, want, got)
+}
+
+func TestIncorrectlyFormattedCustomAttributesStringPairFailsWithUnableToParse(t *testing.T) {
+	a := []string{"a::1"}
+	_, err := getCustomAttributes(a, "")
+	assert.Equal(t, "unable to parse custom attributes", err.Error())
+}
+
+func TestIncorrectlyFormattedCustomAttributesJSONStringFailsWithUnableToUnmarshal(t *testing.T) {
+	a := []string{}
+	b := `{"a":"1}`
+	_, err := getCustomAttributes(a, b)
+	assert.Equal(t, "unable to unmarshal custom attributes", err.Error())
 }

--- a/internal/entities/command_deployment_test.go
+++ b/internal/entities/command_deployment_test.go
@@ -28,8 +28,78 @@ func TestParseAttributesSingleKeyValue(t *testing.T) {
 		"key:value",
 	}
 
-	var want = map[string]string{
+	var want = map[string]interface{}{
 		"key": "value",
+	}
+	var errWant error
+
+	got, errGot := parseCustomAttributes(&a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesSingleIntegerKeyValue(t *testing.T) {
+	a := []string{
+		"a:1",
+	}
+
+	var want = map[string]interface{}{
+		"a": "1",
+	}
+	var errWant error
+
+	got, errGot := parseCustomAttributes(&a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesSingleFloatingKeyValue(t *testing.T) {
+	a := []string{
+		"a:1.5",
+	}
+
+	var want = map[string]interface{}{
+		"a": "1.5",
+	}
+	var errWant error
+
+	got, errGot := parseCustomAttributes(&a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesSingleBooleanKeyValue(t *testing.T) {
+	a := []string{
+		"a:true",
+	}
+
+	var want = map[string]interface{}{
+		"a": "true",
+	}
+	var errWant error
+
+	got, errGot := parseCustomAttributes(&a)
+
+	assert.Equal(t, errWant, errGot)
+	assert.Equal(t, want, *got)
+}
+
+func TestParseAttributesMultipleTypesKeyValues(t *testing.T) {
+	a := []string{
+		"a:true",
+		"b:1",
+		"c:1.5",
+		`d:"value"`,
+	}
+
+	var want = map[string]interface{}{
+		"a": "true",
+		"b": "1",
+		"c": "1.5",
+		"d": `"value"`,
 	}
 	var errWant error
 
@@ -45,7 +115,7 @@ func TestParseAttributesTwoKeyValues(t *testing.T) {
 		"key2:value2",
 	}
 
-	var want = map[string]string{
+	var want = map[string]interface{}{
 		"key":  "value",
 		"key2": "value2",
 	}
@@ -97,6 +167,6 @@ func TestParseAttributesEmptyStringSlice(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
-func nilPointerMapStringString() *map[string]string {
+func nilPointerMapStringString() *map[string]interface{} {
 	return nil
 }


### PR DESCRIPTION
Supports JSON strings for `--customAttributes` for deployment markers. Ref: [NR-165686](https://new-relic.atlassian.net/browse/NR-165686).

