### PR TITLE
chore(build): Try enabling goreleaser debug cmd

### DIFF
--- a/build/release.mk
+++ b/build/release.mk
@@ -21,13 +21,13 @@ release-clean:
 release-publish: clean tools docker-login release-notes recipes events
 	@echo "=== $(PROJECT_NAME) === [ release-publish  ]: Publishing release via $(REL_CMD)"
 	@cat $(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) || true
-	$(REL_CMD) release --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) --verbose
+	$(REL_CMD) release --release-notes=$(SRCDIR)/tmp/$(RELEASE_NOTES_FILE) --debug
 
 # Local Snapshot
 snapshot: clean tools recipes events
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]: Creating release via $(REL_CMD)"
 	@echo "=== $(PROJECT_NAME) === [ snapshot         ]:   THIS WILL NOT BE PUBLISHED!"
-	@$(REL_CMD) --skip-publish --snapshot
+	@$(REL_CMD) --skip-publish --snapshot --debug
 
 release-homebrew:
 ifeq ($(HOMEBREW_GITHUB_API_TOKEN), "")


### PR DESCRIPTION
Try debugging release pipeline [error](https://github.com/newrelic/newrelic-cli/actions/runs/8069906445/job/22046132006#step:8:541) with GoReleaser:
```
release failed after 0s                  error=git is in a dirty stat

Please check in your pipeline what can be changing the following files:
 M scripts/win_metadata_files_remove.sh
```