### PR TITLE
fix(script): Fixed error with Infra Guided Install on windows hosts

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -24,10 +24,10 @@ try {
 }
 
 try {
-  function Find-UninstallGuids {
+function Find-UninstallGuids {
     param (
-      [Parameter(Mandatory)]
-      [string]$Match
+        [Parameter(Mandatory)]
+        [string]$Match
     )
 
     $baseKeys = Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall `
@@ -37,25 +37,25 @@ try {
     | % { $_.Name.TrimStart("HKEY_LOCAL_MACHINE\") }
 
     $allKeys = $baseKeys + $wowKeys
-	
+
     $uninstallIds = New-Object System.Collections.ArrayList
     foreach ($key in $allKeys) {
-      $escapedKey = $key -replace '\[', '`[' -replace '\]', '`]'
-      $keyData = Get-Item -Path "HKLM:\$escapedKey"
-      $name = $keyData.GetValue("DisplayName")
-      if ($name -and $name -match $Match) {
-        $keyId = Split-Path $key -Leaf
-        $uninstallIds.Add($keyId) | Out-Null
-      }
+        $keyData = Get-Item -LiteralPath "HKLM:\$key" -ErrorAction SilentlyContinue
+        if ($keyData) {
+            $name = $keyData.GetValue("DisplayName")
+            if ($name -and $name -match $Match) {
+                $keyId = Split-Path $key -Leaf
+                $uninstallIds.Add($keyId) | Out-Null
+            }
+        }
     }
 
     if ($uninstallIds.Count -eq 0) {
-      return @()
+        return @()
     }
 
     return $uninstallIds
-  }
-
+}
   $uninstallIds = Find-UninstallGuids -Match "New Relic CLI"
 
   foreach ($uninstallId in $uninstallIds) {


### PR DESCRIPTION
Issue mentioned in the [Jira Ticket](https://new-relic.atlassian.net/browse/NR-400198)

**Resolution done:-**

I updated the script code that removes the old logic that manually escaped square brackets ([, ]) in registry keys using -replace. This was unnecessary because PowerShell's -LiteralPath parameter can handle special characters in paths without requiring manual escaping. The old logic was error-prone and introduced parsing issues, such as "Missing type name after '['." By replacing it with -LiteralPath, the updated code simplifies the implementation, avoids these errors, and ensures compatibility with registry keys containing special characters. This change improves both the reliability and maintainability of the function.

I tested my changes after creating few test registery keys with the square brackets.

![image](https://github.com/user-attachments/assets/cf57993b-7f50-4f2b-868b-5ff8564ad62c)
