### PR TITLE
fix(agent-control): use proper fleet link

### DIFF
--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -165,7 +165,7 @@ func (g *PlatformLinkGenerator) generateLoggingLauncherParams(entityGUID string)
 }
 
 func (g *PlatformLinkGenerator) generateFleetLink(_ string) string {
-	longURL := fmt.Sprintf("https://%s/fleet)",
+	longURL := fmt.Sprintf("https://%s/fleet",
 		nrPlatformHostname(),
 	)
 


### PR DESCRIPTION
This PR fixes the link shown when the Agent Control is successfully installed in a host. The link was resolving to `<domain>/fleet)` which was redirecting to the `nr1-core` main page. The fixed link will point to the list of Fleets.