### PR TITLE
fix: License key fatal error

### DIFF
--- a/internal/utils/validation/polling_nrql_validator.go
+++ b/internal/utils/validation/polling_nrql_validator.go
@@ -101,7 +101,7 @@ func (m *PollingNRQLValidator) tryValidate(ctx context.Context, query string) (s
 }
 
 func (m *PollingNRQLValidator) executeQuery(ctx context.Context, query string) ([]nrdb.NRDBResult, error) {
-	accountID := configAPI.RequireActiveProfileAccountID()
+	accountID := configAPI.GetActiveProfileAccountID()
 
 	nrql := nrdb.NRQL(query)
 


### PR DESCRIPTION
Fixes a fatal error that occurs when a user supplies only their license key. Fails silently (debug output) instead, so that the installation can continue.