### PR TITLE
feat: Add supported platform oracle

### DIFF
--- a/internal/install/types/types.go
+++ b/internal/install/types/types.go
@@ -30,6 +30,8 @@ var OpenInstallationPlatformTypes = struct {
 	CENTOS OpenInstallationPlatform
 	// Debian operating system
 	DEBIAN OpenInstallationPlatform
+	// Oracle Linux operating system
+	ORACLE OpenInstallationPlatform
 	// RedHat Enterprise Linux operating system
 	REDHAT OpenInstallationPlatform
 	// SUSE operating system
@@ -47,6 +49,8 @@ var OpenInstallationPlatformTypes = struct {
 	CENTOS: "CENTOS",
 	// Debian operating system
 	DEBIAN: "DEBIAN",
+	// Oracle Linux operating system
+	ORACLE: "ORACLE",
 	// RedHat Enterprise Linux operating system
 	REDHAT: "REDHAT",
 	// SUSE operating system


### PR DESCRIPTION
Adds Oracle Linux as a supported platform to allow for the installation of the Super Agent on Oracle Linux.