### PR TITLE
fix(infra): Remove Test endpoints to fix issue with infra-alert.service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1
+	github.com/newrelic/newrelic-client-go/v2 v2.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.35.0
+	github.com/newrelic/newrelic-client-go/v2 v2.36.2
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.33.0
+	github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/newrelic/newrelic-client-go/v2 v2.33.0 h1:kUuyWzCdbgt4DtF/VrNh73wSC9B
 github.com/newrelic/newrelic-client-go/v2 v2.33.0/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
 github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1 h1:Cf/Lh8hF73biCC9dC8kPd6gi3PeCUQraWUreefh96gk=
 github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2 h1:Euuoyt/j4DUIyZ2yCtBFjJ49x+Q8iXAadmivMzAQHAE=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/newrelic/newrelic-client-go/v2 v2.34.1 h1:/htTJ+sRKK2q3PFNuLURsur2e9N
 github.com/newrelic/newrelic-client-go/v2 v2.34.1/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
 github.com/newrelic/newrelic-client-go/v2 v2.35.0 h1:KunusuCsq/nAYATIUgQZovdAwzZiMMWA49PHsmn4dOc=
 github.com/newrelic/newrelic-client-go/v2 v2.35.0/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2 h1:Euuoyt/j4DUIyZ2yCtBFjJ49x+Q8iXAadmivMzAQHAE=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVe
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
 github.com/newrelic/newrelic-client-go/v2 v2.33.0 h1:kUuyWzCdbgt4DtF/VrNh73wSC9BW2H0ricHNcuWQDbM=
 github.com/newrelic/newrelic-client-go/v2 v2.33.0/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1 h1:Cf/Lh8hF73biCC9dC8kPd6gi3PeCUQraWUreefh96gk=
+github.com/newrelic/newrelic-client-go/v2 v2.36.2-0.20240527091533-de75a293dda1/go.mod h1:JCIsx0H/5MPuP9DzOWMFBrfBZ0apc2NZvsk+Q8CFb7k=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -167,6 +167,8 @@ func validateProfile(maxTimeoutSeconds int, sg *segment.Segment) *types.DetailEr
 
 func checkNetwork() {
 
+	log.Println("Checking if any proxy is configured ...")
+
 	if IsProxyConfigured() {
 		log.Warn("Proxy settings have been configured, but we are still unable to connect to the New Relic platform.")
 		log.Warn("You may need to adjust your proxy environment variables or configure your proxy to allow the specified domain.")

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -167,8 +167,6 @@ func validateProfile(maxTimeoutSeconds int, sg *segment.Segment) *types.DetailEr
 
 func checkNetwork() {
 
-	log.Println("Network check successful")
-
 	if IsProxyConfigured() {
 		log.Warn("Proxy settings have been configured, but we are still unable to connect to the New Relic platform.")
 		log.Warn("You may need to adjust your proxy environment variables or configure your proxy to allow the specified domain.")

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -191,7 +191,6 @@ func checkNetwork() error {
 		}
 		log.Warn("More information about proxy configuration: https://github.com/newrelic/newrelic-cli/blob/main/docs/GETTING_STARTED.md#using-an-http-proxy")
 		log.Warn("More information about network requirements: https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/")
-
 	}
 	return err
 }


### PR DESCRIPTION
JIRA - https://new-relic.atlassian.net/browse/NR-270753 


This PR aims to address the below timeout issue for few customers as it appears CLI is performing few [test calls ](https://github.com/newrelic/newrelic-cli/blob/53c2d81b257fe874d86c4a0b97b14489d9e7cd99/internal/install/command.go#L178) to verify if the New Relic endpoints are reachable and this infra-alert.service is being invoked during this specific [call](https://github.com/newrelic/newrelic-client-go/blob/0e073a6f00c54832713063f6e37222759337ff41/pkg/region/region_constants.go#L27).

`FATAL Get "https://login.newrelic.com/login?return_to=https%3A%2F%2Finfrastructure-alert.service.newrelic.com%2Fv2": dial tcp 18.188.220.94:443: i/o timeout`