### PR TITLE
fix(script): Escape square brackets in registry key paths

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -37,10 +37,11 @@ try {
     | % { $_.Name.TrimStart("HKEY_LOCAL_MACHINE\") }
 
     $allKeys = $baseKeys + $wowKeys
-
+	
     $uninstallIds = New-Object System.Collections.ArrayList
     foreach ($key in $allKeys) {
-      $keyData = Get-Item -Path HKLM:\$key
+      $escapedKey = $key -replace '\[', '`[' -replace '\]', '`]'
+      $keyData = Get-Item -Path "HKLM:\$escapedKey"
       $name = $keyData.GetValue("DisplayName")
       if ($name -and $name -match $Match) {
         $keyId = Split-Path $key -Leaf
@@ -67,8 +68,7 @@ try {
     }
   }
 } catch {
-  Write-Host -ForegroundColor Red "We detected you may be running an anti-virus software preventing our installation to continue. Please check your anti-virus software to allow Powershell execution while running this installation."
-  exit 1;
+  throw $_.Exception
 }
 
 msiexec.exe /qn /i $env:TEMP\NewRelicCLIInstaller.msi | Out-Null;


### PR DESCRIPTION
**Issue:-** Mentioned in the below jira ticket.
[Jira Ticket](https://new-relic.atlassian.net/browse/NR-372770)

**Fix:-** Escape square brackets in registry key paths in Windows installer script.

I tested it after the changes(Infrastructure Agent was installed successfully), please see below.

**Test Data:-**

![image](https://github.com/user-attachments/assets/0b0016cc-44c8-4751-9178-c11237c8a5d0)
![image](https://github.com/user-attachments/assets/783a7b8c-568a-4a8e-9f69-1b078f781885)
![image](https://github.com/user-attachments/assets/eb7d3214-c4a8-4fa3-b8df-ac943cfac49d)
![image](https://github.com/user-attachments/assets/13d7ad0e-ca6c-4bfd-a5d5-463b3e025a89)
