### PR TITLE
make githooks script POSIX-compliant and compatible with /bin/sh

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -8,8 +8,8 @@ conventional_commit_regex="^${commit_types}(\([a-z \-]+\))?!?: .+$"
 
 commit_message=$(cat "$1")
 
-if [[ "$commit_message" =~ $conventional_commit_regex ]]; then
-   echo -e "Commit message meets Conventional Commit standards..."
+if echo "$commit_message" | grep -Eq "$conventional_commit_regex"; then
+   echo "Commit message meets Conventional Commit standards..."
    exit 0
 fi
     echo


### PR DESCRIPTION
When functions like `[[ ... ]]` are used in `/bin/sh`, this can cause problems as this implementation is not POSIX-compliant and not official supported in `/bin/sh`. 

The `[[ ... ]]` construct is a feature of bash, but /bin/sh is often a symbolic link to a shell like dash that doesn’t support `[[ ... ]]`.

Error-messages can look like: 
```sh
.githooks/commit-msg: 11: [[: not found
```

This can cause the commit to fail, even if the commit message would be compliant with the commit standard. 