### PR TITLE
fix(checksum): Update copied checksum file name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,23 +172,23 @@ jobs:
           echo "Found version: $VERSION"
           
           # Copy checksum file and validate
-          cp "$CHECKSUM_FILE" "dist/checksums.txt"
-          if [ ! -f "dist/checksums.txt" ]; then
-            echo "::error::Failed to create checksums.txt"
+          cp "$CHECKSUM_FILE" "dist/checksums_sha256.txt"
+          if [ ! -f "dist/checksums_sha256.txt" ]; then
+            echo "::error::Failed to create checksums_sha256.txt"
             exit 1
           fi
-          echo "Created checksums.txt successfully"
-          
+          echo "Created checksums_sha256.txt successfully"
+
           # Create signature and validate
           gpg --batch --yes -u "4F9A9B5B96EC30B9" \
-              --output "dist/checksums.txt.sig" \
+              --output "dist/checksums_sha256.txt.sig" \
               --detach-sign \
-              "dist/checksums.txt"
-          if [ ! -f "dist/checksums.txt.sig" ]; then
+              "dist/checksums_sha256.txt"
+          if [ ! -f "dist/checksums_sha256.txt.sig" ]; then
             echo "::error::Failed to create signature file"
             exit 1
           fi
-          echo "Created checksums.txt.sig successfully"
+          echo "Created checksums_sha256.txt.sig successfully"
 
       - name: Upload checksums file
         uses: actions/upload-release-asset@v1
@@ -196,8 +196,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
           upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
-          asset_path: ./dist/checksums.txt
-          asset_name: checksums.txt
+          asset_path: ./dist/checksums_sha256.txt
+          asset_name: checksums_sha256.txt
           asset_content_type: text/plain
 
       - name: Upload checksums signature
@@ -206,8 +206,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         with:
           upload_url: ${{ steps.get-latest-release-upload-url.outputs.upload_url }}
-          asset_path: ./dist/checksums.txt.sig
-          asset_name: checksums.txt.sig
+          asset_path: ./dist/checksums_sha256.txt.sig
+          asset_name: checksums_sha256.txt.sig
           asset_content_type: text/plain
 
       - name: Create currentVersion.txt


### PR DESCRIPTION
This is a PR that include minor update where we are changing the file name of the copied checksum file to checksums_sha256.txt to add checksum type context in the name of the file.
This changes are done for the minor request that was asked by the customer(E.ON) in this [WR](https://new-relic.atlassian.net/browse/NR-307933).

Changes for the checksum generation and adding the install scripts to the GIT release assets was done as part of https://github.com/newrelic/newrelic-cli/pull/1736 PR.
Subsequent changes are present in [this](https://github.com/newrelic/newrelic-cli/pull/1743) PR

No Test validation SS is available as there is no way to test the changes in local, a realtime release is required to test the changes..

Any further changes on this will be part of other PR and this PR will be attached in the new one to keep a track of the PR's that include all relevant changes to cater this WR.