### PR TITLE
feat: Env var license key

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -189,9 +189,7 @@ func fetchLicenseKey() *types.DetailError {
 
 	if utils.IsValidLicenseKeyFormat(licenseKey) {
 		return nil
-	}
-
-	if licenseKey != "" {
+	} else {
 		log.Debug("license key provided via NEW_RELIC_LICENSE_KEY is invalid")
 	}
 
@@ -200,9 +198,7 @@ func fetchLicenseKey() *types.DetailError {
 
 	if utils.IsValidLicenseKeyFormat(licenseKey) {
 		return nil
-	}
-
-	if licenseKey != "" {
+	} else {
 		log.Debug("license key provided by config is invalid")
 	}
 

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -70,12 +70,7 @@ func TestValidateProfile(t *testing.T) {
 
 func TestFetchLicenseKey(t *testing.T) {
 	okCase := func() *types.DetailError { return nil }()
-	// Error case
-	// err := fetchLicenseKey()
-	// assert.Equal(t, types.EventTypes.UnableToFetchLicenseKey, err.EventName)
-
-	// licenseKey := os.Getenv("NEW_RELIC_LICENSE_KEY")
-	// assert.Equal(t, "", licenseKey)
+	// TODO: Error case
 
 	// TODO: From API (mock?)
 

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -22,7 +22,7 @@ func TestInstallCommand(t *testing.T) {
 	testcobra.CheckCobraMetadata(t, Command)
 	testcobra.CheckCobraRequiredFlags(t, Command, []string{})
 }
-func TestCommandValidProfile(t *testing.T) {
+func TestValidateProfile(t *testing.T) {
 	accountID := os.Getenv("NEW_RELIC_ACCOUNT_ID")
 	apiKey := os.Getenv("NEW_RELIC_API_KEY")
 	region := os.Getenv("NEW_RELIC_REGION")
@@ -31,7 +31,7 @@ func TestCommandValidProfile(t *testing.T) {
 	defer server.Close()
 
 	os.Setenv("NEW_RELIC_ACCOUNT_ID", "")
-	err := validateProfile(5)
+	err := validateProfile()
 	assert.Error(t, err)
 	assert.Equal(t, types.EventTypes.AccountIDMissing, err.EventName)
 
@@ -42,11 +42,11 @@ func TestCommandValidProfile(t *testing.T) {
 	}
 
 	os.Setenv("NEW_RELIC_API_KEY", "")
-	err = validateProfile(5)
+	err = validateProfile()
 	assert.Equal(t, types.EventTypes.APIKeyMissing, err.EventName)
 
 	os.Setenv("NEW_RELIC_API_KEY", "67890")
-	err = validateProfile(5)
+	err = validateProfile()
 	assert.Equal(t, types.EventTypes.InvalidUserAPIKeyFormat, err.EventName)
 
 	if apiKey == "" {
@@ -56,16 +56,40 @@ func TestCommandValidProfile(t *testing.T) {
 	}
 
 	os.Setenv("NEW_RELIC_REGION", "au")
-	err = validateProfile(5)
+	err = validateProfile()
 	assert.Equal(t, types.EventTypes.InvalidRegion, err.EventName)
 
 	os.Setenv("NEW_RELIC_REGION", "")
-	err = validateProfile(5)
+	err = validateProfile()
 	assert.Equal(t, types.EventTypes.RegionMissing, err.EventName)
 
 	os.Setenv("NEW_RELIC_ACCOUNT_ID", accountID)
 	os.Setenv("NEW_RELIC_REGION", region)
 	os.Setenv("NEW_RELIC_API_KEY", apiKey)
+}
+
+func TestFetchLicenseKey(t *testing.T) {
+	okCase := func() *types.DetailError { return nil }()
+	// Error case
+	// err := fetchLicenseKey()
+	// assert.Equal(t, types.EventTypes.UnableToFetchLicenseKey, err.EventName)
+
+	// licenseKey := os.Getenv("NEW_RELIC_LICENSE_KEY")
+	// assert.Equal(t, "", licenseKey)
+
+	// TODO: From API (mock?)
+
+	// TODO: From profile
+
+	// From environment variable
+	expect := "0123456789abcdefABCDEF0123456789abcdNRAL"
+	os.Setenv("NEW_RELIC_LICENSE_KEY", expect)
+
+	err := fetchLicenseKey()
+	assert.Equal(t, okCase, err)
+
+	actual := os.Getenv("NEW_RELIC_LICENSE_KEY")
+	assert.Equal(t, expect, actual)
 }
 
 func initSegmentMockServer() *httptest.Server {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -207,7 +207,7 @@ func IsValidUserAPIKeyFormat(key string) bool {
 
 // Returns true if the given license key is valid.
 // A valid license key is 40 characters in length,
-// ends with "NRAL", and has a hexidecimal prefix.
+// ends with "NRAL", and has a hexadecimal prefix.
 func IsValidLicenseKeyFormat(licenseKey string) bool {
 	if len(licenseKey) != 40 {
 		return false

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -204,3 +204,22 @@ func IsValidUserAPIKeyFormat(key string) bool {
 
 	return isAlphanumeric
 }
+
+// Returns true if the given license key is valid.
+// A valid license key is 40 characters in length,
+// ends with "NRAL", and has a hexidecimal prefix.
+func IsValidLicenseKeyFormat(licenseKey string) bool {
+	if len(licenseKey) != 40 {
+		return false
+	}
+
+	suffix := "NRAL"
+
+	if !strings.HasSuffix(licenseKey, suffix) {
+		return false
+	}
+
+	prefix := strings.TrimSuffix(licenseKey, suffix)
+
+	return regexp.MustCompile("^[a-fA-F0-9]*$").MatchString(prefix)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -210,16 +210,25 @@ func IsValidUserAPIKeyFormat(key string) bool {
 // ends with "NRAL", and has a hexadecimal prefix.
 func IsValidLicenseKeyFormat(licenseKey string) bool {
 	if len(licenseKey) != 40 {
+		log.Debug("license key is invalid length")
 		return false
 	}
 
 	suffix := "NRAL"
 
 	if !strings.HasSuffix(licenseKey, suffix) {
+		log.Debug("license key does not have suffix \"NRAL\"")
 		return false
 	}
 
 	prefix := strings.TrimSuffix(licenseKey, suffix)
 
-	return regexp.MustCompile("^[a-fA-F0-9]*$").MatchString(prefix)
+	hexadecimal := regexp.MustCompile("^[a-fA-F0-9]*$").MatchString(prefix)
+
+	if !hexadecimal {
+		log.Debug("license key is not hexadecimal")
+		return false
+	}
+
+	return true
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -123,3 +123,22 @@ func TestIsValidUserAPIKeyFormat_Invalid(t *testing.T) {
 	result = IsValidUserAPIKeyFormat("NRAK-@$%^!")
 	assert.False(t, result)
 }
+
+func TestIsValidLicenseKeyFormat_Valid(t *testing.T) {
+	result := IsValidLicenseKeyFormat("0123456789abcdefABCDEF0123456789abcdNRAL")
+	assert.True(t, result)
+}
+
+func TestIsValidLicenseKeyFormat_Invalid(t *testing.T) {
+	// Invalid length
+	result := IsValidLicenseKeyFormat("0123456789abcefNRAL")
+	assert.False(t, result)
+
+	// Invalid suffix
+	result = IsValidLicenseKeyFormat("0123456789abcdefABCDEF0123456789abcdNRAK")
+	assert.False(t, result)
+
+	// Invalid characters
+	result = IsValidLicenseKeyFormat("0123456789ghijklGHIJKL0123456789ghijNRAL")
+	assert.False(t, result)
+}


### PR DESCRIPTION
Refactors the validateProfile function and separates out a fetchLicenseKey function.

fetchLicenseKey will attempt to:
- Read a license key from the environment variable `NEW_RELIC_LICENSE_KEY`
- Read a license key from the active profile config
- Fetch a license key via the API

The license key will be fetched in that order; such that the environment variable is preferred over the active profile config, which is preferred over fetching via the API.

This allows users to use a license key of their choice (via `NEW_RELIC_LICENSE_KEY`) without the need to configure a profile.