### PR TITLE
feat(install): add super-agent as infra-agent substitute dependency for OHIs

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -319,9 +319,11 @@ func (i *RecipeInstall) install(ctx context.Context) error {
 	bundler := i.bundlerFactory(ctx, availableRecipes)
 	bundleInstaller := i.bundleInstallerFactory(ctx, m, i, i.status)
 
-	cbErr := i.installCoreBundle(bundler, bundleInstaller)
-	if cbErr != nil {
-		return cbErr
+	if !i.IsRecipeTargeted(types.SuperAgentRecipeName) {
+		cbErr := i.installCoreBundle(bundler, bundleInstaller)
+		if cbErr != nil {
+			return cbErr
+		}
 	}
 
 	abErr := i.installAdditionalBundle(bundler, bundleInstaller, repo)

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -319,11 +319,9 @@ func (i *RecipeInstall) install(ctx context.Context) error {
 	bundler := i.bundlerFactory(ctx, availableRecipes)
 	bundleInstaller := i.bundleInstallerFactory(ctx, m, i, i.status)
 
-	if !i.IsRecipeTargeted(types.SuperAgentRecipeName) {
-		cbErr := i.installCoreBundle(bundler, bundleInstaller)
-		if cbErr != nil {
-			return cbErr
-		}
+	cbErr := i.installCoreBundle(bundler, bundleInstaller)
+	if cbErr != nil {
+		return cbErr
 	}
 
 	abErr := i.installAdditionalBundle(bundler, bundleInstaller, repo)

--- a/internal/install/recipes/bundler.go
+++ b/internal/install/recipes/bundler.go
@@ -92,14 +92,7 @@ func (b *Bundler) getBundleRecipeWithDependencies(recipe *types.OpenInstallation
 	//	if super-agent is targeted, infrastructure-agent is removed
 	//	if super-agent is not targeted, super-agent is removed
 	if recipe.IsOhi() && utils.StringInSlice(types.InfraAgentRecipeName, recipe.Dependencies) && utils.StringInSlice(types.SuperAgentRecipeName, recipe.Dependencies) && depException != "" {
-		var newDeps []string
-		for _, d := range recipe.Dependencies {
-			if d == depException {
-				continue
-			}
-			newDeps = append(newDeps, d)
-		}
-		recipe.Dependencies = newDeps
+		recipe.Dependencies = utils.RemoveFromSlice(recipe.Dependencies, depException)
 	}
 
 	for _, d := range recipe.Dependencies {

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -13,6 +13,7 @@ const (
 	LoggingRecipeName           = "logs-integration"
 	LoggingSuperAgentRecipeName = "logs-integration-super-agent"
 	GoldenRecipeName            = "alerts-golden-signal"
+	SuperAgentRecipeName        = "super-agent"
 )
 
 var RecipeVariables = map[string]string{}
@@ -413,6 +414,10 @@ func (r *OpenInstallationRecipe) SetRecipeVar(key string, value string) {
 
 func (r *OpenInstallationRecipe) IsApm() bool {
 	return r.HasKeyword("apm")
+}
+
+func (r *OpenInstallationRecipe) IsOhi() bool {
+	return r.HasKeyword("ohi")
 }
 
 func (r *OpenInstallationRecipe) HasHostTargetType() bool {

--- a/internal/install/types/recipe_test.go
+++ b/internal/install/types/recipe_test.go
@@ -113,3 +113,10 @@ func Test_shouldExpandDiscoveryMode(t *testing.T) {
 	dm = expandDiscoveryMode(m)
 	require.Equal(t, 1, len(dm), "One good value should be parsed")
 }
+
+func TestOhiKeywordInRecipeWorks(t *testing.T) {
+	r := OpenInstallationRecipe{}
+	r.Keywords = []string{"ohi"}
+
+	require.Equal(t, r.IsOhi(), true)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -204,3 +204,12 @@ func IsValidUserAPIKeyFormat(key string) bool {
 
 	return isAlphanumeric
 }
+
+func RemoveFromSlice(slice []string, s string) []string {
+	for i, elem := range slice {
+		if elem == s {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"errors"
+	"reflect"
 	"testing"
 
 	log "github.com/sirupsen/logrus"
@@ -122,4 +123,29 @@ func TestIsValidUserAPIKeyFormat_Invalid(t *testing.T) {
 	// Special characters are invaid after the prefix hyphen
 	result = IsValidUserAPIKeyFormat("NRAK-@$%^!")
 	assert.False(t, result)
+}
+
+func TestRemoveFromSliceWorks(t *testing.T) {
+	type test struct {
+		input  []string
+		remove string
+		want   []string
+	}
+	tests := []test{
+		{input: []string{"a", "b", "c"}, remove: "c", want: []string{"a", "b"}},
+		{input: []string{"a", "b", "c"}, remove: "b", want: []string{"a", "c"}},
+		{input: []string{"a", "b"}, remove: "a", want: []string{"b"}},
+		{input: []string{"a", "b"}, remove: "b", want: []string{"a"}},
+		{input: []string{"a"}, remove: "a", want: []string{}},
+		{input: []string{}, remove: "a", want: []string{}},
+		{input: []string{}, remove: "", want: []string{}},
+		{input: nil, remove: "a", want: nil},
+	}
+
+	for _, tc := range tests {
+		got := RemoveFromSlice(tc.input, tc.remove)
+		if !reflect.DeepEqual(tc.want, got) {
+			t.Fatalf("expected: %v, got: %v", tc.want, got)
+		}
+	}
 }


### PR DESCRIPTION
Adds the ability to skip `infrastructure-agent` as a dependency for OHIs if `super-agent` is targeted. If `super-agent` is no targeted, OHIs will fall back to the original `infrastructure-agent` as their dependency.

Requires OIL changes: https://github.com/newrelic/open-install-library/pull/997

Ref: [NR-173011](https://new-relic.atlassian.net/browse/NR-173011)