### PR TITLE
feat: Arm64 docker image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -67,14 +67,44 @@ signs:
 dockers:
   - dockerfile: build/package/Dockerfile
     image_templates:
-      - "newrelic/cli:{{ .Tag }}"
-      - "newrelic/cli:v{{ .Major }}.{{ .Minor }}"
-      - "newrelic/cli:latest"
+      - "newrelic/cli:{{ .Tag }}-amd64"
+      - "newrelic/cli:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "newrelic/cli:latest-amd64"
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=repository=http://github.com/newrelic/newrelic-cli"
       - "--label=homepage=https://developer.newrelic.com/"
       - "--label=maintainer=Developer Toolkit <opensource@newrelic.com>"
+      - "--platform=linux/amd64"
+    goarch: amd64
+  - dockerfile: build/package/Dockerfile
+    image_templates:
+      - "newrelic/cli:{{ .Tag }}-arm64"
+      - "newrelic/cli:v{{ .Major }}.{{ .Minor }}-arm64"
+      - "newrelic/cli:latest-arm64"
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--label=repository=http://github.com/newrelic/newrelic-cli"
+      - "--label=homepage=https://developer.newrelic.com/"
+      - "--label=maintainer=Developer Toolkit <opensource@newrelic.com>"
+      - "--platform=linux/arm64"
+    goarch: arm64
+
+docker_manifests:
+  - name_template: "newrelic/cli:{{ .Tag }}"
+    image_templates:
+      - "newrelic/cli:{{ .Tag }}-amd64"
+      - "newrelic/cli:{{ .Tag }}-arm64"
+  - name_template: "newrelic/cli:v{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "newrelic/cli:v{{ .Major }}.{{ .Minor }}-amd64"
+      - "newrelic/cli:v{{ .Major }}.{{ .Minor }}-arm64"
+  - name_template: "newrelic/cli:latest"
+    image_templates:
+      - "newrelic/cli:latest-amd64"
+      - "newrelic/cli:latest-arm64"
 
 # Uses git-chglog output from release flow
 changelog:


### PR DESCRIPTION
Modifies the GoReleaser config so that both amd64 and arm64 images are created and pushed to the Docker Registry.