### PR TITLE
chore(build): Disable git tracking file permission changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           git config --global user.name ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_USERNAME }}
           git config --global user.email ${{ secrets.NEW_RELIC_GITHUB_SERVICE_ACCOUNT_EMAIL }}
+          git config core.fileMode false
 
           mkdir -p $HOME/.cache/snapcraft/download
           mkdir -p $HOME/.cache/snapcraft/stage-packages


### PR DESCRIPTION
As per [these lines](https://github.com/newrelic/newrelic-cli/actions/runs/8071438889/job/22051188377#step:8:317) in the debug log in the [publish release](https://github.com/newrelic/newrelic-cli/actions/runs/8071438889/job/22051188377) step, I think that the required `chmod +x` permissions for the scripts that need to deal with the Windows medata files, are being tracked by `git` as `modified` which in turn lets `goreleaser` show the[ initial error](https://github.com/newrelic/newrelic-cli/actions/runs/8069906445/job/22046132006#step:8:541) message: `git is in a dirty state`.

This PR adds `git config core.fileMode false` to the `release.yml` workflow, in an attempt to disable that tracking and let the release process to continue.