### PR TITLE
fix(checksum): Remove the Manuel install.ps1 upload

### DIFF
--- a/.github/workflows/release-windows-installer.yml
+++ b/.github/workflows/release-windows-installer.yml
@@ -98,14 +98,3 @@ jobs:
           asset_path: .\build\package\msi\NewRelicCLIInstaller\bin\x64\Release\NewRelicCLIInstaller.msi
           asset_name: NewRelicCLIInstaller.msi
           asset_content_type: application/octet-stream
-
-      - name: Upload windows install script
-        id: upload-windows-install-script
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-        with:
-          upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
-          asset_path: .\scripts\install.ps1
-          asset_name: install.ps1
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
This is the final PR  that include changes to upload the install.sh and install.ps1 files to the GITHUB assets directory and also generating and adding the checksum to the checksum file for validating the install.sh file at customer end, As part of this [WR](https://new-relic.atlassian.net/browse/NR-307933)

To fulfil the requirement below PR include the consecutive changes
[1731](https://github.com/newrelic/newrelic-cli/pull/1731):   Include changes to upload install.sh and install.ps1 to GIt assets using goreleaser config
[1734](https://github.com/newrelic/newrelic-cli/pull/1734): include changes to add the checksum for the install.sh and install.ps1 in the checksum file

This PR include removal of redundant/Manuel step of uploading the install.ps1 to git assets  as this is now covered as part of the above PR changes.



Test:

<img width="1510" height="546" alt="image" src="https://github.com/user-attachments/assets/7975c1e3-10c6-445f-a705-54aa117653c4" />


<img width="383" height="105" alt="image" src="https://github.com/user-attachments/assets/c7a5be89-0ef8-40c7-b4ee-a08cf4c23fab" />


