### PR TITLE
fix: bump Alpine base image to 3.23.4 to resolve CVEs

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 # Add the binary
 COPY newrelic /bin/newrelic


### PR DESCRIPTION
Jira - https://new-relic.atlassian.net/browse/NR-551791 

 ## Summary                                                                         
                                                                                                                                                                                                                 
  - Bumps the Docker base image from `alpine:3.23.3` to `alpine:3.23.4`                                                                                                                                          
  - Resolves 11 unique Alpine CVE IDs across 5 packages (libcrypto3, libssl3, musl, musl-utils, zlib), reducing the daily scan from 30 findings to 10.                                                                                                                                           
                                                                                                                                                                                                                 
 ## Breakdown:                                                                                                                                                                                                    

 | Package | CVEs | Critical | High | Medium | Low |                                                                                                                                                            
  |---|---|---|---|---|---|  
  | libcrypto3, libssl3 | 7 | 1 | 4 | 1 | 1 |                                                                                                                                                                    
  | musl, musl-utils | 2 | — | 1 | 1 | — |
  | zlib | 2 | — | 1 | 1 | — |                                                                                                                                                                                   
  | **Total** | **11** | **1** | **6** | **3** | **1** |

Alpine 3.23.4 was released on 2026-04-15 as a coordinated security release specifically addressing these CVEs:                                                                                                 
  - Release announcement: https://alpinelinux.org/posts/Alpine-3.20.10-3.21.7-3.22.4-3.23.4-released.html
  - Alpine security tracker: https://security.alpinelinux.org/vuln/CVE-2026-31789 (representative link — all CVEs show `fixed: true` in `3.23-main`). To view any CVE's fix status, replace `<CVE-ID>` in `https://security.alpinelinux.org/vuln/<CVE-ID>` — all 11 CVEs above show `fixed: true` in `3.23-main`

## Test Results

The above CVEs are no longer being reported as seen in the latest scan results run against this PR branch. 
https://github.com/newrelic/newrelic-cli/actions/runs/25301940686