### PR TITLE
fix: Prevent panic in 'synthetics run' when client not initialized

### DIFF
--- a/internal/synthetics/command_batch_run.go
+++ b/internal/synthetics/command_batch_run.go
@@ -34,13 +34,14 @@ var cmdRun = &cobra.Command{
 The run command helps start an automated testing job by creating a batch, comprising the specified monitors and their
 specifications (such as overrides), and subsequently, keeps fetching the status of the batch at periodic intervals of
 time, until the status of the batch, which reflects the consolidated status of all monitors in the batch, is either
-success, failure or timed out. 
+success, failure or timed out.
 
 The command may be used with the following flags (the arguments --batchFile and --guid are mutually exclusive).
 
 newrelic synthetics run --batchFile filename.yml
 newrelic synthetics run --guid <guid1> --guid <guid2>
 `,
+	PreRun: client.RequireClient,
 	Run: func(cmd *cobra.Command, args []string) {
 		var (
 			config       StartAutomatedTestInput


### PR DESCRIPTION
Running `newrelic synthetics run --guid 1` causes the CLI to panic if NEW_RELIC_API_KEY and NEW_RELIC_LICENSE_KEY are unset:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xc5a4b3]

goroutine 1 [running]:
github.com/newrelic/newrelic-cli/internal/synthetics.createAutomatedTestBatch({{{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}, ...}, ...})
	/Users/<USER>/<SOME_PATH>/newrelic-cli/internal/synthetics/command_batch_run.go:131 +0x93
github.com/newrelic/newrelic-cli/internal/synthetics.glob..func1(0x15e68e0?, {0xe77c09?, 0x2?, 0x2?})
	/Users/<USER>/<SOME_PATH>/code/github.com/newrelic-cli/internal/synthetics/command_batch_run.go:57 +0x1a5
```

This PR adds a requirement for the client to be initialized to run synthetics, either by setting the env vars above or by adding a profile.

**Expected behavior**

Running `newrelic synthetics run --guid 1` without the user key or license key set will fail with the error message `FATAL could not initialize New Relic client, make sure your profile is configured with 'newrelic profile configure'`

