### PR TITLE
fix(install): Add complete install status for user-canceled execution

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -245,8 +245,9 @@ Our Data Privacy Notice: https://newrelic.com/termsandconditions/services-notice
 
 	select {
 	case <-ctx.Done():
-		i.status.InstallCanceled()
-		return nil
+		err := ctx.Err()
+		i.status.InstallComplete(err)
+		return err
 	case err = <-errChan:
 		if errors.Is(err, types.ErrInterrupt) {
 			i.status.InstallCanceled()

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -245,7 +245,7 @@ Our Data Privacy Notice: https://newrelic.com/termsandconditions/services-notice
 
 	select {
 	case <-ctx.Done():
-		err := ctx.Err()
+		err = ctx.Err()
 		i.status.InstallComplete(err)
 		return err
 	case err = <-errChan:


### PR DESCRIPTION
Adds a `COMPLETE` install status event when CLI execution is user-canceled. Ref: [NR-173729](https://new-relic.atlassian.net/browse/NR-173729).