### PR TITLE
fix(otel): remove dangling references to otel recipe

### DIFF
--- a/internal/install/recipe_installer_test.go
+++ b/internal/install/recipe_installer_test.go
@@ -210,37 +210,6 @@ func TestInstallGuidedShouldNotSkipCoreInstall(t *testing.T) {
 	assert.Equal(t, 1, statusReporter.ReportInstalled[r2.Recipe.Name], "Recipe2 Installed")
 }
 
-func TestInstallGuidedShouldSkipOTEL(t *testing.T) {
-	r := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name(types.InfraAgentRecipeName).Build(),
-		Status: execution.RecipeStatusTypes.AVAILABLE,
-	}
-	r2 := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name("OTEL").WithDiscoveryMode([]types.OpenInstallationDiscoveryMode{
-			types.OpenInstallationDiscoveryModeTypes.TARGETED,
-		}).Build(),
-		Status: execution.RecipeStatusTypes.NULL,
-	}
-	statusReporter := execution.NewMockStatusReporter()
-	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).WithRecipeDetectionResult(r2).WithStatusReporter(statusReporter).Build()
-	recipeInstall.AssumeYes = true
-
-	err := recipeInstall.Install()
-
-	assert.NoError(t, err)
-	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
-	assert.Equal(t, 1, statusReporter.RecipeAvailableCallCount, "Available Count")
-	assert.Equal(t, 1, statusReporter.RecipeInstallingCallCount, "Installing Count")
-	assert.Equal(t, 0, statusReporter.RecipeFailedCallCount, "Failed Count")
-	assert.Equal(t, 0, statusReporter.RecipeUnsupportedCallCount, "Unsupported Count")
-	assert.Equal(t, 1, statusReporter.RecipeInstalledCallCount, "InstalledCount")
-	assert.Equal(t, 0, statusReporter.RecipeRecommendedCallCount, "Recommendation Count")
-	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")
-	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
-	assert.Equal(t, 1, statusReporter.ReportInstalled[r.Recipe.Name], "Infra Installed")
-	assert.Equal(t, 0, statusReporter.ReportInstalled[r2.Recipe.Name], "OTEL Installed")
-}
-
 func TestInstallGuidedShouldSkipSuper(t *testing.T) {
 	r := &recipes.RecipeDetectionResult{
 		Recipe: recipes.NewRecipeBuilder().Name(types.InfraAgentRecipeName).Build(),
@@ -331,30 +300,6 @@ func TestInstallTargetedInstallShouldInstallWithRecomendataion(t *testing.T) {
 	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
 	assert.Equal(t, 1, statusReporter.ReportInstalled[r.Recipe.Name], "Recipe1 Installed")
 	assert.Equal(t, 1, statusReporter.ReportRecommended[r2.Recipe.Name], "Recipe2 Recommended")
-}
-
-func TestInstallTargetedShouldNotSkipOTEL(t *testing.T) {
-	r := &recipes.RecipeDetectionResult{
-		Recipe: recipes.NewRecipeBuilder().Name("OTEL").Build(),
-		Status: execution.RecipeStatusTypes.AVAILABLE,
-	}
-	statusReporter := execution.NewMockStatusReporter()
-	recipeInstall := NewRecipeInstallBuilder().WithRecipeDetectionResult(r).WithTargetRecipeName("OTEL").WithStatusReporter(statusReporter).Build()
-	recipeInstall.AssumeYes = true
-
-	err := recipeInstall.Install()
-
-	assert.NoError(t, err)
-	assert.Equal(t, 1, statusReporter.RecipeDetectedCallCount, "Detection Count")
-	assert.Equal(t, 1, statusReporter.RecipeAvailableCallCount, "Available Count")
-	assert.Equal(t, 1, statusReporter.RecipeInstallingCallCount, "Installing Count")
-	assert.Equal(t, 0, statusReporter.RecipeFailedCallCount, "Failed Count")
-	assert.Equal(t, 0, statusReporter.RecipeUnsupportedCallCount, "Unsupported Count")
-	assert.Equal(t, 1, statusReporter.RecipeInstalledCallCount, "InstalledCount")
-	assert.Equal(t, 0, statusReporter.RecipeRecommendedCallCount, "Recommendation Count")
-	assert.Equal(t, 0, statusReporter.RecipeSkippedCallCount, "Skipped Count")
-	assert.Equal(t, 0, statusReporter.RecipeCanceledCallCount, "Cancelled Count")
-	assert.Equal(t, 1, statusReporter.ReportInstalled[r.Recipe.Name], "OTEL Installed")
 }
 
 func TestInstallTargetedShouldNotSkipSuper(t *testing.T) {


### PR DESCRIPTION
In response to a recent request from the new team (`OTEL`/`OTELCOMM`) maintaining OpenTelemetry products at New Relic (who are now, the new owners of the OpenTelemetry recipe in the Open Install Library too), a request has been received to retire the Open Telemetry recipe since this is currently not in integrated use with installs, neither is this recipe being displayed anywhere in data sources in the Integrations & Agents page; which makes it safe for us to retire this recipe.

While all references to the recipe are supposed to exist in the Open Install Library, they have all been reverted via https://github.com/newrelic/open-install-library/pull/1208 (changes previously added via https://github.com/newrelic/open-install-library/pull/921) - dangling references left in the New Relic CLI (anything added in the past via #1469, #1474) are being removed via this PR. 

**Please merge and release this PR only after the corresponding changes, https://github.com/newrelic/open-install-library/pull/1208 in the Open Install Library are merged and released.**