### PR TITLE
fix(proxy-error): Show warning message for http proxy

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -147,10 +148,20 @@ func checkNetwork() error {
 	}
 
 	err := client.NRClient.TestEndpoints()
+
+	proxyConfig := httpproxy.FromEnvironment()
+
+	if err == nil {
+		if IsProxyConfigured() {
+			if strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "http") && !strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "https") { 
+				log.Warn("Please ensure the HTTPS_PROXY environment variable is set when using a proxy server.")
+				log.Warn("New Relic CLI exclusively supports https proxy, not http for security reasons.")
+			}
+		}
+	}
+
 	if err != nil {
 		if IsProxyConfigured() {
-			proxyConfig := httpproxy.FromEnvironment()
-
 			log.Warn("Proxy settings have been configured, but we are still unable to connect to the New Relic platform.")
 			log.Warn("You may need to adjust your proxy environment variables or configure your proxy to allow the specified domain.")
 			log.Warn("Current proxy config:")

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -153,7 +153,7 @@ func checkNetwork() error {
 
 	if err == nil {
 		if IsProxyConfigured() {
-			if strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "http") && !strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "https") { 
+			if strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "http") && !strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "https") {
 				log.Warn("Please ensure the HTTPS_PROXY environment variable is set when using a proxy server.")
 				log.Warn("New Relic CLI exclusively supports https proxy, not http for security reasons.")
 			}

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"testing"
 	"strings"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 
@@ -95,7 +95,6 @@ func initSegmentMockServer() *httptest.Server {
 	}))
 	return server
 }
-
 
 func TestProxyNetwork(t *testing.T) {
 

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -4,9 +4,10 @@ package install
 
 import (
 	"net/http"
-	"net/http/httptest"
-	"os"
+	// "net/http/httptest"
+	// "os"
 	"testing"
+	"strings"
 
 	"github.com/stretchr/testify/assert"
 
@@ -93,4 +94,31 @@ func initSegmentMockServer() *httptest.Server {
 		_, _ = w.Write([]byte(`[]`))
 	}))
 	return server
+}
+
+
+func TestProxyNetwork(t *testing.T) {
+
+	proxyConfig := struct {
+		HTTPSProxy string
+		HTTPProxy  string
+	}{
+		HTTPSProxy: "http://localhost:3128",
+		HTTPProxy:  "http://localhost:8080",
+	}
+
+	// Validate HTTPSProxy
+	if strings.HasPrefix(proxyConfig.HTTPSProxy, "http://") {
+		t.Log("New Relic CLI exclusively supports https proxy, not http for security reasons.")
+	} else if strings.HasPrefix(proxyConfig.HTTPSProxy, "https://") {
+		// Do nothing
+	} else {
+		t.Log("Invalid proxy provided")
+	}
+
+	// Validate HTTPProxy
+	if strings.HasPrefix(proxyConfig.HTTPProxy, "http://") {
+		t.Log("If you need to use a proxy, consider setting the HTTPS_PROXY environment variable, then try again. New Relic CLI exclusively supports https proxy.")
+	}
+
 }

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -4,8 +4,8 @@ package install
 
 import (
 	"net/http"
-	// "net/http/httptest"
-	// "os"
+	"net/http/httptest"
+	"os"
 	"testing"
 	"strings"
 


### PR DESCRIPTION
This PR will display an warning message through CLI, if `http proxy` is provided to the environment variable `HTTPSProxy`, and continue the installation process ignoring the proxy.

Ticket: https://new-relic.atlassian.net/browse/NR-306868

The warning message would look like this

<img width="515" alt="Screenshot 2024-09-13 at 12 44 58" src="https://github.com/user-attachments/assets/09593f7c-8b6e-4eb0-9165-39cd26f737ba">

Agent installation is successful providing the warning message, log record is attached here

<img width="1267" alt="Screenshot 2024-09-13 at 12 28 37" src="https://github.com/user-attachments/assets/67e3dcb9-c502-4bce-b74b-603f94bc62cb">


