### PR TITLE
chore(release): Ignore windows metadata assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Dockerfile
 # Embedded recipe files
 internal/install/recipes/files/**/*
 !internal/install/recipes/files/.keep
+
+# Windows Binary Metadata
+cmd/newrelic/resource_windows.syso
+cmd/newrelic/versioninfo.json


### PR DESCRIPTION
Trying to fix release pipeline [error](https://github.com/newrelic/newrelic-cli/actions/runs/8100446284/job/22138617304#step:8:899):

```
  ⨯ release failed after 0s                  error=git is in a dirty state
Please check in your pipeline what can be changing the following files:
?? cmd/newrelic/resource_windows.syso
?? cmd/newrelic/versioninfo.json
```
