### PR TITLE
feat(install): add super-agent as infra-agent substitute dependency

### DIFF
--- a/internal/install/recipes/bundler_test.go
+++ b/internal/install/recipes/bundler_test.go
@@ -280,7 +280,7 @@ func withAvailableRecipe(bundler *Bundler, recipeName string, status execution.R
 }
 
 func TestDualDependencyWithFalseyValueReturnsEmptyAndFalse(t *testing.T) {
-	dep, ok := getDualDependency([]string{})
+	dep, ok := detectDependencies([]string{})
 
 	require.Equal(t, dep, "")
 	require.Equal(t, ok, false)
@@ -288,7 +288,7 @@ func TestDualDependencyWithFalseyValueReturnsEmptyAndFalse(t *testing.T) {
 
 func TestCorrectDualDependencyPasses(t *testing.T) {
 	dualDep := "infra || super"
-	dep, ok := getDualDependency([]string{"a", "b", dualDep})
+	dep, ok := detectDependencies([]string{"a", "b", dualDep})
 
 	require.Equal(t, dep, dualDep)
 	require.Equal(t, ok, true)
@@ -296,7 +296,7 @@ func TestCorrectDualDependencyPasses(t *testing.T) {
 
 func TestIncorrectDualDependencyReturnsFalsy(t *testing.T) {
 	dualDep := "infra && super"
-	dep, ok := getDualDependency([]string{"a", "b", dualDep})
+	dep, ok := detectDependencies([]string{"a", "b", dualDep})
 
 	require.Equal(t, dep, "")
 	require.Equal(t, ok, false)


### PR DESCRIPTION
Adds the ability to skip `infrastructure-agent` as a dependency for OHIs if `super-agent` is targeted. If `super-agent` is no targeted, it will fall back to the original `infrastructure-agent` as their dependency.

Requires OIL changes: https://github.com/newrelic/open-install-library/pull/997

Ref: [NR-173011](https://new-relic.atlassian.net/browse/NR-173011)