### PR TITLE
fix(agent-control): Agent control short url fix

### DIFF
--- a/internal/install/execution/link_generator.go
+++ b/internal/install/execution/link_generator.go
@@ -4,5 +4,6 @@ type LinkGenerator interface {
 	GenerateExplorerLink(status InstallStatus) string
 	GenerateEntityLink(entityGUID string) string
 	GenerateLoggingLink(entityGUID string) string
+	GenerateFleetLink(entityGUID string) string
 	GenerateRedirectURL(status InstallStatus) string
 }

--- a/internal/install/execution/mock_link_generator.go
+++ b/internal/install/execution/mock_link_generator.go
@@ -6,9 +6,11 @@ type MockPlatformLinkGenerator struct {
 	GenerateExplorerLinkCallCount int
 	GenerateEntityLinkCallCount   int
 	GenerateLoggingLinkCallCount  int
+	GenerateFleetLinkCallCount    int
 	GenerateExplorerLinkVal       string
 	GenerateEntityLinkVal         string
 	GenerateLoggingLinkVal        string
+	GenerateFleetLinkVal          string
 }
 
 func NewMockPlatformLinkGenerator() *MockPlatformLinkGenerator {
@@ -28,6 +30,11 @@ func (g *MockPlatformLinkGenerator) GenerateEntityLink(entityGUID string) string
 func (g *MockPlatformLinkGenerator) GenerateLoggingLink(entityGUID string) string {
 	g.GenerateLoggingLinkCallCount++
 	return g.GenerateLoggingLinkVal
+}
+
+func (g *MockPlatformLinkGenerator) GenerateFleetLink(entityGUID string) string {
+	g.GenerateFleetLinkCallCount++
+	return g.GenerateFleetLinkVal
 }
 
 func (g *MockPlatformLinkGenerator) GenerateRedirectURL(status InstallStatus) string {

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -47,6 +47,10 @@ func (g *PlatformLinkGenerator) GenerateLoggingLink(entityGUID string) string {
 	return g.generateLoggingLink(entityGUID)
 }
 
+func (g *PlatformLinkGenerator) GenerateFleetLink(entityGUID string) string {
+	return g.generateFleetLink(entityGUID)
+}
+
 // GenerateRedirectURL creates a URL for the user to navigate to after running
 // through an installation. The URL is displayed in the CLI out as well and is
 // also provided in the nerdstorage document. This provides the user two options
@@ -158,6 +162,19 @@ func (g *PlatformLinkGenerator) generateLoggingLauncherParams(entityGUID string)
 	}
 
 	return string(stringifiedParam)
+}
+
+func (g *PlatformLinkGenerator) generateFleetLink(_ string) string {
+	longURL := fmt.Sprintf("https://%s/fleet)",
+		nrPlatformHostname(),
+	)
+
+	shortURL, err := g.generateShortNewRelicURL(longURL)
+	if err != nil {
+		return longURL
+	}
+
+	return shortURL
 }
 
 // The shortenURL function utilizes a New Relic service to convert

--- a/internal/install/execution/terminal_reporter.go
+++ b/internal/install/execution/terminal_reporter.go
@@ -3,7 +3,6 @@ package execution
 import (
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"strings"
 
@@ -148,21 +147,22 @@ func (r TerminalStatusReporter) UpdateRequired(status *InstallStatus) error {
 }
 
 func (r TerminalStatusReporter) printFleetLink(status *InstallStatus) {
+	linkToFleet := ""
+	fleetMsg := "View your fleet at the link below:\n"
 	statuses := r.getRecipesStatusesForInstallationSummary(status)
 
 	for _, s := range statuses {
 		isAgentControlRecipe := s.Name == types.AgentControlRecipeName || s.Name == types.LoggingAgentControlRecipeName
 
 		if s.Status == RecipeStatusTypes.INSTALLED && isAgentControlRecipe {
-			linkToFleetRaw := "https://one.newrelic.com/nr1-core?filters=(domain = 'NR1' AND type = 'FLEET')"
-
-			linkToFleet := url.PathEscape(linkToFleetRaw)
-
-			fmt.Println()
-			fmt.Println("View you fleet at the link below")
-			fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
-
+			linkToFleet = status.PlatformLinkGenerator.GenerateFleetLink(status.HostEntityGUID())
 		}
+	}
+
+	if linkToFleet != "" {
+		fmt.Println("")
+		fmt.Printf("\n  %s", fleetMsg)
+		fmt.Printf("  %s  %s", color.GreenString(ux.IconArrowRight), linkToFleet)
 	}
 }
 


### PR DESCRIPTION
At Agent Control team we received a report about the Fleet link that the newrelic-cli process outputs on installation was broken ([ref](https://newrelic.slack.com/archives/C084EDJFAF8/p1742857120953389)). Looking into it, just seems that when regardless of the environment where the installation takes place we always return the US URL.

This PR fix this by unifying how the Fleet link is constructed

refernce:
[slack](https://newrelic.slack.com/archives/C01PTDC51K2/p1742980341026859) 🧵

Test:
![image](https://github.com/user-attachments/assets/d9b55b08-9a33-48de-9c4d-1274156515f2)
