### PR TITLE
fix(msi): pass latest git tag as version

### DIFF
--- a/.github/workflows/release-windows-installer.yml
+++ b/.github/workflows/release-windows-installer.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3
@@ -30,7 +32,9 @@ jobs:
           path: .\dist\newrelic_windows_amd64_v1
 
       - name: Compile installer
-        run: msbuild .\build\package\msi\NewRelicCLIInstaller.sln
+        run: |
+          $LATEST_VERSION = git describe --tags --abbrev=0 | ForEach-Object { $_ -replace 'v', '' }
+          msbuild .\build\package\msi\NewRelicCLIInstaller.sln -p:Version=$LATEST_VERSION
 
       - name: Create PFX certificate
         id: create-pfx
@@ -90,4 +94,3 @@ jobs:
           asset_path: .\scripts\install.ps1
           asset_name: install.ps1
           asset_content_type: application/octet-stream
-


### PR DESCRIPTION
All changes handled in our gha workflow:`.github/workflows/release-windows-installer.yml`.  Since most of the public GHAs are written for linux distros, had to manually fetch the latest tag using `git`.

- Updated `Checkout code` step to pull branches/tags.  This provides the ability to fetch the latest tag in later steps
![Screenshot 2024-03-21 at 3 14 14 PM](https://github.com/newrelic/newrelic-cli/assets/90725916/e1fe2fbe-52c5-40fc-bed3-0509f26dc1fa)

- Updated  `Compile installer` step to pass a `Version` parameter.  In testing, if this is an empty string, step will fail.  NOTE: tag v1.1.1 was created _after_ v1.2.3, proving that the chronologically newest version is ref'd
![Screenshot 2024-03-21 at 3 14 23 PM](https://github.com/newrelic/newrelic-cli/assets/90725916/a9a762eb-04af-410d-8583-4a4b27438d02)

