### PR TITLE
feat(region): add Japan (JP) region support

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -34,11 +34,12 @@ export NEW_RELIC_API_KEY=<your_personal_api_key>
 ```
 
 API keys are specific to region, and this project defaults to "US".  If you're
-wanting to use this against the EU region, you'll need the following
+wanting to use this against the EU or Japan region, you'll need the following
 environment variable.
 
 ```sh
-export NEW_RELIC_REGION="EU"
+export NEW_RELIC_REGION="EU"   # EU region
+export NEW_RELIC_REGION="JP"   # Japan region
 ```
 
 Creating custom events with the `newrelic events` sub-command requires a License key, which can be configured in a profile or with the following environment variable:
@@ -242,7 +243,7 @@ Custom events may take a moment to appear in query results while they are being 
 | -------------------------------------- | -------------------------------------------------------------- |
 | `NEW_RELIC_ACCOUNT_ID`                 | Your New Relic [account ID].                                   |
 | `NEW_RELIC_API_KEY`                    | Your New Relic [User API key] \(prefixed with `NRAK`).         |
-| `NEW_RELIC_REGION`                     | Your New Relic account's [data center region] \(`US` or `EU`). |
+| `NEW_RELIC_REGION`                     | Your New Relic account's [data center region] \(`US`, `EU`, or `JP`). |
 | `NEW_RELIC_CLI_SKIP_CORE`              | Skipping core recipes during installation \(`1` or `0`).       |
 
 ### Want more?

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -38,8 +38,9 @@ wanting to use this against the EU or Japan region, you'll need the following
 environment variable.
 
 ```sh
+# Set one of the following based on your region:
 export NEW_RELIC_REGION="EU"   # EU region
-export NEW_RELIC_REGION="JP"   # Japan region
+# export NEW_RELIC_REGION="JP" # Japan region
 ```
 
 Creating custom events with the `newrelic events` sub-command requires a License key, which can be configured in a profile or with the following environment variable:

--- a/docs/cli/newrelic_profile_add.md
+++ b/docs/cli/newrelic_profile_add.md
@@ -27,7 +27,7 @@ newrelic profile add --profile <profile> --region <region> --apiKey <apiKey> --a
       --apiKey string              your personal API key
   -h, --help                       help for add
       --licenseKey string          your license key
-  -r, --region string              the US or EU region
+  -r, --region string              the US, EU, or JP region
 ```
 
 ### Options inherited from parent commands

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/newrelic/newrelic-cli
 
 go 1.26.1
 
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.82.2-0.20260416194620-28d678457e4b
-
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Masterminds/semver/v3 v3.3.0

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.79.0
+	github.com/newrelic/newrelic-client-go/v2 v2.83.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.82.2-0.20260416194620-28d678457e4b h1:0cg9SvARZsTxXJVu1wD1Sbntd0Juxm+QoxYRwraMG80=
-github.com/newrelic/newrelic-client-go/v2 v2.82.2-0.20260416194620-28d678457e4b/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.0 h1:HuxTno3USbhxJ2wQt1fKkyUnNrAMW6UYgnbWgRJaVzw=
+github.com/newrelic/newrelic-client-go/v2 v2.83.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.79.0 h1:SNkjPjN8qpqrD/AmwHlHCTmN1oc4d5gMkXmbLOwOIro=
-github.com/newrelic/newrelic-client-go/v2 v2.79.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.83.0 h1:HuxTno3USbhxJ2wQt1fKkyUnNrAMW6UYgnbWgRJaVzw=
+github.com/newrelic/newrelic-client-go/v2 v2.83.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,7 @@ func InitializeCredentialsStore() {
 					region.Staging.String(),
 					region.US.String(),
 					region.EU.String(),
+					region.JP.String(),
 				),
 				Default:      region.US.String(),
 				SetValueFunc: ToLower(),

--- a/internal/fleetcontrol/README.md
+++ b/internal/fleetcontrol/README.md
@@ -121,7 +121,7 @@ export NEW_RELIC_API_KEY="NRAK-YOUR-API-KEY-HERE"
 export NEW_RELIC_ACCOUNT_ID="your-account-id"
 
 # Optional: Specify region (defaults to US)
-export NEW_RELIC_REGION="US"  # or "EU" for European accounts
+export NEW_RELIC_REGION="US"  # or "EU" for European accounts, or "JP" for Japan
 ```
 
 ### Getting Your Credentials

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -164,7 +164,7 @@ func validateProfile() *types.DetailError {
 	}
 
 	if _, err := nrRegion.Parse(region); err != nil {
-		return types.NewDetailError(types.EventTypes.InvalidRegion, `Invalid region provided. Valid regions are "US" or "EU".`)
+		return types.NewDetailError(types.EventTypes.InvalidRegion, `Invalid region provided. Valid regions are "US", "EU", or "JP".`)
 	}
 
 	return nil

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -23,10 +23,12 @@ var nrPlatformHostnames = struct {
 	Staging string
 	US      string
 	EU      string
+	JP      string
 }{
 	Staging: "staging-one.newrelic.com",
 	US:      "one.newrelic.com",
 	EU:      "one.eu.newrelic.com",
+	JP:      "one.jp.newrelic.com",
 }
 
 func NewPlatformLinkGenerator() *PlatformLinkGenerator {
@@ -264,6 +266,10 @@ func nrPlatformHostname() string {
 
 	if strings.EqualFold(r, region.EU.String()) {
 		return nrPlatformHostnames.EU
+	}
+
+	if strings.EqualFold(r, region.JP.String()) {
+		return nrPlatformHostnames.JP
 	}
 
 	return nrPlatformHostnames.US

--- a/internal/migrate/tf_importgen_ci_guide.md
+++ b/internal/migrate/tf_importgen_ci_guide.md
@@ -28,7 +28,7 @@ Before using the `tf-importgen-ci` command, ensure that the following technical 
 - **Environment Variables**: The following must be set:
   - `NEW_RELIC_API_KEY` (required) - Your New Relic User API key with appropriate permissions
   - `NEW_RELIC_ACCOUNT_ID` (required) - The New Relic account ID where your Drop Rules are located
-  - `NEW_RELIC_REGION` (optional) - Set to 'US' or 'EU' based on your account region (defaults to 'US')
+  - `NEW_RELIC_REGION` (optional) - Set to 'US', 'EU', or 'JP' based on your account region (defaults to 'US')
 - **JSON Input**: Valid JSON file containing the exported Drop Rule data from Phase 1, supplied via the `--json` or `--filePath` arguments, as explained in the command arguments below
 
 

--- a/internal/migrate/tf_importgen_guide.md
+++ b/internal/migrate/tf_importgen_guide.md
@@ -33,7 +33,7 @@ Before using any of the migration commands, ensure that the following technical 
 - **Environment Variables**: The following must be set:
   - `NEW_RELIC_API_KEY` (required) - Your New Relic User API key with appropriate permissions
   - `NEW_RELIC_ACCOUNT_ID` (required) - The New Relic account ID where your Drop Rules are located
-  - `NEW_RELIC_REGION` (optional) - Set to 'US' or 'EU' based on your account region (defaults to 'US')
+  - `NEW_RELIC_REGION` (optional) - Set to 'US', 'EU', or 'JP' based on your account region (defaults to 'US')
 - **Terraform Workspace**: A valid Terraform workspace with existing `newrelic_nrql_drop_rule` resources
 
 ### Workspace Preparation

--- a/internal/profile/command.go
+++ b/internal/profile/command.go
@@ -56,7 +56,7 @@ for posting custom events with the ` + "`newrelic events`" + `command.
 	PreRun:  requireProfileName,
 	Run: func(cmd *cobra.Command, args []string) {
 		addStringValueToProfile(config.FlagProfileName, apiKey, config.APIKey, "User API Key", nil, nil)
-		addStringValueToProfile(config.FlagProfileName, flagRegion, config.Region, "Region", nil, []string{"US", "EU"})
+		addStringValueToProfile(config.FlagProfileName, flagRegion, config.Region, "Region", nil, []string{"US", "EU", "JP"})
 		addIntValueToProfile(config.FlagProfileName, accountID, config.AccountID, "Account ID", fetchAccountIDs)
 		addStringValueToProfile(config.FlagProfileName, licenseKey, config.LicenseKey, "License Key", fetchLicenseKey(), nil)
 
@@ -275,7 +275,7 @@ func requireProfileName(cmd *cobra.Command, args []string) {
 func init() {
 	// Add
 	Command.AddCommand(cmdAdd)
-	cmdAdd.Flags().StringVarP(&flagRegion, "region", "r", "", "the US or EU region")
+	cmdAdd.Flags().StringVarP(&flagRegion, "region", "r", "", "the US, EU, or JP region")
 	cmdAdd.Flags().StringVarP(&apiKey, "apiKey", "", "", "your personal API key")
 	cmdAdd.Flags().StringVarP(&licenseKey, "licenseKey", "", "", "your license key")
 	cmdAdd.Flags().IntVarP(&accountID, "accountId", "", 0, "your account ID")


### PR DESCRIPTION
## Summary

Adds support for New Relic's Japan (JP) data center region across the CLI. All changes are purely additive — no existing behavior for US or EU users is modified.

## Changes

  **Core region support (4 files):**
  - `internal/config/config.go` — Added `JP` to the valid region allow-list (validator is write-only, so existing profiles are unaffected on startup)
  - `internal/install/command.go` — Updated invalid-region error message to include `"JP"`
  - `internal/install/execution/platform_link_generator.go` — Added `one.jp.newrelic.com` hostname and JP branch in
    `nrPlatformHostname()` (US fallback unchanged)
  - `internal/profile/command.go` — Added `"JP"` to interactive region selector and `--region` flag description

 **Documentation (5 files):**
  - `docs/GETTING_STARTED.md`
  - `docs/cli/newrelic_profile_add.md`
  - `internal/migrate/tf_importgen_guide.md`
  - `internal/migrate/tf_importgen_ci_guide.md`
  - `internal/fleetcontrol/README.md`
