### PR TITLE
fix(newrelic-entity): fix timestamp issue in entity deployment marker

### DIFF
--- a/internal/entities/command_deployment.go
+++ b/internal/entities/command_deployment.go
@@ -57,7 +57,7 @@ The deployment command marks a change for a New Relic entity
 		if timestamp == 0 {
 			params.Timestamp = nrtime.EpochMilliseconds(time.Now())
 		} else {
-			params.Timestamp = nrtime.EpochMilliseconds(time.UnixMilli(timestamp))
+			params.Timestamp = nrtime.EpochMilliseconds(time.Unix(timestamp, 0))
 		}
 
 		if version == "" {


### PR DESCRIPTION
### Description

As reported in github issue #1759 and #1722, Users were getting `FATAL timestamp can not be more than 24 hours in the past or future. Make sure to use epoch milliseconds for timestamp.` error while running`newrelic entity deployment create` command in newrelic-cli. Upon investigation, the root cause was identified in the timestamp serialization logic of the `nrtime.EpochMilliseconds` type, due to which if the time is on an exact second boundary (e.g., ...000ms), it trims out the trailing zeros. Since the API strictly expects timestamp in milliseconds, sending a 10-digit second timestamp caused errors.

This PR aims to fix this issue by preventing the truncation of trailing zeros and by ensuring that timestamps are serialized as milliseconds.


