### PR TITLE
fix: Add CLI docs support for specific infra agent CLI installs

### DIFF
--- a/docs/cli/newrelic_install.md
+++ b/docs/cli/newrelic_install.md
@@ -29,6 +29,18 @@ newrelic install [flags]
       --trace            trace level logging
 ```
 
+### Installing Specific Agent Versions
+
+Install a specific version of the infrastructure agent by appending the version number to the recipe name with `@`. Currently, specific version installation is supported by the infrastructure agent only.
+
+```
+newrelic install -n infrastructure-agent-installer@1.65.0
+```
+
+Without a specified version, the command installs the latest available version. Supported on Linux and Windows hosts only; not available on macOS.
+
+For a list of available versions, see the [Infrastructure agent release notes](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/).
+
 ### SEE ALSO
 
 - [newrelic](newrelic.md) - The New Relic CLI

--- a/docs/cli/newrelic_install.md
+++ b/docs/cli/newrelic_install.md
@@ -29,17 +29,16 @@ newrelic install [flags]
       --trace            trace level logging
 ```
 
-### Installing Specific Agent Versions
+### Installing Specific Versions of the Infrastructure Agent
 
-Install a specific version of the infrastructure agent by appending the version number to the recipe name with `@`. Currently, specific version installation is supported by the infrastructure agent only.
-
+To install a specific version of the infrastructure agent, append the version number to the recipe name using `@`. This functionality is currently supported only for the infrastructure agent.
 ```
 newrelic install -n infrastructure-agent-installer@1.65.0
 ```
 
-Without a specified version, the command installs the latest available version. Supported on Linux and Windows hosts only; not available on macOS.
+If no version is specified, the latest available version will be installed. This feature is supported on Linux and Windows hosts but is not available on macOS.
 
-For a list of available versions, see the [Infrastructure agent release notes](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/).
+For a list of available versions, please refer to the [Infrastructure Agent Release Notes](https://docs.newrelic.com/docs/release-notes/infrastructure-release-notes/infrastructure-agent-release-notes/).
 
 ### SEE ALSO
 


### PR DESCRIPTION
### Changes:
- Added docs support for specific infra agent CLI installs.

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/2d6a60c0-d22e-4b26-897d-a4a2c406ab0c" />
