### PR TITLE
feat(dashboard): add billboard settings support to JSON to HCL converter

### DIFF
--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -52,9 +52,9 @@ type DashboardBillboardVisual struct {
 }
 
 type DashboardBillboardGridOptions struct {
-	Value   int `json:"value,omitempty"`
-	Label   int `json:"label,omitempty"`
-	Columns int `json:"columns,omitempty"`
+	Value   float64 `json:"value,omitempty"`
+	Label   float64 `json:"label,omitempty"`
+	Columns float64 `json:"columns,omitempty"`
 }
 
 type DashboardWidgetRawConfiguration struct {
@@ -407,9 +407,9 @@ func writeBillboardWidgetAttributes(h *HCLGen, config *DashboardWidgetRawConfigu
 
 			if config.BillboardSettings.GridOptions != (DashboardBillboardGridOptions{}) {
 				h.WriteBlock("grid_options", []string{}, func() {
-					h.WriteIntAttributeIfNotZero("columns", config.BillboardSettings.GridOptions.Columns)
-					h.WriteIntAttributeIfNotZero("label", config.BillboardSettings.GridOptions.Label)
-					h.WriteIntAttributeIfNotZero("value", config.BillboardSettings.GridOptions.Value)
+					h.WriteFloatAttribute("columns", config.BillboardSettings.GridOptions.Columns)
+					h.WriteFloatAttribute("label", config.BillboardSettings.GridOptions.Label)
+					h.WriteFloatAttribute("value", config.BillboardSettings.GridOptions.Value)
 				})
 			}
 		})


### PR DESCRIPTION
### Description

Adds support for billboard settings in the dashboard JSON to HCL converter utility, enabling conversion of billboard widget configurations including link, visual, and grid options.

### Features Added

1. **Link Settings**: Converts billboard link configuration (URL, title, new tab behavior)
2. **Visual Settings**: Handles alignment and display options for billboard widgets
3. **Grid Options**: Supports columns, label, and value grid configuration

### Changes

- Added `DashboardBillboardSettings`, `DashboardBillboardLink`, `DashboardBillboardVisual`, and `DashboardBillboardGridOptions` types
- Extended `DashboardWidgetRawConfiguration` with `BillboardSettings` field
- Implemented billboard settings conversion in `writeBillboardWidgetAttributes` function

Enables complete billboard widget configuration conversion from dashboard JSON exports.