### PR TITLE
feat: Mongodb local validation

### DIFF
--- a/internal/install/validation/integration_validator.go
+++ b/internal/install/validation/integration_validator.go
@@ -45,6 +45,10 @@ func ValidateIntegration(integrationName string) (string, error) {
 
 		cmd := exec.Command(binPath)
 
+		if integrationName == "mongodb3" {
+			cmd = exec.Command(binPath, "-short_running")
+		}
+
 		for k, v := range integration.Env {
 			env := fmt.Sprintf("%s=%s", k, v)
 


### PR DESCRIPTION
Adds an edge case for locally validating mongodb; by using `-short_running` we are able to execute the nri-mongodb3 integration once. The default behavior for nri-mongodb3 is to start a long running, background process.