### PR TITLE
fix: Skip lsass.exe process from being processed

### DIFF
--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -60,7 +60,6 @@ func GetPsUtilCommandLines(ctx context.Context) []types.GenericProcess {
 			continue
 		}
 		name, _ := psproc.Name()
-		log.Debugf("process name is: %s", name)
 		if name == "lsass.exe" {
 			log.Debugf("skipping sensitive process: %s", name)
 			continue

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -59,7 +59,11 @@ func GetPsUtilCommandLines(ctx context.Context) []types.GenericProcess {
 
 			continue
 		}
-
+		name, _ := psproc.Name()
+		if name == "lsass.exe" {
+			log.Debugf("skipping sensitive process: %s", name)
+			continue
+		}
 		p := NewPSUtilProcess(psproc)
 		processes = append(processes, p)
 	}

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -56,12 +56,10 @@ func GetPsUtilCommandLines(ctx context.Context) []types.GenericProcess {
 			if err != process.ErrorProcessNotRunning {
 				log.Debugf("cannot read pid %d: %s", pid, err)
 			}
-
 			continue
 		}
 		name, _ := psproc.Name()
 		if name == "lsass.exe" {
-			log.Debugf("skipping sensitive process: %s", name)
 			continue
 		}
 		p := NewPSUtilProcess(psproc)

--- a/internal/install/recipes/process_evaluator.go
+++ b/internal/install/recipes/process_evaluator.go
@@ -60,6 +60,7 @@ func GetPsUtilCommandLines(ctx context.Context) []types.GenericProcess {
 			continue
 		}
 		name, _ := psproc.Name()
+		log.Debugf("process name is: %s", name)
 		if name == "lsass.exe" {
 			log.Debugf("skipping sensitive process: %s", name)
 			continue


### PR DESCRIPTION
### Changes:
- Skipped LSASS.exe process to be processed for processMatch.

### Test Results (with debug prints):
<img width="1292" height="490" alt="image" src="https://github.com/user-attachments/assets/0bf64a57-b15a-493c-bec9-80a4ba6a37fe" />

### Before Change:
<img width="2584" height="802" alt="image" src="https://github.com/user-attachments/assets/cad1f35b-c0f0-464e-8274-a62d37d0188b" />

### No LSASS.exe in MDE timeline logs Now:
<img width="1191" height="558" alt="image" src="https://github.com/user-attachments/assets/eb0de69c-2031-476f-892a-9c168e888bab" />

