### PR TITLE
fix(dashboard): Updated the Dashboard JSON to HCL Converter Utility with Latest Fields in the Resource

### DIFF
--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -27,6 +28,10 @@ var (
 		"viz.stacked-bar":         "widget_stacked_bar",
 		"logger.log-table-widget": "widget_log_table",
 	}
+	ThresholdSeverityValues = map[string]string{
+		"CRITICAL": "critical",
+		"WARNING":  "warning",
+	}
 )
 
 type DashboardWidgetRawConfiguration struct {
@@ -34,19 +39,24 @@ type DashboardWidgetRawConfiguration struct {
 	NRQLQueries       []DashboardWidgetNRQLQuery     `json:"nrqlQueries"`
 	LinkedEntityGUIDs []string                       `json:"linkedEntityGuids"`
 	Text              string                         `json:"text"`
+	Limit             float64                        `json:"limit,omitempty"`
 	Facet             DashboardWidgetFacet           `json:"facet,omitempty"`
 	Legend            DashboardWidgetLegend          `json:"legend,omitempty"`
+	Threshold         json.RawMessage                `json:"thresholds,omitempty"`
 	YAxisLeft         DashboardWidgetYAxisLeft       `json:"yAxisLeft,omitempty"`
 	NullValues        DashboardWidgetNullValues      `json:"nullValues,omitempty"`
 	Units             DashboardWidgetUnits           `json:"units,omitempty"`
 	Colors            DashboardWidgetColors          `json:"colors,omitempty"`
 	PlatformOptions   DashboardWidgetPlatformOptions `json:"platformOptions,omitempty"`
+	RefreshRate       DashboardWidgetRefreshRate     `json:"refreshRate,omitempty"`
+	InitialSorting    DashboardWidgetInitialSorting  `json:"initialSorting,omitempty"`
 }
 
 type DataFormatter struct {
 	Name      string      `json:"name"`
 	Precision interface{} `json:"precision"`
 	Type      string      `json:"type"`
+	Format    string      `json:"format"`
 }
 
 type DashboardWidgetFacet struct {
@@ -60,6 +70,23 @@ type DashboardWidgetNRQLQuery struct {
 
 type DashboardWidgetLegend struct {
 	Enabled bool `json:"enabled,omitempty"`
+}
+
+type DashboardWidgetThreshold struct {
+	From     float64 `json:"from,omitempty"`
+	Name     string  `json:"name,omitempty"`
+	Severity string  `json:"severity,omitempty"`
+	To       float64 `json:"to,omitempty"`
+}
+
+type DashboardWidgetLineThreshold struct {
+	IsLabelVisible bool                       `json:"isLabelVisible,omitempty"`
+	Threshold      []DashboardWidgetThreshold `json:"thresholds,omitempty"`
+}
+
+type DashboardWidgetBillBoardThreshold struct {
+	AlertSeverity string  `json:"alertSeverity,omitempty"`
+	Value         float64 `json:"value,omitempty"`
 }
 
 type DashboardWidgetYAxisLeft struct {
@@ -96,8 +123,18 @@ type DashboardWidgetColorOverrides struct {
 	Color      string `json:"color,omitempty"`
 	SeriesName string `json:"seriesName,omitempty"`
 }
+
 type DashboardWidgetPlatformOptions struct {
 	IgnoreTimeRange bool `json:"ignoreTimeRange,omitempty"`
+}
+
+type DashboardWidgetRefreshRate struct {
+	Frequency interface{} `json:"frequency,omitempty"`
+}
+
+type DashboardWidgetInitialSorting struct {
+	Direction string `json:"direction"`
+	Name      string `json:"name"`
 }
 
 func GenerateDashboardHCL(resourceLabel string, shiftWidth int, input []byte) (string, error) {
@@ -143,9 +180,64 @@ func GenerateDashboardHCL(resourceLabel string, shiftWidth int, input []byte) (s
 						h.WriteBooleanAttribute("ignore_time_range", config.PlatformOptions.IgnoreTimeRange)
 						h.WriteFloatAttribute("y_axis_left_min", config.YAxisLeft.Min)
 						h.WriteFloatAttribute("y_axis_left_max", config.YAxisLeft.Max)
+						writeInterfaceValues(h, "refresh_rate", config.RefreshRate.Frequency) // function to handle different types of refresh rates which cant be handled through struct
+
 						if w.Visualization.ID == "viz.line" {
 							h.WriteBooleanAttribute("y_axis_left_zero", config.YAxisLeft.Zero)
+
+							var widgetLineThreshold DashboardWidgetLineThreshold
+							if err := json.Unmarshal(config.Threshold, &widgetLineThreshold); err != nil {
+								log.Fatal("Error unmarshalling widgetLineThreshold:", err)
+							}
+
+							h.WriteBooleanAttribute("is_label_visible", widgetLineThreshold.IsLabelVisible)
+
+							for _, q := range widgetLineThreshold.Threshold {
+								h.WriteBlock("threshold", []string{}, func() {
+									h.WriteStringAttribute("name", q.Name)
+									h.WriteStringAttribute("severity", q.Severity)
+									h.WriteFloatAttribute("from", q.From)
+									h.WriteFloatAttribute("to", q.To)
+								})
+							}
 						}
+						if w.Visualization.ID == "viz.billboard" {
+							var billboardThreshold []DashboardWidgetBillBoardThreshold
+							if err := json.Unmarshal(config.Threshold, &billboardThreshold); err != nil {
+								log.Fatal("Error unmarshalling billboardThreshold:", err)
+							}
+							for _, q := range billboardThreshold {
+								h.WriteFloatAttribute(ThresholdSeverityValues[q.AlertSeverity], q.Value)
+							}
+
+							for _, q := range config.DataFormatters {
+								h.WriteBlock("data_format", []string{}, func() {
+									h.WriteStringAttribute("name", q.Name)
+									h.WriteStringAttribute("type", q.Type)
+									h.WriteStringAttribute("format", q.Format)
+									writeInterfaceValues(h, "precision", q.Precision) // function to handle different types of precision
+								})
+							}
+						}
+						if w.Visualization.ID == "viz.table" {
+							h.WriteBlock("initial_sorting", []string{}, func() {
+								h.WriteStringAttribute("name", config.InitialSorting.Name)
+								h.WriteStringAttribute("direction", config.InitialSorting.Direction)
+							})
+							for _, q := range config.DataFormatters {
+								h.WriteBlock("data_format", []string{}, func() {
+									h.WriteStringAttribute("name", q.Name)
+									h.WriteStringAttribute("type", q.Type)
+									h.WriteStringAttribute("format", q.Format)
+									writeInterfaceValues(h, "precision", q.Precision) // function to handle different types of precision
+								})
+							}
+						}
+
+						if w.Visualization.ID == "viz.bullet" {
+							h.WriteFloatAttribute("limit", config.Limit)
+						}
+
 						h.WriteBlock("null_values", []string{}, func() {
 							h.WriteStringAttribute("null_value", config.NullValues.NullValue)
 							for _, so := range config.NullValues.SeriesOverrides {
@@ -236,5 +328,16 @@ func unmarshalDashboardWidgetRawConfiguration(title string, widgetType string, b
 func requireValidVisualizationID(id string) {
 	if widgetTypes[id] == "" {
 		log.Fatalf("unrecognized widget type \"%s\"", id)
+	}
+}
+
+func writeInterfaceValues(h *HCLGen, title string, titleValue interface{}) {
+	switch titleValue.(type) {
+	case string:
+		h.WriteStringAttribute(title, fmt.Sprintf("%s", titleValue)) // string without quotes
+	case float64:
+		h.WriteFloatAttribute(title, titleValue.(float64)) // integer without quotes
+	default:
+		h.WriteStringAttribute(title, fmt.Sprintf("%s", ""))
 	}
 }

--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -332,12 +332,12 @@ func requireValidVisualizationID(id string) {
 }
 
 func writeInterfaceValues(h *HCLGen, title string, titleValue interface{}) {
-	switch titleValue.(type) {
+	switch titleValue := titleValue.(type) {
 	case string:
 		h.WriteStringAttribute(title, fmt.Sprintf("%s", titleValue)) // string without quotes
 	case float64:
-		h.WriteFloatAttribute(title, titleValue.(float64)) // integer without quotes
+		h.WriteFloatAttribute(title, titleValue) // integer without quotes
 	default:
-		h.WriteStringAttribute(title, fmt.Sprintf("%s", ""))
+		h.WriteStringAttribute(title, "")
 	}
 }


### PR DESCRIPTION
Problem Statement:

The problem at hand is to update the CLI dashboards utility which helps convert JSON dashboards into HCL-based dashboards (generating the newrelic_one_dashboard resource HCL configuration, from the JSON version of a dashboard) with the latest fields added to the Terraform resource, as these relatively new fields are unsupported by the CLI tool, owing to their absence in the parser of the tool, that needs an update

Solution :

schema of this CLI utility is updated with the latest fields updated in the newrelic_one_dashboard resource