### PR TITLE
fix: remove false-positive HTTPS_PROXY warning when HTTPS_PROXY is already set

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -181,7 +181,7 @@ func checkNetwork() error {
 
 	if err == nil {
 		if IsProxyConfigured() {
-			if strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "http") && !strings.Contains(strings.ToLower(proxyConfig.HTTPSProxy), "https") {
+			if ShouldWarnAboutProxy(*proxyConfig) {
 				log.Warn("Please ensure the HTTPS_PROXY environment variable is set when using a proxy server.")
 				log.Warn("New Relic CLI exclusively supports https proxy, not http for security reasons.")
 			}
@@ -190,8 +190,6 @@ func checkNetwork() error {
 
 	if err != nil {
 		if IsProxyConfigured() {
-			proxyConfig := httpproxy.FromEnvironment()
-
 			log.Warn("Proxy settings have been configured, but we are still unable to connect to the New Relic platform.")
 			log.Warn("You may need to adjust your proxy environment variables or configure your proxy to allow the specified domain.")
 			log.Warn("Current proxy config:")

--- a/internal/install/command_test.go
+++ b/internal/install/command_test.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/http/httpproxy"
 
 	"github.com/newrelic/newrelic-cli/internal/install/types"
 	"github.com/newrelic/newrelic-cli/internal/testcobra"
@@ -97,28 +97,32 @@ func initSegmentMockServer() *httptest.Server {
 	return server
 }
 
-func TestProxyNetwork(t *testing.T) {
-
-	proxyConfig := struct {
-		HTTPSProxy string
-		HTTPProxy  string
-	}{
-		HTTPSProxy: "http://localhost:3128",
-		HTTPProxy:  "http://localhost:8080",
+func TestShouldWarnAboutProxy(t *testing.T) {
+	warn := func() bool {
+		return ShouldWarnAboutProxy(*httpproxy.FromEnvironment())
 	}
 
-	// Validate HTTPSProxy
-	if strings.HasPrefix(proxyConfig.HTTPSProxy, "http://") {
-		t.Log("New Relic CLI exclusively supports https proxy, not http for security reasons.")
-	} else if strings.HasPrefix(proxyConfig.HTTPSProxy, "https://") {
-		// Do nothing
-	} else {
-		t.Log("Invalid proxy provided")
-	}
+	t.Run("no warning when HTTPS_PROXY is set with http scheme", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "http://localhost:8080")
+		t.Setenv("HTTP_PROXY", "")
+		assert.False(t, warn())
+	})
 
-	// Validate HTTPProxy
-	if strings.HasPrefix(proxyConfig.HTTPProxy, "http://") {
-		t.Log("If you need to use a proxy, consider setting the HTTPS_PROXY environment variable, then try again. New Relic CLI exclusively supports https proxy.")
-	}
+	t.Run("no warning when HTTPS_PROXY is set with https scheme", func(t *testing.T) {
+		t.Setenv("HTTPS_PROXY", "https://localhost:8080")
+		t.Setenv("HTTP_PROXY", "")
+		assert.False(t, warn())
+	})
 
+	t.Run("warns when HTTP_PROXY is set but HTTPS_PROXY is not", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "http://localhost:8080")
+		t.Setenv("HTTPS_PROXY", "")
+		assert.True(t, warn())
+	})
+
+	t.Run("no warning when no proxy is configured", func(t *testing.T) {
+		t.Setenv("HTTP_PROXY", "")
+		t.Setenv("HTTPS_PROXY", "")
+		assert.False(t, warn())
+	})
 }

--- a/internal/install/proxy_configuration.go
+++ b/internal/install/proxy_configuration.go
@@ -6,3 +6,10 @@ func IsProxyConfigured() bool {
 	proxyConfig := httpproxy.FromEnvironment()
 	return proxyConfig.HTTPProxy != "" || proxyConfig.HTTPSProxy != "" || proxyConfig.NoProxy != ""
 }
+
+// ShouldWarnAboutProxy reports whether the proxy environment looks misconfigured:
+// HTTP_PROXY is set (suggesting the user intends to use a proxy) but HTTPS_PROXY
+// is absent, meaning the CLI's HTTPS calls to New Relic will bypass the proxy entirely.
+func ShouldWarnAboutProxy(cfg httpproxy.Config) bool {
+	return cfg.HTTPProxy != "" && cfg.HTTPSProxy == ""
+}


### PR DESCRIPTION
## Summary

- The guided install was printing a warning _\"Please ensure the HTTPS_PROXY environment variable is set\"_ even when `HTTPS_PROXY` **was already set** with an `http://` URL (e.g. `HTTPS_PROXY=http://localhost:8080`)
- Root cause: the condition used a broken string-matching heuristic — it checked if `HTTPS_PROXY` contained `"http"` but not `"https"`, which matches any `http://` URL
- Fix: replaced the heuristic with a direct env var check — the warning now only fires when `HTTP_PROXY` is set but `HTTPS_PROXY` is absent (the actual misconfiguration the message was meant to flag)
- Replaced the non-asserting `TestProxyNetwork` (which only called `t.Log`) with `TestProxyWarningCondition`, which covers all four cases with real assertions

## Test plan

- [ ] `go test -tags unit ./internal/install/ -run TestProxyWarningCondition -v` — all 4 subtests pass
- [ ] Manual: set `HTTPS_PROXY=http://localhost:8080` and run guided install — warning should no longer appear
- [ ] Manual: set `HTTP_PROXY=http://localhost:8080` (no `HTTPS_PROXY`) and run guided install — warning should still appear

Fixes [NR-560830](https://new-relic.atlassian.net/browse/NR-560830) — resolved via AI (Claude Code / Claude Sonnet 4.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-560830]: https://new-relic.atlassian.net/browse/NR-560830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ