### PR TITLE
chore(security): suppress .dockerbuild artifact upload in vuln scan workflow

### DIFF
--- a/.github/workflows/vuln-scan-report.yml
+++ b/.github/workflows/vuln-scan-report.yml
@@ -44,6 +44,8 @@ jobs:
           load: true
           push: false
           tags: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
+        env:
+          DOCKER_BUILD_SUMMARY: false
 
       - name: Create Trivy scan template
         run: |
@@ -82,7 +84,6 @@ jobs:
           severity-cutoff: low
           only-fixed: true
           output-format: json
-          upload-artifacts: false
 
       - name: Merge and deduplicate scan results
         run: |

--- a/.github/workflows/vuln-scan-report.yml
+++ b/.github/workflows/vuln-scan-report.yml
@@ -82,6 +82,7 @@ jobs:
           severity-cutoff: low
           only-fixed: true
           output-format: json
+          upload-artifacts: false
 
       - name: Merge and deduplicate scan results
         run: |


### PR DESCRIPTION
- Adds DOCKER_BUILD_SUMMARY: false env var to the docker/build-push-action step to suppress the .dockerbuild artifact upload