### PR TITLE
chore(release): Get recent tag across all branches

### DIFF
--- a/.github/workflows/release-windows-installer.yml
+++ b/.github/workflows/release-windows-installer.yml
@@ -25,14 +25,14 @@ jobs:
       - name: Output latest tag
         id: latest-tag
         run: |
-          $tag = git describe --tags --abbrev=0
+          $tag = git describe --tags $(git rev-list --tags --max-count=1)
 
           Write-Host "Latest tag - before: $tag"
 
           git fetch origin
           git fetch --tags
 
-          $latestTag = git describe --tags --abbrev=0
+          $latestTag = git describe --tags $(git rev-list --tags --max-count=1)
 
           Write-Host "Latest tag - after: $latestTag"
 
@@ -47,7 +47,7 @@ jobs:
 
       - name: Compile installer
         run: |
-          $LATEST_VERSION = git describe --tags --abbrev=0 | ForEach-Object { $_ -replace 'v', '' }
+          $LATEST_VERSION = git git describe --tags $(git rev-list --tags --max-count=1) | ForEach-Object { $_ -replace 'v', '' }
           Write-Host "(Compile installer) Latest version $LATEST_VERSION"
           msbuild .\build\package\msi\NewRelicCLIInstaller.sln -p:Version=$LATEST_VERSION
 

--- a/.github/workflows/release-windows-installer.yml
+++ b/.github/workflows/release-windows-installer.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Compile installer
         run: |
-          $LATEST_VERSION = git git describe --tags $(git rev-list --tags --max-count=1) | ForEach-Object { $_ -replace 'v', '' }
+          $LATEST_VERSION = git describe --tags $(git rev-list --tags --max-count=1) | ForEach-Object { $_ -replace 'v', '' }
           Write-Host "(Compile installer) Latest version $LATEST_VERSION"
           msbuild .\build\package\msi\NewRelicCLIInstaller.sln -p:Version=$LATEST_VERSION
 


### PR DESCRIPTION
Command obtained from [stack overflow](https://stackoverflow.com/questions/1404796/how-can-i-get-the-latest-tag-name-in-current-branch-in-git)

On my local machine

_fetch_
![Screenshot_2024-03-27_at_5_10_43 PM](https://github.com/newrelic/newrelic-cli/assets/15141412/fa6a8420-2718-46a6-b010-fc15d0713b9a)

_describe tags_
![Screenshot 2024-03-27 at 5 12 24 PM](https://github.com/newrelic/newrelic-cli/assets/15141412/16462ca8-53f2-49a6-835a-0589e9d25e6f)

_new describe tags_
![Screenshot 2024-03-27 at 5 12 57 PM](https://github.com/newrelic/newrelic-cli/assets/15141412/9218c176-fe3c-4ebb-800a-22244501d864)

It is worth noting that after some time, the original command seems to be working. It is unclear what has changed
![Screenshot 2024-03-27 at 5 14 08 PM](https://github.com/newrelic/newrelic-cli/assets/15141412/e4fe8e24-cd83-4bbf-9dd5-2be0331956ca)
