### PR TITLE
fix(fleetcontrol): improve error messages and ensure case-insensitive agent types

### DIFF
--- a/internal/fleetcontrol/fleet_configuration_create.go
+++ b/internal/fleetcontrol/fleet_configuration_create.go
@@ -62,7 +62,18 @@ func handleFleetCreateConfiguration(cmd *cobra.Command, args []string, flags *Fl
 	configBodyBytes := []byte(configBody)
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
+
+	// Normalize agent type to ensure correct casing for the API
+	// The API expects specific casing (e.g., "NRInfra" not "nrinfra")
+	// YAML validation allows case-insensitive input for user convenience
+	normalizedAgentType, err := NormalizeAgentType(f.AgentType)
+	if err != nil {
+		return PrintError(fmt.Errorf("invalid agent type: %w", err))
+	}
 
 	// Build custom headers required by the API
 	// These headers specify the entity name, agent type, and managed entity type
@@ -71,7 +82,7 @@ func handleFleetCreateConfiguration(cmd *cobra.Command, args []string, flags *Fl
 			"Newrelic-Entity": fmt.Sprintf(
 				`{"name": "%s", "agentType": "%s", "managedEntityType": "%s"}`,
 				f.Name,
-				f.AgentType,
+				normalizedAgentType,
 				f.ManagedEntityType,
 			),
 		},

--- a/internal/fleetcontrol/fleet_configuration_delete.go
+++ b/internal/fleetcontrol/fleet_configuration_delete.go
@@ -30,10 +30,13 @@ func handleFleetDeleteConfiguration(cmd *cobra.Command, args []string, flags *Fl
 	f := flags.DeleteConfiguration()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to delete the configuration
-	_, err := client.NRClient.FleetControl.FleetControlDeleteConfiguration(
+	_, err = client.NRClient.FleetControl.FleetControlDeleteConfiguration(
 		f.ConfigurationID,
 		orgID,
 	)

--- a/internal/fleetcontrol/fleet_configuration_get.go
+++ b/internal/fleetcontrol/fleet_configuration_get.go
@@ -34,7 +34,10 @@ func handleFleetGetConfiguration(cmd *cobra.Command, args []string, flags *FlagV
 	f := flags.GetConfiguration()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Map validated mode to client library type
 	// YAML validation has already confirmed this value is in allowed_values

--- a/internal/fleetcontrol/fleet_configuration_version_add.go
+++ b/internal/fleetcontrol/fleet_configuration_version_add.go
@@ -62,7 +62,10 @@ func handleFleetAddVersion(cmd *cobra.Command, args []string, flags *FlagValues)
 	configBodyBytes := []byte(configBody)
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Build custom headers with the configuration GUID
 	// This tells the API to add a version to the existing configuration

--- a/internal/fleetcontrol/fleet_configuration_version_delete.go
+++ b/internal/fleetcontrol/fleet_configuration_version_delete.go
@@ -30,10 +30,13 @@ func handleFleetDeleteVersion(cmd *cobra.Command, args []string, flags *FlagValu
 	f := flags.DeleteVersion()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to delete the version
-	err := client.NRClient.FleetControl.FleetControlDeleteConfigurationVersion(
+	err = client.NRClient.FleetControl.FleetControlDeleteConfigurationVersion(
 		f.VersionID,
 		orgID,
 	)

--- a/internal/fleetcontrol/fleet_configuration_version_list.go
+++ b/internal/fleetcontrol/fleet_configuration_version_list.go
@@ -36,7 +36,10 @@ func handleFleetGetConfigurationVersions(cmd *cobra.Command, args []string, flag
 	f := flags.GetVersions()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to get all configuration versions
 	result, err := client.NRClient.FleetControl.FleetControlGetConfigurationVersions(

--- a/internal/fleetcontrol/fleet_deployment_create.go
+++ b/internal/fleetcontrol/fleet_deployment_create.go
@@ -81,10 +81,16 @@ func handleFleetCreateDeployment(cmd *cobra.Command, args []string, flags *FlagV
 			})
 		}
 
+		// Normalize agent type to ensure correct casing for the API
+		normalizedAgentType, err := NormalizeAgentType(f.AgentType)
+		if err != nil {
+			return PrintError(fmt.Errorf("invalid agent type: %w", err))
+		}
+
 		// Build single agent input from legacy flags
 		agents = []fleetcontrol.FleetControlAgentInput{
 			{
-				AgentType:                f.AgentType,
+				AgentType:                normalizedAgentType,
 				ConfigurationVersionList: configVersionList,
 				Version:                  f.AgentVersion,
 			},

--- a/internal/fleetcontrol/fleet_management_create.go
+++ b/internal/fleetcontrol/fleet_management_create.go
@@ -57,9 +57,9 @@ func handleFleetCreate(cmd *cobra.Command, args []string, flags *FlagValues) err
 
 	// Get organization ID (either from flag or fetch from API)
 	// This avoids an unnecessary API call if the user already knows their org ID
-	orgID := GetOrganizationID(f.OrganizationID)
-	if orgID == "" {
-		return PrintError(fmt.Errorf("failed to determine organization ID"))
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
 	}
 
 	// Parse tags from "key:value1,value2" format to API format

--- a/internal/fleetcontrol/helpers.go
+++ b/internal/fleetcontrol/helpers.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/newrelic/newrelic-cli/internal/client"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
 )
@@ -24,17 +22,45 @@ import (
 //
 // Returns:
 //   - The organization ID (either provided or fetched)
-func GetOrganizationID(providedOrgID string) string {
+//   - Error if the API call fails when fetching the organization ID
+func GetOrganizationID(providedOrgID string) (string, error) {
 	if providedOrgID != "" {
-		return providedOrgID
+		return providedOrgID, nil
 	}
 
 	org, err := client.NRClient.Organization.GetOrganization()
 	if err != nil {
-		log.Warnf("Failed to get organization: %v", err)
-		return ""
+		return "", fmt.Errorf("failed to get organization from API: %w", err)
 	}
-	return org.ID
+	return org.ID, nil
+}
+
+// NormalizeAgentType converts a case-insensitive agent type string to the canonical format expected by the API.
+// This allows users to specify agent types in any case while ensuring the API receives the correct format.
+//
+// Parameters:
+//   - typeStr: The agent type string (case-insensitive)
+//
+// Returns:
+//   - The normalized agent type string with correct casing
+//   - Error if the agent type is not recognized (should not happen after YAML validation)
+//
+// Note: YAML validation has already confirmed this value is in allowed_values.
+// This normalization ensures the API receives the correct casing.
+func NormalizeAgentType(typeStr string) (string, error) {
+	switch strings.ToUpper(typeStr) {
+	case "NRINFRA":
+		return "NRInfra", nil
+	case "NRDOT":
+		return "NRDOT", nil
+	case "FLUENTBIT":
+		return "FluentBit", nil
+	case "NRPROMETHEUSAGENT":
+		return "NRPrometheusAgent", nil
+	default:
+		// This should never happen if YAML validation is working correctly
+		return "", fmt.Errorf("unrecognized agent type: %s (expected NRInfra, NRDOT, FluentBit, or NRPrometheusAgent)", typeStr)
+	}
 }
 
 // ParseTags converts tag strings in the format "key:value1,value2" into FleetControlTagInput structs.
@@ -153,8 +179,14 @@ func ParseAgentSpec(agentSpec string) (fleetcontrol.FleetControlAgentInput, erro
 		return fleetcontrol.FleetControlAgentInput{}, fmt.Errorf("at least one configuration version ID is required")
 	}
 
+	// Normalize agent type to ensure correct casing for the API
+	normalizedAgentType, err := NormalizeAgentType(agentType)
+	if err != nil {
+		return fleetcontrol.FleetControlAgentInput{}, fmt.Errorf("invalid agent type '%s': expected NRInfra, NRDOT, FluentBit, or NRPrometheusAgent (case-insensitive)", agentType)
+	}
+
 	return fleetcontrol.FleetControlAgentInput{
-		AgentType:                agentType,
+		AgentType:                normalizedAgentType,
 		Version:                  version,
 		ConfigurationVersionList: configVersionList,
 	}, nil


### PR DESCRIPTION
## Summary
This PR addresses two issues reported by the fleet team:

1. **Misleading error messages**: When organization ID retrieval fails (e.g., due to "Unauthorized IP address"), the CLI showed a generic "failed to determine organization ID" message without revealing the underlying cause.

2. **Agent type case sensitivity**: The documentation and YAML validation indicate that `--agent-type` is case-insensitive, but the API requires specific casing (e.g., "NRInfra" not "nrinfra"). Users providing lowercase values would pass validation but fail at the API level.

## Changes
- Modified `GetOrganizationID()` to return the actual API error, providing users with clear information about what went wrong
- Added `NormalizeAgentType()` function to convert any casing to the API-expected format
- Applied normalization across all agent type inputs (configuration create, deployment create, and agent spec parsing)
- Updated all callers of `GetOrganizationID()` to properly handle the new error return value

## Testing
Verified that:
- Agent type values like "nrinfra", "NRINFRA", and "NRInfra" all work correctly
- Invalid agent types are still properly rejected with helpful error messages
- Organization ID errors now display the underlying API error
- All code compiles successfully