### PR TITLE
fix(build): adds updated GPG Key ID

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -57,7 +57,10 @@ signs:
     args:
       [
         "-u",
-        "92ADA76A30A3F1FD",
+        # GPG Key ID Updated on 29 April 2025 - Expires 27 April 2027
+        "4F9A9B5B96EC30B9",
+        # When the Key ID here is updated, it has to be paired with an update
+        # to the PGP_PRIVATE_KEY attribute consumed by GitHub Workflows
         "--output",
         "${signature}",
         "--detach-sign",


### PR DESCRIPTION
The GPG Key currently in use by the New Relic CLI expired on 27 April 2025; hence, a replacement of the key is needed.
For the replacement to be done, the ID of the GPG Key created has to be added to the GoReleaser config (as added by this PR) - following the merge of this PR, the `PGP_PRIVATE_KEY` attribute in the secrets of this repository shall be updated with the newly generated PGP Private Key. With both of these steps done, our releases should be back working again.