### PR TITLE
fix(agent-control): link to fleet

### DIFF
--- a/internal/install/execution/link_generator.go
+++ b/internal/install/execution/link_generator.go
@@ -4,5 +4,6 @@ type LinkGenerator interface {
 	GenerateExplorerLink(status InstallStatus) string
 	GenerateEntityLink(entityGUID string) string
 	GenerateLoggingLink(entityGUID string) string
+	GenerateFleetLink(entityGUID string) string
 	GenerateRedirectURL(status InstallStatus) string
 }

--- a/internal/install/execution/mock_link_generator.go
+++ b/internal/install/execution/mock_link_generator.go
@@ -6,9 +6,11 @@ type MockPlatformLinkGenerator struct {
 	GenerateExplorerLinkCallCount int
 	GenerateEntityLinkCallCount   int
 	GenerateLoggingLinkCallCount  int
+	GenerateFleetLinkCallCount    int
 	GenerateExplorerLinkVal       string
 	GenerateEntityLinkVal         string
 	GenerateLoggingLinkVal        string
+	GenerateFleetLinkVal          string
 }
 
 func NewMockPlatformLinkGenerator() *MockPlatformLinkGenerator {
@@ -28,6 +30,11 @@ func (g *MockPlatformLinkGenerator) GenerateEntityLink(entityGUID string) string
 func (g *MockPlatformLinkGenerator) GenerateLoggingLink(entityGUID string) string {
 	g.GenerateLoggingLinkCallCount++
 	return g.GenerateLoggingLinkVal
+}
+
+func (g *MockPlatformLinkGenerator) GenerateFleetLink(entityGUID string) string {
+	g.GenerateFleetLinkCallCount++
+	return g.GenerateFleetLinkVal
 }
 
 func (g *MockPlatformLinkGenerator) GenerateRedirectURL(status InstallStatus) string {

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -47,6 +47,10 @@ func (g *PlatformLinkGenerator) GenerateLoggingLink(entityGUID string) string {
 	return g.generateLoggingLink(entityGUID)
 }
 
+func (g *PlatformLinkGenerator) GenerateFleetLink(entityGUID string) string {
+	return g.generateFleetLink(entityGUID)
+}
+
 // GenerateRedirectURL creates a URL for the user to navigate to after running
 // through an installation. The URL is displayed in the CLI out as well and is
 // also provided in the nerdstorage document. This provides the user two options
@@ -158,6 +162,19 @@ func (g *PlatformLinkGenerator) generateLoggingLauncherParams(entityGUID string)
 	}
 
 	return string(stringifiedParam)
+}
+
+func (g *PlatformLinkGenerator) generateFleetLink(_ string) string {
+	longURL := fmt.Sprintf("https://%s/nr1-core?filters=(domain = 'NR1' AND type = 'FLEET')",
+		nrPlatformHostname(),
+	)
+
+	shortURL, err := g.generateShortNewRelicURL(longURL)
+	if err != nil {
+		return longURL
+	}
+
+	return shortURL
 }
 
 // The shortenURL function utilizes a New Relic service to convert

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -165,7 +165,7 @@ func (g *PlatformLinkGenerator) generateLoggingLauncherParams(entityGUID string)
 }
 
 func (g *PlatformLinkGenerator) generateFleetLink(_ string) string {
-	longURL := fmt.Sprintf("https://%s/nr1-core?filters=(domain = 'NR1' AND type = 'FLEET')",
+	longURL := fmt.Sprintf("https://%s/nr1-core?filters=(domain='NR1'ANDtype='FLEET')",
 		nrPlatformHostname(),
 	)
 

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -165,7 +165,7 @@ func (g *PlatformLinkGenerator) generateLoggingLauncherParams(entityGUID string)
 }
 
 func (g *PlatformLinkGenerator) generateFleetLink(_ string) string {
-	longURL := fmt.Sprintf("https://%s/nr1-core?filters=(domain='NR1'ANDtype='FLEET')",
+	longURL := fmt.Sprintf("https://%s/fleet)",
 		nrPlatformHostname(),
 	)
 

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 
@@ -148,21 +147,22 @@ func (r TerminalStatusReporter) UpdateRequired(status *InstallStatus) error {
 }
 
 func (r TerminalStatusReporter) printFleetLink(status *InstallStatus) {
+	linkToFleet := ""
+	fleetMsg := "View your fleet at the link below:\n"
 	statuses := r.getRecipesStatusesForInstallationSummary(status)
 
 	for _, s := range statuses {
 		isAgentControlRecipe := s.Name == types.AgentControlRecipeName || s.Name == types.LoggingAgentControlRecipeName
 
 		if s.Status == RecipeStatusTypes.INSTALLED && isAgentControlRecipe {
-			linkToFleetRaw := "https://one.newrelic.com/nr1-core?filters=(domain = 'NR1' AND type = 'FLEET')"
-
-			linkToFleet := url.PathEscape(linkToFleetRaw)
-
-			fmt.Println()
-			fmt.Println("View your fleet at the link below")
-			fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
-
+			linkToFleet = status.PlatformLinkGenerator.GenerateFleetLink(status.HostEntityGUID())
 		}
+	}
+
+	if linkToFleet != "" {
+		fmt.Println("")
+		fmt.Printf("\n  %s", fleetMsg)
+		fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
 	}
 }
 

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -159,7 +159,7 @@ func (r TerminalStatusReporter) printFleetLink(status *InstallStatus) {
 			linkToFleet := url.PathEscape(linkToFleetRaw)
 
 			fmt.Println()
-			fmt.Println("View you fleet at the link below")
+			fmt.Println("View your fleet at the link below")
 			fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
 
 		}


### PR DESCRIPTION
Hi team!

At Agent Control team we received a report about the Fleet link that the `newrelic-cli` process outputs on installation was broken ([ref](https://newrelic.slack.com/archives/C084EDJFAF8/p1742857120953389)). Looking into it, just seems that when regardless of the environment where the installation takes place we always return the `US` URL.

I have tried to fix this by unifying how the Fleet link is constructed with the other link generation procedures (logs, entities, etc) but I am finding 2 issues:

- Some of the CI is not triggered due to me being external to the team and not having access to secrets.
- When trying to test this locally by building the `newrelic-cli` and running the installation command directly as instructed by the guided install process (and substituting the CLI binary with my locally built one of course) I get these errors about creating short URLs, but I'm not really sure if are related or not:
```console
  Installing New Relic
DEBUG Agent Control process not found.
DEBUG Preparing bundle
DEBUG Status of core skip: false
DEBUG Skipping core bundle
DEBUG Agent Control process not found.
DEBUG Preparing bundle
DEBUG bundling additional bundle
DEBUG recipes in list 2
DEBUG recipe event
DEBUG performing request                            method=POST url="https://staging-api.newrelic.com/graphql"
DEBUG recipe event
DEBUG performing request                            method=POST url="https://staging-api.newrelic.com/graphql"
DEBUG Additional Targeted bundle recipes:{ADDITIONALTARGETED []}
DEBUG completed
DEBUG final installation statuses updated
DEBUG HTTPClient: error performing request
DEBUG error creating short URL
DEBUG HTTPClient: error performing request
DEBUG error creating short URL
  --------------------
  Installation Summary

  ⊘  logs-integration-agent-control  (unsupported)
  ⊘  agent-control  (unsupported)

  Installation incomplete. Follow the instructions at the URL below to complete the installation process.

  ⮕  https://staging-one.newrelic.com/launcher/nr1-core.explorer?platform[filters]=&platform[accountId]=12549194&cards[0]=eyJuZXJkbGV0SWQiOiJucjEtaW5zdGFsbC1uZXdyZWxpYy5pbnN0YWxsYXRpb24tcGxhbiIsInJlZmVycmVyIjoibmV3cmVsaWMtY2xpIiwiaW5zdGFsbElkcyI6WyIwNzI2OTEzMS1kOWRiLTRjZjUtOTk3YS1mYzgxNWI1YWJlNmMiXX0=
```

Could you please help me get this right? Thanks a lot!