### PR TITLE
fix(fleetcontrol): improve error handling and enforce exact value matching

### DIFF
--- a/internal/fleetcontrol/README.md
+++ b/internal/fleetcontrol/README.md
@@ -158,9 +158,9 @@ Create a fleet to group and manage entities of the same type.
 **Required Flags:**
 - `--name` - Fleet name
 - `--managed-entity-type` - Type of entities this fleet will manage
-  - Allowed values: `HOST`, `KUBERNETESCLUSTER` (case-insensitive)
+  - Allowed values: `HOST`, `KUBERNETESCLUSTER`
 - `--operating-system` - Operating system type (**required for HOST fleets only**)
-  - Allowed values: `LINUX`, `WINDOWS` (case-insensitive)
+  - Allowed values: `LINUX`, `WINDOWS`
   - **Must be specified** when creating `HOST` fleets to ensure proper agent configuration
   - **Must NOT be specified** for `KUBERNETESCLUSTER` fleets (Kubernetes manages its own OS)
 
@@ -520,9 +520,9 @@ Create a versioned configuration for fleet agents.
 **Required Flags:**
 - `--name` - Configuration name
 - `--agent-type` - Type of agent this configuration targets
-  - Allowed values: `NRInfra`, `NRDOT`, `FluentBit`, `NRPrometheusAgent` (case-insensitive)
+  - Allowed values: `NRInfra`, `NRDOT`, `FluentBit`, `NRPrometheusAgent`
 - `--managed-entity-type` - Type of entities this configuration applies to
-  - Allowed values: `HOST`, `KUBERNETESCLUSTER` (case-insensitive)
+  - Allowed values: `HOST`, `KUBERNETESCLUSTER`
 - **Exactly one of:**
   - `--configuration-file-path` - Path to configuration file (JSON/YAML) - **recommended for production**
   - `--configuration-content` - Inline configuration content (JSON/YAML) - **for testing/development only**
@@ -1283,7 +1283,7 @@ newrelic fleetcontrol fleet members add \
 
 ### Agent Types
 
-Used in configuration commands. Values are case-insensitive.
+Used in configuration commands. Values must match exactly.
 
 **Allowed values:**
 - `NRInfra` - New Relic Infrastructure agent
@@ -1293,14 +1293,14 @@ Used in configuration commands. Values are case-insensitive.
 
 **Example:**
 ```bash
---agent-type "nrinfra"  # Case-insensitive, works fine
+--agent-type "NRInfra"  # Must use exact casing
 ```
 
 ---
 
 ### Managed Entity Types
 
-Used in fleet and configuration commands. Values are case-insensitive.
+Used in fleet and configuration commands. Values must match exactly.
 
 **Allowed values:**
 - `HOST` - Physical or virtual hosts
@@ -1308,14 +1308,14 @@ Used in fleet and configuration commands. Values are case-insensitive.
 
 **Example:**
 ```bash
---managed-entity-type "host"  # Case-insensitive, works fine
+--managed-entity-type "HOST"  # Must use exact casing
 ```
 
 ---
 
 ### Configuration Modes
 
-Used in configuration get command. Values are case-insensitive.
+Used in configuration get command. Values must match exactly.
 
 **Allowed values:**
 - `ConfigEntity` (default) - Query by configuration entity ID
@@ -1323,7 +1323,7 @@ Used in configuration get command. Values are case-insensitive.
 
 **Example:**
 ```bash
---mode "configversionentity"  # Case-insensitive, works fine
+--mode "ConfigVersionEntity"  # Must use exact casing
 ```
 
 ---
@@ -1447,7 +1447,7 @@ The syntax using separate flags can be preferred in the case of single-agent dep
 | **"Authentication failed"** | Verify `NEW_RELIC_API_KEY` is set correctly. Ensure it's a User API key, not Browser or License key. |
 | **"Account not found"** | Check `NEW_RELIC_ACCOUNT_ID` is correct. Find it in New Relic UI or URL. |
 | **"required flag not set"** | Ensure flag syntax is correct: `--flag-name value` or `--flag-name=value` (not `flag-name=value`) |
-| **"invalid value for flag"** | Check validation rules above. Values may need to match allowed values (case-insensitive) |
+| **"invalid value for flag"** | Check validation rules above. Values must match allowed values exactly (case-sensitive) |
 | **"mutually exclusive flags"** | Only one of the mutually exclusive flags should be provided (e.g., `--fleet-id` OR `--fleet-ids`, not both). For deployments, use either `--agent` or all three legacy flags, not a mix. |
 | **"agent version '*' not supported for HOST fleets"** | Wildcard version (`"*"`) is only allowed for KUBERNETESCLUSTER fleets. Use an explicit version (e.g., `"1.70.0"`) for HOST fleets. |
 | **"--configuration-version-ids is required"** | When using legacy deployment syntax, you must provide all three flags: `--agent-type`, `--agent-version`, AND `--configuration-version-ids`. |
@@ -1476,7 +1476,7 @@ flag-name=value        # Missing -- prefix
 
 When you see "invalid value for flag", check:
 1. Value is in the allowed values list (see Validation Rules Reference)
-2. Spelling is correct (validation is case-insensitive but value must be in the list)
+2. Spelling and casing are correct (validation is case-sensitive - values must match exactly)
 3. No extra spaces or quotes
 
 **Example validation error:**

--- a/internal/fleetcontrol/configs/fleet_configuration_create.yaml
+++ b/internal/fleetcontrol/configs/fleet_configuration_create.yaml
@@ -28,14 +28,12 @@ flags:
     description: the agent type (e.g., NRInfra, NRDOT)
     validation:
       allowed_values: ["NRInfra","NRDOT", "FluentBit", "NRPrometheusAgent"]
-      case_insensitive: true
   - name: managed-entity-type
     type: string
     required: true
     description: the type of entities this configuration manages
     validation:
       allowed_values: ["HOST", "KUBERNETESCLUSTER"]
-      case_insensitive: true
   - name: organization-id
     type: string
     description: the organization ID; if not provided, will be derived from current organization

--- a/internal/fleetcontrol/configs/fleet_configuration_get.yaml
+++ b/internal/fleetcontrol/configs/fleet_configuration_get.yaml
@@ -28,7 +28,6 @@ flags:
     description: the entity type to retrieve (ConfigEntity for configuration, ConfigVersionEntity for specific version entity)
     validation:
       allowed_values: ["ConfigEntity", "ConfigVersionEntity"]
-      case_insensitive: true
   - name: version
     type: int
     default: -1

--- a/internal/fleetcontrol/configs/fleet_deployment_create.yaml
+++ b/internal/fleetcontrol/configs/fleet_deployment_create.yaml
@@ -32,6 +32,8 @@ flags:
   - name: agent-type
     type: string
     description: "(legacy) the agent type for single agent deployment (e.g., NRInfra, NRDOT). Mutually exclusive with --agent"
+    validation:
+      allowed_values: ["NRInfra", "NRDOT", "FluentBit", "NRPrometheusAgent"]
   - name: agent-version
     type: string
     description: "(legacy) the agent version for single agent deployment (e.g., 1.70.0, 2.0.0). Mutually exclusive with --agent"

--- a/internal/fleetcontrol/configs/fleet_management_create.yaml
+++ b/internal/fleetcontrol/configs/fleet_management_create.yaml
@@ -27,7 +27,6 @@ flags:
     description: the type of entities this fleet manages
     validation:
       allowed_values: ["HOST", "KUBERNETESCLUSTER"]
-      case_insensitive: true
   - name: description
     type: string
     description: a description of the fleet
@@ -42,7 +41,6 @@ flags:
     description: the operating system type for HOST fleets (LINUX or WINDOWS); not applicable for KUBERNETESCLUSTER fleets
     validation:
       allowed_values: ["LINUX", "WINDOWS"]
-      case_insensitive: true
   - name: tags
     type: stringSlice
     description: tags in format key:value1,value2 (can be specified multiple times)

--- a/internal/fleetcontrol/fleet_configuration_create.go
+++ b/internal/fleetcontrol/fleet_configuration_create.go
@@ -62,7 +62,10 @@ func handleFleetCreateConfiguration(cmd *cobra.Command, args []string, flags *Fl
 	configBodyBytes := []byte(configBody)
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Build custom headers required by the API
 	// These headers specify the entity name, agent type, and managed entity type

--- a/internal/fleetcontrol/fleet_configuration_delete.go
+++ b/internal/fleetcontrol/fleet_configuration_delete.go
@@ -30,10 +30,13 @@ func handleFleetDeleteConfiguration(cmd *cobra.Command, args []string, flags *Fl
 	f := flags.DeleteConfiguration()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to delete the configuration
-	_, err := client.NRClient.FleetControl.FleetControlDeleteConfiguration(
+	_, err = client.NRClient.FleetControl.FleetControlDeleteConfiguration(
 		f.ConfigurationID,
 		orgID,
 	)

--- a/internal/fleetcontrol/fleet_configuration_get.go
+++ b/internal/fleetcontrol/fleet_configuration_get.go
@@ -34,7 +34,10 @@ func handleFleetGetConfiguration(cmd *cobra.Command, args []string, flags *FlagV
 	f := flags.GetConfiguration()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Map validated mode to client library type
 	// YAML validation has already confirmed this value is in allowed_values

--- a/internal/fleetcontrol/fleet_configuration_version_add.go
+++ b/internal/fleetcontrol/fleet_configuration_version_add.go
@@ -62,7 +62,10 @@ func handleFleetAddVersion(cmd *cobra.Command, args []string, flags *FlagValues)
 	configBodyBytes := []byte(configBody)
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Build custom headers with the configuration GUID
 	// This tells the API to add a version to the existing configuration

--- a/internal/fleetcontrol/fleet_configuration_version_delete.go
+++ b/internal/fleetcontrol/fleet_configuration_version_delete.go
@@ -30,10 +30,13 @@ func handleFleetDeleteVersion(cmd *cobra.Command, args []string, flags *FlagValu
 	f := flags.DeleteVersion()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to delete the version
-	err := client.NRClient.FleetControl.FleetControlDeleteConfigurationVersion(
+	err = client.NRClient.FleetControl.FleetControlDeleteConfigurationVersion(
 		f.VersionID,
 		orgID,
 	)

--- a/internal/fleetcontrol/fleet_configuration_version_list.go
+++ b/internal/fleetcontrol/fleet_configuration_version_list.go
@@ -36,7 +36,10 @@ func handleFleetGetConfigurationVersions(cmd *cobra.Command, args []string, flag
 	f := flags.GetVersions()
 
 	// Get organization ID (provided or fetched from API)
-	orgID := GetOrganizationID(f.OrganizationID)
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
+	}
 
 	// Call New Relic API to get all configuration versions
 	result, err := client.NRClient.FleetControl.FleetControlGetConfigurationVersions(

--- a/internal/fleetcontrol/fleet_deployment_create.go
+++ b/internal/fleetcontrol/fleet_deployment_create.go
@@ -66,24 +66,15 @@ func handleFleetCreateDeployment(cmd *cobra.Command, args []string, flags *FlagV
 		if f.AgentType == "" {
 			return PrintError(fmt.Errorf("--agent-type is required when not using --agent flag"))
 		}
-
-		// Validate agent type against allowed values
-		validAgentTypes := map[string]bool{
-			"NRInfra":           true,
-			"NRDOT":             true,
-			"FluentBit":         true,
-			"NRPrometheusAgent": true,
-		}
-		if !validAgentTypes[f.AgentType] {
-			return PrintError(fmt.Errorf("invalid agent type '%s': must be one of [NRInfra, NRDOT, FluentBit, NRPrometheusAgent]", f.AgentType))
-		}
-
 		if f.AgentVersion == "" {
 			return PrintError(fmt.Errorf("--agent-version is required when not using --agent flag"))
 		}
 		if len(f.ConfigurationVersionIDs) == 0 {
 			return PrintError(fmt.Errorf("--configuration-version-ids is required when not using --agent flag"))
 		}
+
+		// Note: agent-type values are validated by YAML framework
+		// See configs/fleet_deployment_create.yaml allowed_values
 
 		// Convert configuration version IDs to the required format for agent input
 		var configVersionList []fleetcontrol.FleetControlConfigurationVersionListInput

--- a/internal/fleetcontrol/fleet_deployment_create.go
+++ b/internal/fleetcontrol/fleet_deployment_create.go
@@ -66,6 +66,18 @@ func handleFleetCreateDeployment(cmd *cobra.Command, args []string, flags *FlagV
 		if f.AgentType == "" {
 			return PrintError(fmt.Errorf("--agent-type is required when not using --agent flag"))
 		}
+
+		// Validate agent type against allowed values
+		validAgentTypes := map[string]bool{
+			"NRInfra":           true,
+			"NRDOT":             true,
+			"FluentBit":         true,
+			"NRPrometheusAgent": true,
+		}
+		if !validAgentTypes[f.AgentType] {
+			return PrintError(fmt.Errorf("invalid agent type '%s': must be one of [NRInfra, NRDOT, FluentBit, NRPrometheusAgent]", f.AgentType))
+		}
+
 		if f.AgentVersion == "" {
 			return PrintError(fmt.Errorf("--agent-version is required when not using --agent flag"))
 		}

--- a/internal/fleetcontrol/fleet_management_create.go
+++ b/internal/fleetcontrol/fleet_management_create.go
@@ -57,9 +57,9 @@ func handleFleetCreate(cmd *cobra.Command, args []string, flags *FlagValues) err
 
 	// Get organization ID (either from flag or fetch from API)
 	// This avoids an unnecessary API call if the user already knows their org ID
-	orgID := GetOrganizationID(f.OrganizationID)
-	if orgID == "" {
-		return PrintError(fmt.Errorf("failed to determine organization ID"))
+	orgID, err := GetOrganizationID(f.OrganizationID)
+	if err != nil {
+		return PrintError(fmt.Errorf("failed to determine organization ID: %w", err))
 	}
 
 	// Parse tags from "key:value1,value2" format to API format

--- a/internal/fleetcontrol/helpers.go
+++ b/internal/fleetcontrol/helpers.go
@@ -7,8 +7,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
 	"github.com/newrelic/newrelic-cli/internal/client"
 	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
 )
@@ -24,17 +22,17 @@ import (
 //
 // Returns:
 //   - The organization ID (either provided or fetched)
-func GetOrganizationID(providedOrgID string) string {
+//   - Error if the API call fails when fetching the organization ID
+func GetOrganizationID(providedOrgID string) (string, error) {
 	if providedOrgID != "" {
-		return providedOrgID
+		return providedOrgID, nil
 	}
 
 	org, err := client.NRClient.Organization.GetOrganization()
 	if err != nil {
-		log.Warnf("Failed to get organization: %v", err)
-		return ""
+		return "", fmt.Errorf("failed to get organization from API: %w", err)
 	}
-	return org.ID
+	return org.ID, nil
 }
 
 // ParseTags converts tag strings in the format "key:value1,value2" into FleetControlTagInput structs.
@@ -128,6 +126,18 @@ func ParseAgentSpec(agentSpec string) (fleetcontrol.FleetControlAgentInput, erro
 	if agentType == "" {
 		return fleetcontrol.FleetControlAgentInput{}, fmt.Errorf("agent type cannot be empty")
 	}
+
+	// Validate agent type against allowed values
+	validAgentTypes := map[string]bool{
+		"NRInfra":           true,
+		"NRDOT":             true,
+		"FluentBit":         true,
+		"NRPrometheusAgent": true,
+	}
+	if !validAgentTypes[agentType] {
+		return fleetcontrol.FleetControlAgentInput{}, fmt.Errorf("invalid agent type '%s': must be one of [NRInfra, NRDOT, FluentBit, NRPrometheusAgent]", agentType)
+	}
+
 	if version == "" {
 		return fleetcontrol.FleetControlAgentInput{}, fmt.Errorf("agent version cannot be empty")
 	}
@@ -222,7 +232,7 @@ func ValidateAgentVersionsForFleet(fleetID string, agents []fleetcontrol.FleetCo
 func MapManagedEntityType(typeStr string) (fleetcontrol.FleetControlManagedEntityType, error) {
 	// Note: YAML validation has already confirmed this value is in allowed_values
 	// This mapping must match the YAML allowed_values exactly
-	switch strings.ToUpper(typeStr) {
+	switch typeStr {
 	case "HOST":
 		return fleetcontrol.FleetControlManagedEntityTypeTypes.HOST, nil
 	case "KUBERNETESCLUSTER":
@@ -230,7 +240,7 @@ func MapManagedEntityType(typeStr string) (fleetcontrol.FleetControlManagedEntit
 	default:
 		// This should never happen if YAML validation is working correctly
 		return fleetcontrol.FleetControlManagedEntityType(""), fmt.Errorf(
-			"unrecognized managed entity type '%s' - YAML validation may have failed", typeStr)
+			"unrecognized managed entity type '%s' - expected exact match for 'HOST' or 'KUBERNETESCLUSTER'", typeStr)
 	}
 }
 
@@ -246,7 +256,7 @@ func MapManagedEntityType(typeStr string) (fleetcontrol.FleetControlManagedEntit
 func MapScopeType(typeStr string) (fleetcontrol.FleetControlEntityScope, error) {
 	// Note: YAML validation has already confirmed this value is in allowed_values
 	// This mapping must match the YAML allowed_values exactly
-	switch strings.ToUpper(typeStr) {
+	switch typeStr {
 	case "ACCOUNT":
 		return fleetcontrol.FleetControlEntityScopeTypes.ACCOUNT, nil
 	case "ORGANIZATION":
@@ -254,7 +264,7 @@ func MapScopeType(typeStr string) (fleetcontrol.FleetControlEntityScope, error) 
 	default:
 		// This should never happen if YAML validation is working correctly
 		return fleetcontrol.FleetControlEntityScope(""), fmt.Errorf(
-			"unrecognized scope type '%s' - YAML validation may have failed", typeStr)
+			"unrecognized scope type '%s' - expected exact match for 'ACCOUNT' or 'ORGANIZATION'", typeStr)
 	}
 }
 
@@ -270,15 +280,15 @@ func MapScopeType(typeStr string) (fleetcontrol.FleetControlEntityScope, error) 
 func MapConfigurationMode(modeStr string) (fleetcontrol.GetConfigurationMode, error) {
 	// Note: YAML validation has already confirmed this value is in allowed_values
 	// This mapping must match the YAML allowed_values exactly
-	switch strings.ToLower(modeStr) {
-	case "configentity", "":
+	switch modeStr {
+	case "ConfigEntity", "":
 		return fleetcontrol.GetConfigurationModeTypes.ConfigEntity, nil
-	case "configversionentity":
+	case "ConfigVersionEntity":
 		return fleetcontrol.GetConfigurationModeTypes.ConfigVersionEntity, nil
 	default:
 		// This should never happen if YAML validation is working correctly
 		return fleetcontrol.GetConfigurationMode(""), fmt.Errorf(
-			"unrecognized configuration mode '%s' - YAML validation may have failed", modeStr)
+			"unrecognized configuration mode '%s' - expected exact match for 'ConfigEntity' or 'ConfigVersionEntity'", modeStr)
 	}
 }
 
@@ -294,7 +304,7 @@ func MapConfigurationMode(modeStr string) (fleetcontrol.GetConfigurationMode, er
 func MapOperatingSystemType(osStr string) (fleetcontrol.FleetControlOperatingSystemType, error) {
 	// Note: YAML validation has already confirmed this value is in allowed_values
 	// This mapping must match the YAML allowed_values exactly
-	switch strings.ToUpper(osStr) {
+	switch osStr {
 	case "LINUX":
 		return fleetcontrol.FleetControlOperatingSystemTypeTypes.LINUX, nil
 	case "WINDOWS":
@@ -302,7 +312,7 @@ func MapOperatingSystemType(osStr string) (fleetcontrol.FleetControlOperatingSys
 	default:
 		// This should never happen if YAML validation is working correctly
 		return fleetcontrol.FleetControlOperatingSystemType(""), fmt.Errorf(
-			"unrecognized operating system type '%s' - YAML validation may have failed", osStr)
+			"unrecognized operating system type '%s' - expected exact match for 'LINUX' or 'WINDOWS'", osStr)
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR addresses two issues reported by the fleet team:

1. **Misleading error messages**: When organization ID retrieval fails (e.g., due to "Unauthorized IP address"), the CLI showed a generic "failed to determine organization ID" message without revealing the underlying cause.

2. **Inconsistent validation**: The original implementation used `case_insensitive: true` in YAML configs but didn't properly normalize values before sending to the API, leading to confusion about which values were actually accepted.

## Changes

### Error Handling
- Modified `GetOrganizationID()` to return the actual API error, providing users with clear information about what went wrong (e.g., "Unauthorized IP address")
- Updated all 7 callers of `GetOrganizationID()` to properly handle the new error return value

### Exact Value Matching
- **Removed all `case_insensitive: true` from YAML config files** - values must now match exactly as specified
- Removed case normalization (`ToUpper`/`ToLower`) from all `Map*` functions to enforce exact matching
- Added explicit validation for agent types in:
  - `ParseAgentSpec()` - validates `--agent` flag format (e.g., "NRInfra:1.70.0:version1")  
  - `fleet_deployment_create.go` - validates legacy `--agent-type` flag
- Updated README documentation to reflect case-sensitive validation requirements

### Required Values
Users must now provide exact values as specified:
- Agent types: `NRInfra`, `NRDOT`, `FluentBit`, `NRPrometheusAgent` (not "nrinfra" or "NRINFRA")
- Managed entity types: `HOST`, `KUBERNETESCLUSTER` (not "host" or "kubernetescluster")
- Operating systems: `LINUX`, `WINDOWS` (not "linux" or "windows")
- Configuration modes: `ConfigEntity`, `ConfigVersionEntity` (not "configentity")

## Testing
Verified that:
- Lowercase values like "nrinfra", "host", etc. are now properly rejected with clear error messages
- Correct values like "NRInfra", "HOST" work as expected
- Organization ID errors now display the underlying API error
- All code compiles successfully