### PR TITLE
fix(autodiscovery): add `NEW_RELIC_SKIP_AUTODISCOVERY` env var to skip autodiscovery for targeted installs

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -246,6 +246,7 @@ Custom events may take a moment to appear in query results while they are being 
 | `NEW_RELIC_API_KEY`                    | Your New Relic [User API key] \(prefixed with `NRAK`).         |
 | `NEW_RELIC_REGION`                     | Your New Relic account's [data center region] \(`US`, `EU`, or `JP`). |
 | `NEW_RELIC_CLI_SKIP_CORE`              | Skipping core recipes during installation \(`1` or `0`).       |
+| `NEW_RELIC_SKIP_AUTODISCOVERY`         | When combined with `-n`, skip auto-discovery for all recipes not explicitly requested. Reduces installation time in automated environments by preventing `requireAtDiscovery` scripts from running for every known recipe. Has no effect without `-n`. Accepts truthy values: `1`, `true`, `TRUE`. |
 
 ### Want more?
 

--- a/docs/cli/newrelic_install.md
+++ b/docs/cli/newrelic_install.md
@@ -29,6 +29,13 @@ newrelic install [flags]
       --trace            trace level logging
 ```
 
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `NEW_RELIC_CLI_SKIP_CORE` | Skip installation of core recipes (infrastructure agent and logs integration). Set to `1` to enable. |
+| `NEW_RELIC_SKIP_AUTODISCOVERY` | When combined with `-n`, skip the auto-discovery phase for all recipes not explicitly requested. This prevents `requireAtDiscovery` scripts from running for every known recipe, which can significantly reduce installation time in scripted or automated environments. Has no effect when `-n` is not provided. Accepts truthy values: `1`, `true`, `TRUE`, `t`. |
+
 ### Installing Specific Versions of the Infrastructure Agent
 
 To install a specific version of the infrastructure agent, append the version number to the recipe name using `@`. This functionality is currently supported only for the infrastructure agent.

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -59,28 +59,8 @@ func processRecipeNames(recipeNames []string) ([]string, error) {
 
 // Command represents the install command.
 var Command = &cobra.Command{
-	Use:   "install",
-	Short: "Install New Relic.",
-	Long: `Install New Relic.
-
-Installs New Relic using the guided installation flow, or one or more specific
-recipes when the -n (--recipe) flag is provided.
-
-Environment variables:
-
-  NEW_RELIC_CLI_SKIP_CORE=1
-      Skip installation of core recipes (infrastructure agent and logs
-      integration). Useful when only a non-core recipe is needed.
-
-  NEW_RELIC_SKIP_AUTODISCOVERY=1
-      When combined with -n (--recipe), skip the auto-discovery phase for all
-      recipes that were not explicitly requested. Auto-discovery runs
-      requireAtDiscovery scripts for every known recipe to detect installed
-      services, which can take a significant amount of time. Setting this
-      variable limits discovery to only the targeted recipes, reducing
-      installation time. Has no effect when no -n flag is provided.
-      Accepts: 1, true, TRUE, t (or their falsy counterparts to disable).
-`,
+	Use:    "install",
+	Short:  "Install New Relic.",
 	PreRun: client.RequireClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		extractedRecipeNames, err := processRecipeNames(recipeNames)

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -59,8 +59,28 @@ func processRecipeNames(recipeNames []string) ([]string, error) {
 
 // Command represents the install command.
 var Command = &cobra.Command{
-	Use:    "install",
-	Short:  "Install New Relic.",
+	Use:   "install",
+	Short: "Install New Relic.",
+	Long: `Install New Relic.
+
+Installs New Relic using the guided installation flow, or one or more specific
+recipes when the -n (--recipe) flag is provided.
+
+Environment variables:
+
+  NEW_RELIC_CLI_SKIP_CORE=1
+      Skip installation of core recipes (infrastructure agent and logs
+      integration). Useful when only a non-core recipe is needed.
+
+  NEW_RELIC_SKIP_AUTODISCOVERY=1
+      When combined with -n (--recipe), skip the auto-discovery phase for all
+      recipes that were not explicitly requested. Auto-discovery runs
+      requireAtDiscovery scripts for every known recipe to detect installed
+      services, which can take a significant amount of time. Setting this
+      variable limits discovery to only the targeted recipes, reducing
+      installation time. Has no effect when no -n flag is provided.
+      Accepts: 1, true, TRUE, t (or their falsy counterparts to disable).
+`,
 	PreRun: client.RequireClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		extractedRecipeNames, err := processRecipeNames(recipeNames)

--- a/internal/install/recipes/recipe_detector.go
+++ b/internal/install/recipes/recipe_detector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"sort"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -88,11 +89,12 @@ func (dt *RecipeDetector) GetDetectedRecipes() (RecipeDetectionResults, RecipeDe
 func (dt *RecipeDetector) shouldDiscover(recipe *types.OpenInstallationRecipe) bool {
 	isTargeted := dt.installerContext.IsRecipeTargeted(recipe.Name)
 
-	// When NEW_RELIC_SKIP_AUTODISCOVERY=1 and a targeted install is requested,
-	// skip discovery for all non-targeted recipes to avoid unnecessary script
-	// execution (e.g. requireAtDiscovery scripts) for recipes the user didn't ask for.
-	if os.Getenv("NEW_RELIC_SKIP_AUTODISCOVERY") == "1" &&
-		(dt.installerContext.RecipeNamesProvided() || dt.installerContext.RecipePathsProvided()) {
+	// When NEW_RELIC_SKIP_AUTODISCOVERY is set to a truthy value (1, true, TRUE, …)
+	// and a targeted install is requested, skip discovery for all non-targeted
+	// recipes to avoid unnecessary script execution (e.g. requireAtDiscovery scripts)
+	// for recipes the user didn't ask for.
+	skipAD, _ := strconv.ParseBool(os.Getenv("NEW_RELIC_SKIP_AUTODISCOVERY"))
+	if skipAD && (dt.installerContext.RecipeNamesProvided() || dt.installerContext.RecipePathsProvided()) {
 		return isTargeted
 	}
 

--- a/internal/install/recipes/recipe_detector.go
+++ b/internal/install/recipes/recipe_detector.go
@@ -2,6 +2,7 @@ package recipes
 
 import (
 	"context"
+	"os"
 	"sort"
 	"time"
 
@@ -86,6 +87,16 @@ func (dt *RecipeDetector) GetDetectedRecipes() (RecipeDetectionResults, RecipeDe
 
 func (dt *RecipeDetector) shouldDiscover(recipe *types.OpenInstallationRecipe) bool {
 	isTargeted := dt.installerContext.IsRecipeTargeted(recipe.Name)
+
+	// When NEW_RELIC_SKIP_AUTODISCOVERY=1 and a targeted install is requested,
+	// skip discovery for all non-targeted recipes to avoid unnecessary script
+	// execution (e.g. requireAtDiscovery scripts) for recipes the user didn't ask for.
+	if os.Getenv("NEW_RELIC_SKIP_AUTODISCOVERY") == "1" &&
+		(dt.installerContext.RecipeNamesProvided() || dt.installerContext.RecipePathsProvided()) {
+		return isTargeted
+	}
+
+	// Check recipe's discoveryMode setting
 	if len(recipe.PreInstall.DiscoveryMode) == 1 &&
 		(recipe.PreInstall.DiscoveryMode[0] == types.OpenInstallationDiscoveryModeTypes.TARGETED) {
 		return isTargeted

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -156,6 +156,78 @@ func TestRecipeDetectorShouldDiscover(t *testing.T) {
 	require.True(t, detector.shouldDiscover(recipe), "Should discover when targeted, and guided mode")
 }
 
+func TestSkipAutodiscoveryEnvVar_SkipsNonTargetedRecipes(t *testing.T) {
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1")
+
+	targeted := NewRecipeBuilder().Name("agent-control").Build()
+	other := NewRecipeBuilder().Name("infrastructure-agent-installer").Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{"agent-control"}})
+	b.WithProcessEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithProcessEvaluatorRecipeStatus(other, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(other, execution.RecipeStatusTypes.AVAILABLE)
+	detector := b.Build()
+
+	available, unavailable, err := detector.GetDetectedRecipes()
+
+	require.NoError(t, err)
+	_, ok := available.GetRecipeDetection("agent-control")
+	require.True(t, ok, "targeted recipe should be available")
+	unavailableOther, ok := unavailable.GetRecipeDetection("infrastructure-agent-installer")
+	require.True(t, ok, "non-targeted recipe should be in unavailable")
+	require.Equal(t, execution.RecipeStatusTypes.NULL, unavailableOther.Status, "non-targeted recipe should have NULL status")
+}
+
+func TestSkipAutodiscoveryEnvVar_IncludesTargetedRecipe(t *testing.T) {
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1")
+
+	targeted := NewRecipeBuilder().Name("agent-control").Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{"agent-control"}})
+	b.WithProcessEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	detector := b.Build()
+
+	require.True(t, detector.shouldDiscover(targeted), "targeted recipe should be discovered")
+}
+
+func TestSkipAutodiscoveryEnvVar_NoEffectWithoutTargetedRecipes(t *testing.T) {
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1")
+
+	recipe := NewRecipeBuilder().Name("infrastructure-agent-installer").Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	// No recipe names provided — guided install
+	b.WithInstallContext(&types.InstallerContext{})
+	b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+	detector := b.Build()
+
+	require.True(t, detector.shouldDiscover(recipe), "should discover all recipes when no targeted names provided (guided install)")
+}
+
+func TestSkipAutodiscoveryEnvVar_NotSet_DiscoversAll(t *testing.T) {
+	// Ensure env var is not set (default behaviour)
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "")
+
+	targeted := NewRecipeBuilder().Name("agent-control").Build()
+	other := NewRecipeBuilder().Name("infrastructure-agent-installer").Build()
+
+	b := NewRecipeDetectorTestBuilder()
+	b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{"agent-control"}})
+	b.WithProcessEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithProcessEvaluatorRecipeStatus(other, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(targeted, execution.RecipeStatusTypes.AVAILABLE)
+	b.WithScriptEvaluatorRecipeStatus(other, execution.RecipeStatusTypes.AVAILABLE)
+	detector := b.Build()
+
+	require.True(t, detector.shouldDiscover(targeted), "targeted recipe should be discovered")
+	require.True(t, detector.shouldDiscover(other), "non-targeted recipe should still be discovered when env var not set")
+}
+
 type MockRecipesFinder struct {
 	recipes []*types.OpenInstallationRecipe
 	err     error

--- a/internal/install/recipes/recipe_detector_test.go
+++ b/internal/install/recipes/recipe_detector_test.go
@@ -157,7 +157,7 @@ func TestRecipeDetectorShouldDiscover(t *testing.T) {
 }
 
 func TestSkipAutodiscoveryEnvVar_SkipsNonTargetedRecipes(t *testing.T) {
-	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1")
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "true") // also valid: "1", "TRUE", "t"
 
 	targeted := NewRecipeBuilder().Name("agent-control").Build()
 	other := NewRecipeBuilder().Name("infrastructure-agent-installer").Build()
@@ -181,7 +181,7 @@ func TestSkipAutodiscoveryEnvVar_SkipsNonTargetedRecipes(t *testing.T) {
 }
 
 func TestSkipAutodiscoveryEnvVar_IncludesTargetedRecipe(t *testing.T) {
-	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1")
+	t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", "1") // numeric form also valid
 
 	targeted := NewRecipeBuilder().Name("agent-control").Build()
 
@@ -192,6 +192,23 @@ func TestSkipAutodiscoveryEnvVar_IncludesTargetedRecipe(t *testing.T) {
 	detector := b.Build()
 
 	require.True(t, detector.shouldDiscover(targeted), "targeted recipe should be discovered")
+}
+
+func TestSkipAutodiscoveryEnvVar_AcceptsTrueString(t *testing.T) {
+	// Regression test: PowerShell users naturally set env vars to 'true' not '1'.
+	// strconv.ParseBool handles both, plus TRUE, T, t, etc.
+	for _, val := range []string{"true", "TRUE", "True", "1", "t", "T"} {
+		t.Setenv("NEW_RELIC_SKIP_AUTODISCOVERY", val)
+
+		recipe := NewRecipeBuilder().Name("other-recipe").Build()
+		b := NewRecipeDetectorTestBuilder()
+		b.WithInstallContext(&types.InstallerContext{RecipeNames: []string{"agent-control"}})
+		b.WithProcessEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+		b.WithScriptEvaluatorRecipeStatus(recipe, execution.RecipeStatusTypes.AVAILABLE)
+		detector := b.Build()
+
+		require.False(t, detector.shouldDiscover(recipe), "should skip non-targeted recipe for env var value %q", val)
+	}
 }
 
 func TestSkipAutodiscoveryEnvVar_NoEffectWithoutTargetedRecipes(t *testing.T) {


### PR DESCRIPTION
## Summary

When running a targeted install (e.g. `newrelic install -n agent-control`), the CLI evaluates `requireAtDiscovery` scripts for all known recipes — currently 87+ — before building the install bundle. This includes expensive checks like the MSSQL registry scan (~2 minutes) even when the user only asked for a single specific recipe.

Setting `NEW_RELIC_SKIP_AUTODISCOVERY=1` (or any truthy value: `true`, `TRUE`, `t`) alongside a `-n` flag now limits discovery to only the explicitly requested recipes. All others immediately return a `NULL` status, which is a no-op in the reporting pipeline, so no existing output or event reporting is affected.

The guard requires both the env var **and** a targeted recipe (`-n` or `-c`). Guided installs — where no recipe is named — are entirely unaffected even if the env var is set, preserving the existing discovery behaviour for interactive users.

`strconv.ParseBool` is used for the truthy check rather than a raw `== "1"` comparison. This was necessary after field testing revealed that PowerShell users naturally write `$env:NEW_RELIC_SKIP_AUTODISCOVERY='true'`, which the original `== "1"` check silently ignored.

Documentation has been added in three places: the `Long` description on the cobra command (visible via `newrelic install --help`), `docs/cli/newrelic_install.md`, and the env var reference table in `docs/GETTING_STARTED.md`.

## Note

The commit `3c1c64c2` includes a `newrelic` binary that was temporarily committed to share a test build with the Agent Control team. This should be removed before merge — either by amending the commit or dropping the file in a follow-up squash.

## Test plan

- [ ] `go test ./internal/install/recipes/... -run "TestRecipeDetector|TestSkipAutodiscovery"` — 13 tests covering the new env var behaviour, truthy value forms, guided install safety, and unchanged default behaviour
- [ ] Manually verified by Agent Control team (Victor Ripoll) against a Windows host running `newrelic install -n agent-control --debug` with `$env:NEW_RELIC_SKIP_AUTODISCOVERY=1` — autodiscovery logs for non-targeted recipes no longer appear