### PR TITLE
feat: Publish CLI Docker image during release instead of during PR merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,3 +195,14 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
       AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
+  snapshot:
+    if: github.ref == 'refs/heads/main'
+    needs: snapshot
+    uses: newrelic/newrelic-cli/.github/workflows/snapshot.yml@main
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      SPLIT_PROD_KEY: ${{ secrets.SPLIT_PROD_KEY }}
+      SPLIT_STAGING_KEY: ${{ secrets.SPLIT_STAGING_KEY }}
+      SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,8 +1,20 @@
 name: Snapshot
 
+permissions: write-all
+
 on:
-  push:
-    branches: [main]
+  workflow_call:
+    secrets:
+      DOCKER_USERNAME:
+        required: true
+      DOCKER_PASSWORD:
+        required: true
+      SPLIT_PROD_KEY:
+        required: true
+      SPLIT_STAGING_KEY:
+        required: true
+      SEGMENT_WRITE_KEY:
+        required: true
 
 jobs:
   snapshot:


### PR DESCRIPTION
JIRA: https://new-relic.atlassian.net/browse/NR-272393

These modifications will initiate the CLI Docker image push during the release process rather than at the point of merging a PR into the main branch