### PR TITLE
feat: Fleet management link

### DIFF
--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -114,6 +114,8 @@ func (r TerminalStatusReporter) InstallComplete(status *InstallStatus) error {
 
 		r.printLoggingLink(status)
 
+		r.printFleetLink(status)
+
 		fmt.Println()
 		fmt.Println("\n  --------------------")
 		fmt.Println()
@@ -144,13 +146,30 @@ func (r TerminalStatusReporter) UpdateRequired(status *InstallStatus) error {
 	return nil
 }
 
+func (r TerminalStatusReporter) printFleetLink(status *InstallStatus) {
+	statuses := r.getRecipesStatusesForInstallationSummary(status)
+
+	for _, s := range statuses {
+		isSuperAgentRecipe := s.Name == types.SuperAgentRecipeName || s.Name == types.LoggingSuperAgentRecipeName
+
+		if s.Status == RecipeStatusTypes.INSTALLED && isSuperAgentRecipe {
+			linkToFleet := "https://one.newrelic.com/nr1-core?filters=%28domain%20%3D%20%27NR1%27%20AND%20type%20%3D%20%27FLEET%27%29"
+
+			fmt.Println()
+			fmt.Println("View you fleet at the link below")
+			fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
+
+		}
+	}
+}
+
 func (r TerminalStatusReporter) printLoggingLink(status *InstallStatus) {
 	linkToLogging := ""
 	loggingMsg := "View your logs at the link below:\n"
 	statusesToDisplay := r.getRecipesStatusesForInstallationSummary(status)
 
 	for _, s := range statusesToDisplay {
-		if s.Status == RecipeStatusTypes.INSTALLED && (s.Name == types.LoggingRecipeName || s.Name == types.LoggingSuperAgentRecipeName) {
+		if s.Status == RecipeStatusTypes.INSTALLED && s.Name == types.LoggingRecipeName {
 			linkToLogging = status.PlatformLinkGenerator.GenerateLoggingLink(status.HostEntityGUID())
 		}
 	}

--- a/internal/install/execution/terminal_reporter_test.go
+++ b/internal/install/execution/terminal_reporter_test.go
@@ -111,7 +111,7 @@ func Test_ShouldGenerateLoggingLink(t *testing.T) {
 	err := r.InstallComplete(status)
 	require.NoError(t, err)
 	require.Equal(t, 1, g.GenerateEntityLinkCallCount)
-	require.Equal(t, 2, g.GenerateLoggingLinkCallCount)
+	require.Equal(t, 1, g.GenerateLoggingLinkCallCount)
 }
 
 func Test_ShouldNotGenerateExplorerLink(t *testing.T) {


### PR DESCRIPTION
A successful installation of the Super Agent or Super Agent Logging will now display a link leading the user to the Fleet Management view.

A successful installation of the Super Agent Logging recipe no longer displays a link to the logging page due to a lack of an entity id.