### PR TITLE
fix: Add InstallEventsReporter only if API key is set

### DIFF
--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -73,10 +73,18 @@ func NewRecipeInstaller(ic types.InstallerContext) *RecipeInstall {
 	mv := discovery.NewManifestValidator()
 	ff := recipes.NewRecipeFileFetcher([]string{})
 	lf := execution.NewRecipeLogForwarder()
+
+	// Initialize status subscribers
 	ers := []execution.StatusSubscriber{
 		execution.NewTerminalStatusReporter(),
-		execution.NewInstallEventsReporter(&nrClient.InstallEvents),
 	}
+
+	// Only add InstallEventsReporter if an API key is available
+	apiKey := configAPI.GetActiveProfileString(config.APIKey)
+	if apiKey != "" {
+		ers = append(ers, execution.NewInstallEventsReporter(&nrClient.InstallEvents))
+	}
+
 	slg := execution.NewPlatformLinkGenerator()
 	statusRollup := execution.NewInstallStatus(ic, ers, slg)
 
@@ -193,7 +201,7 @@ func (i *RecipeInstall) Install() error {
 
 Welcome to New Relic. Let's set up full stack observability for your environment.
 Our Data Privacy Notice: https://newrelic.com/termsandconditions/services-notices
-	`)
+    `)
 	fmt.Println()
 
 	log.Tracef("InstallerContext: %+v", i.InstallerContext)


### PR DESCRIPTION
[Jira Ticket](https://new-relic.atlassian.net/browse/NR-377103)

**Problem:-**

Customers were encountering the following error during execution:

`Debug Error: 401 response returned: Invalid credentials provided. Missing API key or an invalid API key was provided.`

**Cause:-**

The 401 Unauthorized error occurred because the recipe attempted to authenticate with New Relic's API using a License Key, which is not valid for API authentication. API operations require a valid API Key (User API Key or Personal API Key).

**Solution:-**

This fix updates the code to only add the **InstallEventsReporter status subscriber** if a valid API Key is present in the active profile. This prevents attempts to authenticate with invalid credentials and avoids unnecessary 401 errors.

**Testing Results:-** No  401 Unauthorized error after the fix.

![image](https://github.com/user-attachments/assets/dc6a636c-8c20-43c0-98fa-14d2ada42a7e)

![image](https://github.com/user-attachments/assets/6f587ddf-dcbd-43fb-ba00-9864ac5b8065)

