### PR TITLE
chore: Resolved go task formatting inconsistency

### DIFF
--- a/internal/install/execution/go_task_recipe_executor_test.go
+++ b/internal/install/execution/go_task_recipe_executor_test.go
@@ -42,7 +42,7 @@ tasks:
 
 func TestExecute_HandleRecipeLastError(t *testing.T) {
 	v := types.RecipeVars{
-		"TEST_VAR": "testValue",
+		"TEST_VAR": "testValue\n \n",
 	}
 	r := types.OpenInstallationRecipe{
 		Name: "test-recipe",

--- a/internal/install/execution/line_capture_buffer.go
+++ b/internal/install/execution/line_capture_buffer.go
@@ -1,9 +1,9 @@
 package execution
 
 import (
-	"io"
-
 	log "github.com/sirupsen/logrus"
+	"io"
+	"strings"
 )
 
 type LineCaptureBuffer struct {
@@ -28,7 +28,7 @@ func (c *LineCaptureBuffer) Write(p []byte) (n int, err error) {
 			s := string(c.current)
 			c.fullRecipeOutput = append(c.fullRecipeOutput, s)
 
-			if s != "" {
+			if strings.TrimSpace(s) != "" {
 				log.Debugf(s)
 				c.LastFullLine = s
 			}


### PR DESCRIPTION
Added logic to remove leading and trailing whitespace from error messages received from the OIL recipe. This addresses the issue of error messages being formatted incorrectly, often displaying only the exit status without the actual message content.
JIRA: https://new-relic.atlassian.net/browse/NR-329044

Before adding the logic
<img width="1711" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/cb302fdd-2337-4ec1-8fb5-e76520789ac6">

After adding the logic
<img width="1725" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/35457a77-17db-4a45-b2c3-2ed026c6ef62">
