### PR TITLE
feat(super-agent): Skip core bundle if installed

### DIFF
--- a/internal/install/bundle_installer.go
+++ b/internal/install/bundle_installer.go
@@ -3,6 +3,7 @@ package install
 import (
 	"context"
 	"fmt"
+	"github.com/newrelic/newrelic-cli/internal/utils"
 
 	log "github.com/sirupsen/logrus"
 
@@ -105,6 +106,10 @@ func (bi *BundleInstaller) InstallContinueOnError(bundle *recipes.Bundle, assume
 
 func (bi *BundleInstaller) reportBundleStatus(bundle *recipes.Bundle) {
 	for _, recipe := range bundle.BundleRecipes {
+		if utils.StringInSlice(types.SuperAgentRecipeName, recipe.Recipe.Dependencies) && recipe.HasStatus(execution.RecipeStatusTypes.INSTALLED) {
+			bi.installedRecipes[recipe.Recipe.Name] = true
+			continue
+		}
 		if bi.installedRecipes[recipe.Recipe.Name] {
 			continue
 		}

--- a/internal/install/bundle_installer_test.go
+++ b/internal/install/bundle_installer_test.go
@@ -51,6 +51,16 @@ func TestInstallContinueOnErrorReturnsImmediatelyWhenNoIsEntered(t *testing.T) {
 	test.mockStatusReporter.AssertNumberOfCalls(t, "ReportStatus", 1)
 }
 
+func TestInstallContinueOnErrorReturnsImmediatelyWhenSuperAgentIsInstalled(t *testing.T) {
+	test := createBundleInstallerTest().withPrompterYesNoVal(false).withRecipeInstallerError()
+	test.addRecipeToBundle("super-agent", execution.RecipeStatusTypes.INSTALLED)
+
+	test.BundleInstaller.InstallContinueOnError(test.bundle, false)
+
+	test.mockRecipeInstaller.AssertNumberOfCalls(t, "executeAndValidateWithProgress", 0)
+	test.mockStatusReporter.AssertNumberOfCalls(t, "ReportStatus", 1)
+}
+
 func TestInstallContinueOnErrorIgnoresUxPromptIfBundleIsAdditionalTargeted(t *testing.T) {
 	test := createBundleInstallerTest().withRecipeInstallerError()
 	test.addRecipeToBundle("recipe1", execution.RecipeStatusTypes.UNSUPPORTED)

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -170,7 +170,6 @@ func validateProfile(maxTimeoutSeconds int, sg *segment.Segment) *types.DetailEr
 }
 
 func checkNetwork() error {
-
 	if client.NRClient == nil {
 		return nil
 	}

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -412,16 +412,12 @@ func (i *RecipeInstall) isTargetInstallRecipe(recipeName string) bool {
 // If the host has super agent installed infra agent and logs agent would be UNSUPPORTED
 // It then installs the additional bundle and reports any unsupported recipes.
 func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleInstaller RecipeBundleInstaller, repo *recipes.RecipeRepository) error {
-	var (
-		additionalBundle *recipes.Bundle
-		bun              *recipes.Bundler
-		ok               bool
-	)
-	if i.hostHasSuperAgentProcess() {
-		if bun, ok = bundler.(*recipes.Bundler); ok {
-			bun.HasSuperInstalled = true
-			log.Debugf("Super agent process found. Proceeding with additional bundle.")
-		}
+	var additionalBundle *recipes.Bundle
+	bun, ok := bundler.(*recipes.Bundler)
+
+	if i.hostHasSuperAgentProcess() && ok {
+		bun.HasSuperInstalled = true
+		log.Debugf("Super agent process found. Proceeding with additional bundle.")
 	} else {
 		log.Debugf("Super agent process not found. Proceeding with additional bundle.")
 	}

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -442,6 +442,8 @@ func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleIns
 	// if the list of the recipes provided in the bundle and super agent installed
 	// mark the status as unsupported || skipped
 	if i.RecipeNamesProvided() {
+		log.Debugf("bundling addtional bundle")
+		log.Debugf("recipes in list %d", len(i.RecipeNames))
 		additionalBundle = bundler.CreateAdditionalTargetedBundle(i.RecipeNames)
 		// if addtional bundle has super and
 		if bundler.(*recipes.Bundler).HasSuperInstalled {

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -409,7 +409,7 @@ func (i *RecipeInstall) isTargetInstallRecipe(recipeName string) bool {
 // installAdditionalBundle installs additional bundles for the given recipes.
 // It checks if the host has a super agent process running, and proceeds with the additional bundle.
 // If the list of recipes is provided, it creates a targeted bundle; otherwise, it creates a guided bundle.
-// If the host has super agent installed infra agent and logs agent would be UNSUPPORTED
+// If the host has super agent installed infra agent and logs agent would be NULL
 // It then installs the additional bundle and reports any unsupported recipes.
 func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleInstaller RecipeBundleInstaller, repo *recipes.RecipeRepository) error {
 	var additionalBundle *recipes.Bundle
@@ -429,7 +429,7 @@ func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleIns
 		if bun.HasSuperInstalled {
 			for _, coreRecipe := range bundler.(*recipes.Bundler).GetCoreRecipeNames() {
 				if i, ok := additionalBundle.ContainsName(coreRecipe); ok {
-					additionalBundle.BundleRecipes[i].AddDetectionStatus(execution.RecipeStatusTypes.UNSUPPORTED, 0)
+					additionalBundle.BundleRecipes[i].AddDetectionStatus(execution.RecipeStatusTypes.NULL, 0)
 				}
 			}
 			log.Debugf("Additional Targeted bundle recipes in queue:%s", additionalBundle)

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -422,20 +422,20 @@ func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleIns
 	} else {
 		log.Debugf("Super agent process not found. Proceeding with additional bundle.")
 	}
-	if bundler.(*recipes.Bundler).HasSuperInstalled {
-		// recipe name should not be infra & logs
-		// && i.RecipeNames
-		for _, r := range i.RecipeNames {
-			if r == types.InfraAgentRecipeName || r == types.LoggingRecipeName {
-				fmt.Printf("Super agent process found on the host. Skipping installation.")
-				// todo:
-				return nil
-			}
-			if r == types.SuperAgentRecipeName {
-				// FIXME: Provide the logic for the super agent present case
-			}
-		}
-	}
+	//if bundler.(*recipes.Bundler).HasSuperInstalled {
+	//	// recipe name should not be infra & logs
+	//	// && i.RecipeNames
+	//	for _, r := range i.RecipeNames {
+	//		if r == types.InfraAgentRecipeName || r == types.LoggingRecipeName {
+	//			fmt.Printf("Super agent process found on the host. Skipping installation.")
+	//			// todo:
+	//			return nil
+	//		}
+	//		if r == types.SuperAgentRecipeName {
+	//			// FIXME: Provide the logic for the super agent present case
+	//		}
+	//	}
+	//}
 	// In the above the bundle is not yet created for -n recipe-a, infra , log
 	// so instead create the bundle
 	// have a separate method to deal with the installed super agent
@@ -444,6 +444,15 @@ func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleIns
 	if i.RecipeNamesProvided() {
 		additionalBundle = bundler.CreateAdditionalTargetedBundle(i.RecipeNames)
 		// if addtional bundle has super and
+		if bundler.(*recipes.Bundler).HasSuperInstalled {
+			for _, coreRecipe := range bundler.(*recipes.Bundler).GetCoreRecipeNames() {
+				if i, ok := additionalBundle.ContainsName(coreRecipe); ok {
+					additionalBundle.BundleRecipes[i].AddDetectionStatus(execution.RecipeStatusTypes.UNSUPPORTED, 0)
+				}
+			}
+			log.Debugf("Additional Targeted bundle recipes in queue:%s", additionalBundle)
+		}
+
 		i.reportUnsupportedTargetedRecipes(additionalBundle, repo)
 		log.Debugf("Additional Targeted bundle recipes:%s", additionalBundle)
 	} else {

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -8,11 +8,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/newrelic/newrelic-cli/internal/config"
-
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/newrelic/newrelic-cli/internal/config"
 	"github.com/newrelic/newrelic-cli/internal/install/execution"
 	"github.com/newrelic/newrelic-cli/internal/install/recipes"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
@@ -100,7 +99,6 @@ func TestInstallGuidedShouldSkipCoreInstallWhileSuperAgentIsInstalled(t *testing
 
 	err := recipeInstall.Install()
 
-	//fmt.Print(err)
 	assert.Equal(t, "no recipes were installed", err.Error(), "no recipe installed")
 	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
 	assert.Equal(t, 0, statusReporter.RecipeAvailableCallCount, "Available Count")
@@ -335,6 +333,32 @@ func TestInstallTargetedInstallShouldInstallCoreIfCoreWasSkipped(t *testing.T) {
 	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")
 	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
 	assert.Equal(t, 1, statusReporter.ReportInstalled[r.Recipe.Name], "Recipe1 Installed")
+}
+
+func TestInstallTargetedInstallShouldInstallCoreIfCoreWasSkippedWhileSuperAgentIsInstalled(t *testing.T) {
+	r := &recipes.RecipeDetectionResult{
+		Recipe: recipes.NewRecipeBuilder().Name(types.InfraAgentRecipeName).Build(),
+		Status: execution.RecipeStatusTypes.AVAILABLE,
+	}
+	statusReporter := execution.NewMockStatusReporter()
+	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).withShouldInstallCore(func() bool { return false }).
+		WithTargetRecipeName(types.InfraAgentRecipeName).WithStatusReporter(statusReporter).
+		WithRunningProcess("super-agent-process", types.SuperAgentProcessName).Build()
+	recipeInstall.AssumeYes = true
+
+	err := recipeInstall.Install()
+
+	assert.Equal(t, "no recipes were installed", err.Error())
+	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
+	assert.Equal(t, 1, statusReporter.RecipeAvailableCallCount, "Available Count")
+	assert.Equal(t, 0, statusReporter.RecipeInstallingCallCount, "Installing Count")
+	assert.Equal(t, 0, statusReporter.RecipeFailedCallCount, "Failed Count")
+	assert.Equal(t, 1, statusReporter.RecipeUnsupportedCallCount, "Unsupported Count")
+	assert.Equal(t, 0, statusReporter.RecipeInstalledCallCount, "InstalledCount")
+	assert.Equal(t, 0, statusReporter.RecipeRecommendedCallCount, "Recommendation Count")
+	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")
+	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
+	assert.Equal(t, 0, statusReporter.ReportInstalled[r.Recipe.Name], "Recipe1 Installed")
 }
 
 func TestInstallTargetedInstallWithoutRecipeShouldNotInstall(t *testing.T) {
@@ -775,7 +799,6 @@ func TestWhenSingleInstallRunningNoError(t *testing.T) {
 	recipeInstall := NewRecipeInstallBuilder().WithRunningProcess("env=123 newrelic install", "newrelic").Build()
 
 	err := recipeInstall.Install()
-
 	if err != nil {
 		assert.False(t, strings.Contains(err.Error(), "only 1 newrelic install command can run at one time"))
 	}
@@ -794,7 +817,6 @@ func TestWhenSingleInstallRunningNoErrorWindows(t *testing.T) {
 	recipeInstall := NewRecipeInstallBuilder().WithRunningProcess("env=123 C:\\path\\newrelic.exe install", "C:\\path\\newrelic.exe").Build()
 
 	err := recipeInstall.Install()
-
 	if err != nil {
 		assert.False(t, strings.Contains(err.Error(), "only 1 newrelic install command can run at one time"))
 	}

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -99,7 +99,7 @@ func TestInstallGuidedShouldSkipCoreInstallWhileSuperAgentIsInstalled(t *testing
 
 	err := recipeInstall.Install()
 
-	assert.Equal(t, "no recipes were installed", err.Error(), "no recipe installed")
+	assert.Equal(t, "super Agent is installed, preventing the installation of this recipe", err.Error())
 	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
 	assert.Equal(t, 0, statusReporter.RecipeAvailableCallCount, "Available Count")
 	assert.Equal(t, 0, statusReporter.RecipeInstallingCallCount, "Installing Count")

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -353,7 +353,7 @@ func TestInstallTargetedInstallShouldInstallCoreIfCoreWasSkippedWhileSuperAgentI
 	assert.Equal(t, 1, statusReporter.RecipeAvailableCallCount, "Available Count")
 	assert.Equal(t, 0, statusReporter.RecipeInstallingCallCount, "Installing Count")
 	assert.Equal(t, 0, statusReporter.RecipeFailedCallCount, "Failed Count")
-	assert.Equal(t, 1, statusReporter.RecipeUnsupportedCallCount, "Unsupported Count")
+	assert.Equal(t, 0, statusReporter.RecipeUnsupportedCallCount, "Unsupported Count")
 	assert.Equal(t, 0, statusReporter.RecipeInstalledCallCount, "InstalledCount")
 	assert.Equal(t, 0, statusReporter.RecipeRecommendedCallCount, "Recommendation Count")
 	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")

--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -348,7 +348,7 @@ func TestInstallTargetedInstallShouldInstallCoreIfCoreWasSkippedWhileSuperAgentI
 
 	err := recipeInstall.Install()
 
-	assert.Equal(t, "no recipes were installed", err.Error())
+	assert.Equal(t, "super Agent is installed, preventing the installation of this recipe", err.Error())
 	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
 	assert.Equal(t, 1, statusReporter.RecipeAvailableCallCount, "Available Count")
 	assert.Equal(t, 0, statusReporter.RecipeInstallingCallCount, "Installing Count")

--- a/internal/install/recipes/bundle.go
+++ b/internal/install/recipes/bundle.go
@@ -31,7 +31,7 @@ var BundleTypes = struct {
 }
 
 func (b *Bundle) AddRecipe(bundleRecipe *BundleRecipe) {
-	if b.ContainsName(bundleRecipe.Recipe.Name) {
+	if _, ok := b.ContainsName(bundleRecipe.Recipe.Name); ok {
 		return
 	}
 	b.BundleRecipes = append(b.BundleRecipes, bundleRecipe)
@@ -45,15 +45,15 @@ func (b *Bundle) IsAdditionalTargeted() bool {
 	return b.Type == BundleTypes.ADDITIONALTARGETED
 }
 
-func (b *Bundle) ContainsName(name string) bool {
+func (b *Bundle) ContainsName(name string) (int, bool) {
 
 	for i := range b.BundleRecipes {
 		if b.BundleRecipes[i].Recipe.Name == name {
-			return true
+			return i, true
 		}
 	}
 
-	return false
+	return -1, false
 }
 
 func (b *Bundle) GetBundleRecipe(name string) *BundleRecipe {

--- a/internal/install/recipes/bundle_recipe.go
+++ b/internal/install/recipes/bundle_recipe.go
@@ -36,6 +36,13 @@ func (br *BundleRecipe) HasStatus(status execution.RecipeStatusType) bool {
 	return false
 }
 
+func (br *BundleRecipe) LastStatus(status execution.RecipeStatusType) bool {
+	if len(br.DetectedStatuses) > 0 {
+		return br.DetectedStatuses[len(br.DetectedStatuses)-1].Status == status
+	}
+	return false
+}
+
 func (br *BundleRecipe) AreAllDependenciesAvailable() bool {
 	for _, depName := range br.Recipe.Dependencies {
 		if br.IsNameInDependencies(depName) {

--- a/internal/install/recipes/bundle_recipe.go
+++ b/internal/install/recipes/bundle_recipe.go
@@ -27,6 +27,7 @@ func (br *BundleRecipe) AddDetectionStatus(newStatus execution.RecipeStatusType,
 	br.DetectedStatuses = append(br.DetectedStatuses, &DetectedStatusType{Status: newStatus, DurationMs: durationMs})
 }
 
+
 func (br *BundleRecipe) HasStatus(status execution.RecipeStatusType) bool {
 	for _, detectedStatus := range br.DetectedStatuses {
 		if detectedStatus.Status == status {

--- a/internal/install/recipes/bundle_recipe.go
+++ b/internal/install/recipes/bundle_recipe.go
@@ -27,7 +27,6 @@ func (br *BundleRecipe) AddDetectionStatus(newStatus execution.RecipeStatusType,
 	br.DetectedStatuses = append(br.DetectedStatuses, &DetectedStatusType{Status: newStatus, DurationMs: durationMs})
 }
 
-
 func (br *BundleRecipe) HasStatus(status execution.RecipeStatusType) bool {
 	for _, detectedStatus := range br.DetectedStatuses {
 		if detectedStatus.Status == status {
@@ -47,9 +46,11 @@ func (br *BundleRecipe) AreAllDependenciesAvailable() bool {
 	}
 	for _, ds := range br.Dependencies {
 		if !ds.HasStatus(execution.RecipeStatusTypes.AVAILABLE) {
+			log.Debugf("recipe %s is not available dependency for %s", br.Recipe.Name, ds.Recipe.Name)
 			return false
 		}
 	}
+	log.Debugf("all dependencies are available")
 	return true
 }
 

--- a/internal/install/recipes/bundle_test.go
+++ b/internal/install/recipes/bundle_test.go
@@ -20,8 +20,10 @@ func TestBundle_ShouldAddRecipes(t *testing.T) {
 	}
 
 	bundle.AddRecipe(newRecipe)
+	index, found := bundle.ContainsName(newRecipe.Recipe.Name)
 	require.Equal(t, len(bundle.BundleRecipes), 2)
-	require.True(t, true, bundle.ContainsName(newRecipe.Recipe.Name))
+	require.Equal(t, true, found)
+	require.Equal(t, 1, index)
 }
 
 func TestBundle_ShouldNotUpdateRecipe(t *testing.T) {
@@ -37,7 +39,9 @@ func TestBundle_ShouldNotUpdateRecipe(t *testing.T) {
 	bundle.AddRecipe(bundleRecipe)
 
 	require.Equal(t, len(bundle.BundleRecipes), 1)
-	require.Equal(t, true, bundle.ContainsName(bundleRecipe.Recipe.Name))
+	_, found := bundle.ContainsName(bundleRecipe.Recipe.Name)
+
+	require.Equal(t, true, found)
 }
 
 func TestBundle_ShouldContainRecipeName(t *testing.T) {
@@ -48,8 +52,9 @@ func TestBundle_ShouldContainRecipeName(t *testing.T) {
 			},
 		},
 	}
+	_, found := bundle.ContainsName("recipe1")
 
-	require.Equal(t, true, bundle.ContainsName("recipe1"))
+	require.Equal(t, true, found)
 }
 
 func TestBundle_ShouldNotContainRecipeName(t *testing.T) {
@@ -60,8 +65,9 @@ func TestBundle_ShouldNotContainRecipeName(t *testing.T) {
 			},
 		},
 	}
+	_, found := bundle.ContainsName("some other name")
 
-	require.Equal(t, false, bundle.ContainsName("some other name"))
+	require.Equal(t, false, found)
 }
 
 func TestBundle_ShouldBeGuided(t *testing.T) {

--- a/internal/install/recipes/bundler.go
+++ b/internal/install/recipes/bundler.go
@@ -72,6 +72,7 @@ func (b *Bundler) createBundle(recipes []string, bType BundleType) *Bundle {
 			if dualDep, ok := detectDependencies(d.Recipe.Dependencies); ok {
 				dep := b.updateDependency(dualDep, recipes)
 				if dep != nil {
+					log.Debugf("Found dual dependency and selected : %s", dep)
 					d.Recipe.Dependencies = dep
 				} else {
 					log.Debugf("could not process update for dual dependency: %s", dualDep)
@@ -130,6 +131,7 @@ func (b *Bundler) getBundleRecipeWithDependencies(recipe *types.OpenInstallation
 			log.Debugf("dependent recipe %s not found, skipping recipe %s", d, recipe.Name)
 		}
 		// A dependency is missing, invalidating the bundle recipe
+		log.Debugf("A dependency is missing, invalidating the bundle recipe %s", recipe.Name)
 		b.cachedBundleRecipes[recipe.Name] = nil
 		return nil
 	}

--- a/internal/install/recipes/bundler.go
+++ b/internal/install/recipes/bundler.go
@@ -34,7 +34,7 @@ func NewBundler(context context.Context, availableRecipes RecipeDetectionResults
 }
 
 func (b *Bundler) CreateCoreBundle() *Bundle {
-	return b.createBundle(b.getCoreRecipeNames(), BundleTypes.CORE)
+	return b.createBundle(b.GetCoreRecipeNames(), BundleTypes.CORE)
 }
 
 func (b *Bundler) CreateAdditionalGuidedBundle() *Bundle {
@@ -53,7 +53,7 @@ func (b *Bundler) CreateAdditionalTargetedBundle(recipes []string) *Bundle {
 	return b.createBundle(recipes, BundleTypes.ADDITIONALTARGETED)
 }
 
-func (b *Bundler) getCoreRecipeNames() []string {
+func (b *Bundler) GetCoreRecipeNames() []string {
 	coreRecipeNames := make([]string, 0, len(coreRecipeMap))
 	for k := range coreRecipeMap {
 		coreRecipeNames = append(coreRecipeNames, k)
@@ -80,20 +80,21 @@ func (b *Bundler) createBundle(recipes []string, bType BundleType) *Bundle {
 
 			bundleRecipe = b.getBundleRecipeWithDependencies(d.Recipe)
 
-			for _, recipe := range recipes {
-				for _, dependency := range bundleRecipe.Dependencies {
-					if dependency.Recipe.Name != recipe {
-						log.Debugf("Found dependency %s", dependency.Recipe.Name)
-						for _, brDeps := range bundleRecipe.Dependencies {
-							if brDeps.Recipe.Name == types.SuperAgentRecipeName {
-								brDeps.AddDetectionStatus(execution.RecipeStatusTypes.INSTALLED, 0)
+			if bundleRecipe != nil {
+				for _, recipe := range recipes {
+					// TODo: better to do it after making it as a bundle
+					for _, dependency := range bundleRecipe.Dependencies {
+						if dependency.Recipe.Name != recipe {
+							log.Debugf("Found dependency %s", dependency.Recipe.Name)
+							for _, brDeps := range bundleRecipe.Dependencies {
+								if brDeps.Recipe.Name == types.SuperAgentRecipeName {
+									brDeps.AddDetectionStatus(execution.RecipeStatusTypes.INSTALLED, 0)
+								}
 							}
 						}
 					}
 				}
-			}
 
-			if bundleRecipe != nil {
 				log.Debugf("Adding bundle recipe:%s status:%+v dependencies:%+v", bundleRecipe.Recipe.Name, bundleRecipe.DetectedStatuses, bundleRecipe.Recipe.Dependencies)
 				bundle.AddRecipe(bundleRecipe)
 			}

--- a/internal/install/recipes/bundler.go
+++ b/internal/install/recipes/bundler.go
@@ -138,6 +138,7 @@ func (b *Bundler) getBundleRecipeWithDependencies(recipe *types.OpenInstallation
 		if dt, ok := b.AvailableRecipes.GetRecipeDetection(recipe.Name); ok {
 			bundleRecipe.AddDetectionStatus(dt.Status, dt.DurationMs)
 			b.cachedBundleRecipes[recipe.Name] = bundleRecipe
+			log.Debugf("bundle recipe with dependency %v", bundleRecipe)
 			return bundleRecipe
 		}
 	}

--- a/internal/install/recipes/bundler.go
+++ b/internal/install/recipes/bundler.go
@@ -2,13 +2,12 @@ package recipes
 
 import (
 	"context"
+	"github.com/newrelic/newrelic-cli/internal/install/execution"
 	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/newrelic/newrelic-cli/internal/install"
-	"github.com/newrelic/newrelic-cli/internal/install/execution"
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 )
@@ -22,6 +21,7 @@ type Bundler struct {
 	AvailableRecipes    RecipeDetectionResults
 	Context             context.Context
 	cachedBundleRecipes map[string]*BundleRecipe
+	HasSuper            bool
 }
 
 func NewBundler(context context.Context, availableRecipes RecipeDetectionResults) *Bundler {
@@ -29,6 +29,7 @@ func NewBundler(context context.Context, availableRecipes RecipeDetectionResults
 		Context:             context,
 		AvailableRecipes:    availableRecipes,
 		cachedBundleRecipes: make(map[string]*BundleRecipe),
+		HasSuper:            false,
 	}
 }
 
@@ -176,7 +177,8 @@ func (b *Bundler) updateDependency(dualDep string, recipes []string) []string {
 		dep = strings.TrimSpace(dep)
 		// TODO: Update the doc
 		if strings.EqualFold(dep, "super-agent") && r.FindProcess(types.SuperAgentProcessName) {
-			deps = []string{"super-agent"}
+			deps = []string{}
+			// FIXME: Uncertainity
 			b.cachedBundleRecipes[dep].AddDetectionStatus(execution.RecipeStatusTypes.INSTALLED, 0)
 			break
 		}

--- a/internal/install/recipes/bundler_test.go
+++ b/internal/install/recipes/bundler_test.go
@@ -29,7 +29,6 @@ func TestCreateAdditionalTargetedBundleShouldNotSkipCoreRecipes(t *testing.T) {
 	goldenRecipe := NewRecipeBuilder().Name(types.GoldenRecipeName).Build()
 	mysqlRecipe := NewRecipeBuilder().Name("mysql").Build()
 	bundler := createTestBundler()
-	// Todo: fix me
 	bundler.HasSuperInstalled = true
 	withAvailableRecipe(bundler, types.InfraAgentRecipeName, execution.RecipeStatusTypes.AVAILABLE, infraRecipe)
 	withAvailableRecipe(bundler, types.LoggingRecipeName, execution.RecipeStatusTypes.AVAILABLE, loggingRecipe)

--- a/internal/install/recipes/bundler_test.go
+++ b/internal/install/recipes/bundler_test.go
@@ -303,6 +303,7 @@ func TestIncorrectDualDependencyReturnsFalsy(t *testing.T) {
 }
 
 func TestUpdateDependencyReturnsFirstDualDependencyThatIsInTargetedRecipes(t *testing.T) {
+	b := Bundler{}
 	type test struct {
 		dualDep string
 		recipes []string
@@ -318,7 +319,7 @@ func TestUpdateDependencyReturnsFirstDualDependencyThatIsInTargetedRecipes(t *te
 	}
 
 	for _, tc := range tests {
-		got := updateDependency(tc.dualDep, tc.recipes)
+		got := b.updateDependency(tc.dualDep, tc.recipes)
 		if !reflect.DeepEqual(tc.want, got) {
 			t.Fatalf("expected: %v, got: %v", tc.want, got)
 		}

--- a/internal/install/recipes/mock_process_evaluator.go
+++ b/internal/install/recipes/mock_process_evaluator.go
@@ -30,5 +30,11 @@ func (pe *MockProcessEvaluator) DetectionStatus(ctx context.Context, r *types.Op
 }
 
 func (pe *MockProcessEvaluator) FindProcess(process string) bool {
+	for _, p := range pe.processes {
+		name, _ := p.Name()
+		if name == process {
+			return true
+		}
+	}
 	return false
 }

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -2,7 +2,6 @@ package recipes
 
 import (
 	"context"
-
 	"github.com/newrelic/newrelic-cli/internal/install/execution"
 
 	"github.com/shirou/gopsutil/v3/process"
@@ -85,6 +84,10 @@ func (pe *ProcessEvaluator) DetectionStatus(ctx context.Context, r *types.OpenIn
 		log.Tracef("recipe %s is not matching any process", r.Name)
 		return execution.RecipeStatusTypes.NULL
 	}
+	//if pe.FindProcess(install.SuperAgentProcessName){
+	//	log.Debugf("Found super agent running on the host")
+	//	return execution.RecipeStatusTypes.INSTALLED
+	//}
 
 	return execution.RecipeStatusTypes.AVAILABLE
 }

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -84,10 +84,6 @@ func (pe *ProcessEvaluator) DetectionStatus(ctx context.Context, r *types.OpenIn
 		log.Tracef("recipe %s is not matching any process", r.Name)
 		return execution.RecipeStatusTypes.NULL
 	}
-	//if pe.FindProcess(install.SuperAgentProcessName){
-	//	log.Debugf("Found super agent running on the host")
-	//	return execution.RecipeStatusTypes.INSTALLED
-	//}
 
 	return execution.RecipeStatusTypes.AVAILABLE
 }

--- a/internal/install/types/recipe.go
+++ b/internal/install/types/recipe.go
@@ -14,6 +14,7 @@ const (
 	LoggingSuperAgentRecipeName = "logs-integration-super-agent"
 	GoldenRecipeName            = "alerts-golden-signal"
 	SuperAgentRecipeName        = "super-agent"
+	SuperAgentProcessName       = "newrelic-super-agent"
 )
 
 var RecipeVariables = map[string]string{}


### PR DESCRIPTION
This pull request uses the CLI functionality to detect the presence of the Super Agent on the host. If detected, it will install OHI with the Super Agent dependency, skipping the core bundle installation. If core recipes are targeted for installation, they will be unsupported since the Super Agent is already installed. (Associated PR: https://github.com/newrelic/open-install-library/pull/1072)