### PR TITLE
fix(dashboard): add multi account support for nrql query block in dashboard

### DIFF
--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -63,7 +63,7 @@ type DashboardWidgetFacet struct {
 }
 
 type DashboardWidgetNRQLQuery struct {
-	AccountID int    `json:"accountId"`
+	AccountID []int  `json:"accountIds"`
 	Query     string `json:"query"`
 }
 
@@ -170,7 +170,7 @@ func GenerateDashboardHCL(resourceLabel string, shiftWidth int, input []byte) (s
 
 						for _, q := range config.NRQLQueries {
 							h.WriteBlock("nrql_query", []string{}, func() {
-								h.WriteIntAttributeIfNotZero("account_id", q.AccountID)
+								h.WriteIntArrayAttribute("account_ids", q.AccountID)
 								h.WriteMultilineStringAttribute("query", q.Query)
 							})
 						}


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed (if relevant).

Enhanced the NRQL block in the dashboard to support multiple account IDs, enabling the creation of widgets with multi-account data. This update aligns with the dashboard team's efforts to improve multi-account functionality.

the changes are done as a part of [this](https://github.com/newrelic/newrelic-cli/issues/1567) git Issue

Fixes # (issue)

Type of change
Please delete options that are not relevant.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

Please delete options that are not relevant.

- [x] My commit message follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] My code is formatted to [Go standards](https://go.dev/blog/gofmt)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. Go [here](https://github.com/newrelic/terraform-provider-newrelic/blob/main/CONTRIBUTING.md#testing) for instructions on running tests locally.