### PR TITLE
fix(ci): add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/cleanup-eu.yml
+++ b/.github/workflows/cleanup-eu.yml
@@ -5,6 +5,9 @@ on:
     workflows: [End to end testing (EU), Release]
     types: [completed]
 
+permissions:
+  contents: read
+
 env:
   workflow_run_id: ${{ github.event.workflow_run.id }}
   config_name: gitusdkrnrclieu${{ github.event.workflow_run.id }}.json

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -5,6 +5,9 @@ on:
     workflows: [End to end testing, Release]
     types: [completed]
 
+permissions:
+  contents: read
+
 env:
   workflow_run_id: ${{ github.event.workflow_run.id }}
   config_name: gitusdkrnrcli${{ github.event.workflow_run.id }}.json

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   # Compile on all supported OSes
   compile:

--- a/.github/workflows/e2e-dp-eu.yml
+++ b/.github/workflows/e2e-dp-eu.yml
@@ -10,6 +10,9 @@ on:
 #    workflows: ["Release"]
 #    types: [requested]
 
+permissions:
+  contents: read
+
 jobs:
   get-test-definition-files:
     name: Get Test Definition Files

--- a/.github/workflows/e2e-dp-us.yml
+++ b/.github/workflows/e2e-dp-us.yml
@@ -10,6 +10,9 @@ on:
 #    workflows: ["Release"]
 #    types: [requested]
 
+permissions:
+  contents: read
+
 jobs:
   get-test-definition-files:
     name: Get Test Definition Files

--- a/.github/workflows/e2e-eu.yml
+++ b/.github/workflows/e2e-eu.yml
@@ -9,6 +9,9 @@ on:
     workflows: ["Release"]
     types: [requested]
 
+permissions:
+  contents: read
+
 jobs:
   get-test-definition-files:
     name: Get Test Definition Files

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,6 +9,9 @@ on:
     workflows: ["Release"]
     types: [requested]
 
+permissions:
+  contents: read
+
 jobs:
   get-test-definition-files:
     name: Get Test Definition Files

--- a/.github/workflows/newrelic_homebrew_core_rebase.yml
+++ b/.github/workflows/newrelic_homebrew_core_rebase.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   update-newrelic-homebrew-core:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-oil-then-cli.yml
+++ b/.github/workflows/release-oil-then-cli.yml
@@ -12,6 +12,10 @@ on:
         required: true
         type: string
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   coordinator:
     name: Publish OIL Tag & Release CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ on:
       NEW_RELIC_REGION:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tutone.yml
+++ b/.github/workflows/tutone.yml
@@ -2,6 +2,9 @@ name: Tutone Generate
 
 on: [ workflow_dispatch ]
 
+permissions:
+  contents: read
+
 jobs:
   createPullRequest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves NR-560197 — CodeQL flagged 17 `actions/missing-workflow-permissions` alerts across 11 workflow files.

## Summary

- Added least-privilege `permissions:` blocks at the workflow level for all 11 affected files                                                                                                                                                                                            
- 10 workflows need read-only access: `contents: read`                                                                                                                                                         
- `release-oil-then-cli.yml` also needs `actions: write` to trigger and list workflow runs via `gh workflow run` / `gh run list` using `GITHUB_TOKEN`