### PR TITLE
fix(terraform): handle missing thresholds in line widget conversion

### DIFF
--- a/internal/utils/terraform/dashboard.go
+++ b/internal/utils/terraform/dashboard.go
@@ -289,20 +289,24 @@ func requireValidVisualizationID(id string) {
 
 func writeLineWidgetAttributes(h *HCLGen, config *DashboardWidgetRawConfiguration) {
 	h.WriteBooleanAttribute("y_axis_left_zero", config.YAxisLeft.Zero)
-	var widgetLineThreshold DashboardWidgetLineThreshold
-	if err := json.Unmarshal(config.Threshold, &widgetLineThreshold); err != nil {
-		log.Fatal("Error unmarshalling widgetLineThreshold:", err)
-	}
 
-	h.WriteBooleanAttribute("is_label_visible", widgetLineThreshold.IsLabelVisible)
+	// Only process thresholds if they exist
+	if len(config.Threshold) > 0 && string(config.Threshold) != "null" {
+		var widgetLineThreshold DashboardWidgetLineThreshold
+		if err := json.Unmarshal(config.Threshold, &widgetLineThreshold); err != nil {
+			log.Fatal("Error unmarshalling widgetLineThreshold:", err)
+		}
 
-	for _, q := range widgetLineThreshold.Threshold {
-		h.WriteBlock("threshold", []string{}, func() {
-			h.WriteStringAttribute("name", q.Name)
-			h.WriteStringAttribute("severity", q.Severity)
-			h.WriteFloatAttribute("from", q.From)
-			h.WriteFloatAttribute("to", q.To)
-		})
+		h.WriteBooleanAttribute("is_label_visible", widgetLineThreshold.IsLabelVisible)
+
+		for _, q := range widgetLineThreshold.Threshold {
+			h.WriteBlock("threshold", []string{}, func() {
+				h.WriteStringAttribute("name", q.Name)
+				h.WriteStringAttribute("severity", q.Severity)
+				h.WriteFloatAttribute("from", q.From)
+				h.WriteFloatAttribute("to", q.To)
+			})
+		}
 	}
 }
 


### PR DESCRIPTION
### Description
The `newrelic utils terraform dashboard` command fails with a fatal error when processing dashboards that contain line widgets (`viz.line`) without threshold configuration. This prevents legitimate dashboard JSON exports from New Relic from being converted to Terraform HCL format.

### Go Version
```
go version go1.25.1 darwin/arm64
```

### Current behavior
When attempting to convert a New Relic dashboard JSON to Terraform HCL format, the CLI immediately crashes with a fatal error if any line widget in the dashboard doesn't have thresholds configured:

```bash
cat example_mvp.json | newrelic utils terraform dashboard --label test
FATAL Error unmarshalling widgetLineThreshold:unexpected end of JSON input
```

The command terminates without producing any output.

### Expected behavior
The command should successfully convert the dashboard JSON to Terraform HCL format. Line widgets without thresholds are valid in New Relic dashboards (thresholds are optional), so the conversion should handle their absence gracefully and generate valid Terraform configuration.

### Steps To Reproduce
1. Create a JSON file named `example_mvp.json` with the following content:
```json
{
  "name": "MVP Dashboard",
  "description": "Minimal dashboard to reproduce line widget threshold issue",
  "permissions": "PUBLIC_READ_ONLY",
  "pages": [
    {
      "name": "Test Page",
      "description": "Page with line widget without thresholds",
      "widgets": [
        {
          "id": "1",
          "title": "Line Widget Without Thresholds",
          "layout": {
            "column": 1,
            "row": 1,
            "width": 4,
            "height": 3
          },
          "linkedEntityGuids": null,
          "visualization": {
            "id": "viz.line"
          },
          "rawConfiguration": {
            "facet": {},
            "legend": {
              "enabled": true
            },
            "nrqlQueries": [
              {
                "accountId": 12345,
                "query": "SELECT count(*) FROM Transaction TIMESERIES"
              }
            ],
            "platformOptions": {},
            "yAxisLeft": {
              "zero": false
            }
          }
        }
      ]
    }
  ]
}
```

2. Run the command:
```bash
cat example_mvp.json | newrelic utils terraform dashboard --label test
```

3. See error:
```
FATAL Error unmarshalling widgetLineThreshold:unexpected end of JSON input
```

### Debug Output (if applicable)
```
FATAL Error unmarshalling widgetLineThreshold:unexpected end of JSON input
```

The error originates from `internal/utils/terraform/dashboard.go:293` in the `writeLineWidgetAttributes()` function, which unconditionally attempts to unmarshal the `config.Threshold` field even when it's empty or null.

### Additional Context
- This issue affects any dashboard exported from New Relic containing line widgets without threshold configuration
- Line widgets are one of the most common widget types in New Relic dashboards
- The `thresholds` field is optional in New Relic's dashboard API specification
- The `example_mvp.json` file triggers this issue as it contains multiple line widgets without thresholds
- The root cause is in the `writeLineWidgetAttributes()` function which doesn't validate that threshold data exists before attempting to unmarshal it

### References or Related Issues
- Affected file: `internal/utils/terraform/dashboard.go`
- Affected function: `writeLineWidgetAttributes()`
- Affected command: `newrelic utils terraform dashboard`
