### PR TITLE
feat: Agent version command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.38.0
+	github.com/newrelic/newrelic-client-go/v2 v2.48.1
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 	golang.org/x/net v0.23.0
 	golang.org/x/term v0.18.0
+	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	mvdan.cc/sh/v3 v3.4.3
@@ -68,7 +69,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.20.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.48.1
+	github.com/newrelic/newrelic-client-go/v2 v2.48.2
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.48.1 h1:cQ7CicUgh/nIOWG9VG7pXyzCdICL4bDRgWyByg3bl4U=
-github.com/newrelic/newrelic-client-go/v2 v2.48.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.48.2 h1:Pd8/ADdidF/dISMCy9B2UHvcD11lnj4Use6j++OOEf4=
+github.com/newrelic/newrelic-client-go/v2 v2.48.2/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.38.0 h1:2Q106SyrB7e0zeWP7374HBCJ2N5aWhZ8sZBkzmxwzn0=
-github.com/newrelic/newrelic-client-go/v2 v2.38.0/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
+github.com/newrelic/newrelic-client-go/v2 v2.48.1 h1:cQ7CicUgh/nIOWG9VG7pXyzCdICL4bDRgWyByg3bl4U=
+github.com/newrelic/newrelic-client-go/v2 v2.48.1/go.mod h1:pDFY24/6iIMEbPIdowTRrRn9YYwkXc3j+B+XpTb4oF4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/agent/command.go
+++ b/internal/agent/command.go
@@ -64,11 +64,9 @@ android, browser, dotnet, elixir, go, infrastructure, ios, java, nodejs, php, py
 			return err
 		}
 
-		fmt.Printf("%+v\n", result)
+		agentNameTitleCase := version.AgentNameTitleCase(agentName)
 
-		// agentNameTitleCase := agentNameTitleCase(agentName)
-
-		// fmt.Printf("%s: %s\n", agentNameTitleCase, version)
+		fmt.Printf("%s: %s\n", agentNameTitleCase, result.Version)
 
 		return nil
 	},

--- a/internal/agent/command_test.go
+++ b/internal/agent/command_test.go
@@ -20,7 +20,7 @@ func TestAgent(t *testing.T) {
 func TestAgentConfig(t *testing.T) {
 	assert.Equal(t, "config", cmdConfig.Name())
 	testcobra.CheckCobraMetadata(t, cmdConfig)
-	testcobra.CheckCobraMetadata(t, cmdConfig)
+	testcobra.CheckCobraRequiredFlags(t, cmdConfigObfuscate, []string{})
 }
 
 func TestAgentConfigObfuscate(t *testing.T) {
@@ -33,4 +33,10 @@ func TestAgentConfigMigrate(t *testing.T) {
 	assert.Equal(t, "migrateV3toV4", cmdMigrateV3toV4.Name())
 	testcobra.CheckCobraMetadata(t, cmdMigrateV3toV4)
 	testcobra.CheckCobraRequiredFlags(t, cmdMigrateV3toV4, []string{})
+}
+
+func TestAgentAgentVersion(t *testing.T) {
+	assert.Equal(t, "version", cmdAgentVersion.Name())
+	testcobra.CheckCobraMetadata(t, cmdAgentVersion)
+	testcobra.CheckCobraRequiredFlags(t, cmdAgentVersion, []string{})
 }

--- a/internal/agent/version/version.go
+++ b/internal/agent/version/version.go
@@ -1,0 +1,34 @@
+package version
+
+import (
+	"reflect"
+
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agent"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func AgentNameTitleCase(agentName agent.AgentReleasesFilter) string {
+	caser := cases.Title(language.AmericanEnglish)
+
+	switch agentName {
+	case agent.AgentReleasesFilterTypes.DOTNET:
+		return ".NET"
+	case agent.AgentReleasesFilterTypes.IOS:
+		return "iOS"
+	case agent.AgentReleasesFilterTypes.NODEJS:
+		return "Node.js"
+	case agent.AgentReleasesFilterTypes.PHP:
+		return "PHP"
+	case agent.AgentReleasesFilterTypes.SDK:
+		return "C SDK"
+	default:
+		return caser.String(string(agentName))
+	}
+}
+
+func IsValidAgentName(agentName string) bool {
+	a := reflect.ValueOf(agent.AgentReleasesFilterTypes)
+
+	return a.FieldByName(agentName).String() == agentName
+}

--- a/internal/agent/version/version_test.go
+++ b/internal/agent/version/version_test.go
@@ -1,0 +1,105 @@
+package version_test
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-cli/internal/agent/version"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/agent"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAgentNameTitleCase(t *testing.T) {
+	t.Parallel()
+
+	expected := "Android"
+	agentName := agent.AgentReleasesFilterTypes.ANDROID
+	actual := version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Browser"
+	agentName = agent.AgentReleasesFilterTypes.BROWSER
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = ".NET"
+	agentName = agent.AgentReleasesFilterTypes.DOTNET
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Elixir"
+	agentName = agent.AgentReleasesFilterTypes.ELIXIR
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Go"
+	agentName = agent.AgentReleasesFilterTypes.GO
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Infrastructure"
+	agentName = agent.AgentReleasesFilterTypes.INFRASTRUCTURE
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "iOS"
+	agentName = agent.AgentReleasesFilterTypes.IOS
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Java"
+	agentName = agent.AgentReleasesFilterTypes.JAVA
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Node.js"
+	agentName = agent.AgentReleasesFilterTypes.NODEJS
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "PHP"
+	agentName = agent.AgentReleasesFilterTypes.PHP
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Python"
+	agentName = agent.AgentReleasesFilterTypes.PYTHON
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "Ruby"
+	agentName = agent.AgentReleasesFilterTypes.RUBY
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+
+	expected = "C SDK"
+	agentName = agent.AgentReleasesFilterTypes.SDK
+	actual = version.AgentNameTitleCase(agentName)
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestIsValidAgentName(t *testing.T) {
+	t.Parallel()
+
+	agentName := "PYTHON"
+	actual := version.IsValidAgentName(agentName)
+
+	assert.True(t, actual)
+
+	agentName = "ASDF"
+	actual = version.IsValidAgentName(agentName)
+
+	assert.False(t, actual)
+}


### PR DESCRIPTION
Adds a sub-command to 'newrelic agent' called 'version', which displays the latest agent version for a given agent name.