### PR TITLE
feat: Local validation windows

### DIFF
--- a/internal/install/validation/integration_validator.go
+++ b/internal/install/validation/integration_validator.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -40,6 +41,10 @@ func ValidateIntegration(integrationName string) (string, error) {
 
 	for _, integration := range config.Integrations {
 		integrationBasename := integration.Name
+
+		if runtime.GOOS == "windows" {
+			integrationBasename += ".exe"
+		}
 
 		binPath := filepath.Join(IntegrationsDirname, integrationBasename)
 


### PR DESCRIPTION
Appends .exe to nri binaries if the operating system is Windows, thereby enabling local validation for Windows.