### PR TITLE
feat(iam): add usermanagement and accessmanagement CLI commands

### DIFF
--- a/cmd/newrelic/main.go
+++ b/cmd/newrelic/main.go
@@ -9,6 +9,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	// Commands
+	"github.com/newrelic/newrelic-cli/internal/accessmanagement"
 	"github.com/newrelic/newrelic-cli/internal/agent"
 	"github.com/newrelic/newrelic-cli/internal/apiaccess"
 	"github.com/newrelic/newrelic-cli/internal/apm"
@@ -31,6 +32,7 @@ import (
 	"github.com/newrelic/newrelic-cli/internal/profile"
 	"github.com/newrelic/newrelic-cli/internal/reporting"
 	"github.com/newrelic/newrelic-cli/internal/synthetics"
+	"github.com/newrelic/newrelic-cli/internal/usermanagement"
 	"github.com/newrelic/newrelic-cli/internal/utils"
 	"github.com/newrelic/newrelic-cli/internal/workload"
 )
@@ -41,6 +43,7 @@ var (
 
 func init() {
 	// Bind imported sub-commands
+	Command.AddCommand(accessmanagement.Command)
 	Command.AddCommand(agent.Command)
 	Command.AddCommand(apiaccess.Command)
 	Command.AddCommand(synthetics.Command)
@@ -60,6 +63,7 @@ func init() {
 	Command.AddCommand(migrate.Command)
 	Command.AddCommand(profile.Command)
 	Command.AddCommand(reporting.Command)
+	Command.AddCommand(usermanagement.Command)
 	Command.AddCommand(utils.Command)
 	Command.AddCommand(workload.Command)
 

--- a/internal/accessmanagement/README.md
+++ b/internal/accessmanagement/README.md
@@ -1,0 +1,360 @@
+# Access Management CLI - Command Reference
+
+A command-line interface for managing New Relic access grants, roles, and permissions. These commands correspond to the **Access Management** section of the New Relic Administration UI.
+
+Access management covers what groups can access — the roles they hold and the accounts or organization they hold them in. To manage the users and groups that receive access, see the [User Management CLI](../usermanagement/README.md).
+
+## Table of Contents
+
+- [Command Hierarchy](#command-hierarchy)
+- [Prerequisites](#prerequisites)
+- [Command Reference](#command-reference)
+  - [Grant Commands](#grant-commands)
+  - [Role Commands](#role-commands)
+  - [Permission Commands](#permission-commands)
+- [Working with JSON Responses](#working-with-json-responses)
+- [End-to-End Workflow](#end-to-end-workflow)
+- [Directory Structure](#directory-structure)
+- [Additional Resources](#additional-resources)
+
+---
+
+## Command Hierarchy
+
+```
+newrelic accessmanagement
+├── grants
+│   ├── get     # Retrieve access grants, optionally filtered by group
+│   ├── create  # Grant a role to a group (account or organization scope)
+│   └── revoke  # Revoke a role from a group
+│
+├── roles
+│   └── get     # Retrieve available roles, optionally filtered by name or group
+│
+└── permissions
+    └── get     # Retrieve permissions, optionally filtered by role or scope
+```
+
+---
+
+## Prerequisites
+
+### Required Environment Variables
+
+```bash
+export NEW_RELIC_API_KEY="NRAK-YOUR-API-KEY-HERE"
+export NEW_RELIC_ACCOUNT_ID="your-account-id"
+```
+
+### Required Permissions
+
+Your API key must belong to a user with the **Organization manager** role. Read operations (grants get, roles get, permissions get) require at minimum the **Authentication domain read-only** capability.
+
+### Key IDs You Will Need
+
+- **Group ID** — from `newrelic usermanagement groups get`
+- **Role ID** — from `newrelic accessmanagement roles get`
+- **Account ID** — your New Relic account number (required for account-scoped grants)
+
+---
+
+## Command Reference
+
+### Grant Commands
+
+#### `accessmanagement grants get` - Retrieve access grants
+
+Returns all access grants in your organization, with an optional filter by group.
+
+**Optional Flags:**
+- `--groupId` - Filter grants by group ID
+
+**Examples:**
+
+```bash
+# Get all grants
+newrelic accessmanagement grants get
+
+# Get grants for a specific group
+newrelic accessmanagement grants get --groupId <groupId>
+```
+
+**Response:**
+```json
+{
+  "grants": [
+    {
+      "groupId": "group-123",
+      "roleId": "role-456",
+      "roleType": "ORGANIZATION",
+      "accountId": null,
+      "displayName": "All product admin"
+    },
+    {
+      "groupId": "group-123",
+      "roleId": "role-789",
+      "roleType": "ACCOUNT",
+      "accountId": 12345678,
+      "displayName": "Standard user"
+    }
+  ]
+}
+```
+
+---
+
+#### `accessmanagement grants create` - Create an access grant
+
+Grants a role to a group. You must specify whether the grant applies to a specific account or to the entire organization.
+
+**Required Flags:**
+- `--groupId` - Group ID
+- `--roleId` - Role ID
+- `--scope` - Grant scope: `account` or `organization`
+
+**Optional Flags:**
+- `--accountId` - Account ID (required when `--scope` is `account`)
+
+**Examples:**
+
+```bash
+# Grant account-scoped access
+newrelic accessmanagement grants create \
+  --groupId <groupId> \
+  --roleId <roleId> \
+  --scope account \
+  --accountId 12345678
+
+# Grant organization-scoped access
+newrelic accessmanagement grants create \
+  --groupId <groupId> \
+  --roleId <roleId> \
+  --scope organization
+```
+
+**Response:**
+```json
+{
+  "roles": [
+    {
+      "displayName": "Standard user",
+      "organizationId": "org-abc123",
+      "roleId": "role-789",
+      "roleType": "ACCOUNT"
+    }
+  ]
+}
+```
+
+---
+
+#### `accessmanagement grants revoke` - Revoke an access grant
+
+Removes a role from a group. The group's users immediately lose any access that role provided.
+
+**Required Flags:**
+- `--groupId` - Group ID
+- `--roleId` - Role ID
+- `--scope` - Grant scope: `account` or `organization`
+
+**Optional Flags:**
+- `--accountId` - Account ID (required when `--scope` is `account`)
+
+**Examples:**
+
+```bash
+# Revoke account-scoped access
+newrelic accessmanagement grants revoke \
+  --groupId <groupId> \
+  --roleId <roleId> \
+  --scope account \
+  --accountId 12345678
+
+# Revoke organization-scoped access
+newrelic accessmanagement grants revoke \
+  --groupId <groupId> \
+  --roleId <roleId> \
+  --scope organization
+```
+
+**Response:** Prints `success` on completion.
+
+---
+
+### Role Commands
+
+#### `accessmanagement roles get` - Retrieve roles
+
+Returns all roles available in your organization. Use this to find the role ID you need for grant operations.
+
+**Optional Flags:**
+- `--name` - Filter by role name (partial match, case-insensitive)
+- `--groupId` - Filter to roles currently granted to a specific group
+
+**Examples:**
+
+```bash
+# Get all roles
+newrelic accessmanagement roles get
+
+# Filter by name (partial match)
+newrelic accessmanagement roles get --name "Admin"
+
+# Find roles already granted to a group
+newrelic accessmanagement roles get --groupId <groupId>
+```
+
+**Response:**
+```json
+{
+  "roles": [
+    {
+      "id": "role-456",
+      "displayName": "All product admin",
+      "name": "all_product_admin",
+      "type": "ORGANIZATION",
+      "scope": "organization",
+      "organizationId": "org-abc123"
+    },
+    {
+      "id": "role-789",
+      "displayName": "Standard user",
+      "name": "standard_user",
+      "type": "ACCOUNT",
+      "scope": "account",
+      "organizationId": "org-abc123"
+    }
+  ]
+}
+```
+
+---
+
+### Permission Commands
+
+#### `accessmanagement permissions get` - Retrieve permissions
+
+Returns all permissions in your organization, optionally filtered by role or scope. Permissions represent individual capabilities that are bundled into roles.
+
+**Optional Flags:**
+- `--roleId` - Filter by role ID
+- `--scope` - Filter by scope: `account` or `organization`
+
+**Examples:**
+
+```bash
+# Get all permissions
+newrelic accessmanagement permissions get
+
+# Get permissions for a specific role
+newrelic accessmanagement permissions get --roleId <roleId>
+
+# Get only account-scoped permissions
+newrelic accessmanagement permissions get --scope account
+
+# Combine filters
+newrelic accessmanagement permissions get --roleId <roleId> --scope account
+```
+
+**Response:**
+```json
+{
+  "permissions": [
+    {
+      "category": "ALERTS",
+      "feature": "alerts_conditions",
+      "id": "perm-001",
+      "scope": "account"
+    },
+    {
+      "category": "ENTITY_EXPLORER",
+      "feature": "workloads",
+      "id": "perm-002",
+      "scope": "account"
+    }
+  ]
+}
+```
+
+---
+
+## Working with JSON Responses
+
+```bash
+# Get a role ID by name
+newrelic accessmanagement roles get --name "Standard user" \
+  | jq -r '.roles[] | select(.displayName == "Standard user") | .id'
+
+# List all role IDs and display names
+newrelic accessmanagement roles get \
+  | jq -r '.roles[] | "\(.id)\t\(.displayName)"'
+
+# Get all grants for a group (group ID from usermanagement)
+GROUP_ID=$(newrelic usermanagement groups get \
+  --authDomainId <authDomainId> --name "Platform Engineers" \
+  | jq -r '.authenticationDomains[].groups.groups[0].id')
+newrelic accessmanagement grants get --groupId "$GROUP_ID"
+
+# List permission categories for a role
+newrelic accessmanagement permissions get --roleId <roleId> \
+  | jq -r '[.permissions[].category] | unique[]'
+```
+
+---
+
+## End-to-End Workflow
+
+The access management workflow begins after you have created users and groups in [usermanagement](../usermanagement/README.md). This section picks up at step 5 of that workflow.
+
+```bash
+# Prerequisites: AUTH_DOMAIN, GROUP_ID, and USER_ID set from usermanagement steps
+# See: usermanagement/README.md#end-to-end-workflow
+
+# 5. Find the role you want to grant
+ROLE_ID=$(newrelic accessmanagement roles get --name "Standard user" \
+  | jq -r '.roles[] | select(.displayName == "Standard user") | .id')
+
+# 6. Grant the group account-scoped access
+newrelic accessmanagement grants create \
+  --groupId "$GROUP_ID" \
+  --roleId "$ROLE_ID" \
+  --scope account \
+  --accountId "$YOUR_ACCOUNT_ID"
+
+# 7. Verify the grant was created
+newrelic accessmanagement grants get --groupId "$GROUP_ID"
+
+# To revoke later:
+newrelic accessmanagement grants revoke \
+  --groupId "$GROUP_ID" \
+  --roleId "$ROLE_ID" \
+  --scope account \
+  --accountId "$YOUR_ACCOUNT_ID"
+```
+
+For steps 1–4 (creating users and groups), see [usermanagement — End-to-End Workflow](../usermanagement/README.md#end-to-end-workflow).
+
+---
+
+## Directory Structure
+
+```
+internal/accessmanagement/
+├── README.md                     # This file
+├── command.go                    # Root command and shared flag variables
+├── command_grants.go             # Grant get/create/revoke commands
+├── command_roles.go              # Role get command
+├── command_permissions.go        # Permission get command
+├── command_grants_test.go
+├── command_roles_test.go
+└── command_permissions_test.go
+```
+
+---
+
+## Additional Resources
+
+- [New Relic Access Management Documentation](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/#where)
+- [Roles and Permissions Reference](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-concepts/#roles)
+- [User Management CLI](../usermanagement/README.md) — create the users and groups that receive the access grants you configure here
+- [New Relic CLI Overview](https://github.com/newrelic/newrelic-cli)

--- a/internal/accessmanagement/command.go
+++ b/internal/accessmanagement/command.go
@@ -1,0 +1,18 @@
+package accessmanagement
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	groupID    string
+	roleID     string
+	grantScope string
+	accountID  int
+)
+
+// Command represents the accessmanagement command.
+var Command = &cobra.Command{
+	Use:   "accessmanagement",
+	Short: "Manage New Relic access grants, roles, and permissions.",
+}

--- a/internal/accessmanagement/command_grants.go
+++ b/internal/accessmanagement/command_grants.go
@@ -1,0 +1,160 @@
+package accessmanagement
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/authorizationmanagement"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/customeradministration"
+)
+
+var cmdGrants = &cobra.Command{
+	Use:     "grants",
+	Short:   "Manage access grants.",
+	Example: "newrelic accessmanagement grants --help",
+	Long:    `Manage role access grants for New Relic groups.`,
+}
+
+var cmdGrantsGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve access grants.",
+	Long: `Retrieve access grants.
+
+Returns access grants, optionally filtered by group ID.
+`,
+	Example: `
+  # Get all grants
+  newrelic accessmanagement grants get
+
+  # Get grants for a specific group
+  newrelic accessmanagement grants get --groupId <groupId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		filter := customeradministration.MultiTenantAuthorizationGrantFilterInputExpression{}
+
+		if groupID != "" {
+			filter.GroupId = &customeradministration.MultiTenantAuthorizationGrantGroupIdInputFilter{
+				Eq: groupID,
+			}
+		}
+
+		resp, err := client.NRClient.CustomerAdministration.GetGrantsWithContext(utils.SignalCtx, "", filter, nil)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGrantsCreate = &cobra.Command{
+	Use:   "create",
+	Short: "Create an access grant for a group.",
+	Long: `Create an access grant for a group.
+
+Grants the specified role to a group. Use --scope account with --accountId for
+account-scoped access, or --scope organization for organization-scoped access.
+`,
+	Example: `
+  # Grant account-scoped access
+  newrelic accessmanagement grants create --groupId <groupId> --roleId <roleId> --scope account --accountId 12345678
+
+  # Grant organization-scoped access
+  newrelic accessmanagement grants create --groupId <groupId> --roleId <roleId> --scope organization
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := authorizationmanagement.AuthorizationManagementGrantAccess{
+			GroupId: groupID,
+		}
+
+		switch grantScope {
+		case "account":
+			if accountID == 0 {
+				log.Fatal("--accountId is required when --scope is account")
+			}
+			input.AccountAccessGrants = []authorizationmanagement.AuthorizationManagementAccountAccessGrant{
+				{AccountID: accountID, RoleId: roleID},
+			}
+		case "organization":
+			input.OrganizationAccessGrants = []authorizationmanagement.AuthorizationManagementOrganizationAccessGrant{
+				{RoleId: roleID},
+			}
+		default:
+			log.Fatal("--scope must be one of: account, organization")
+		}
+
+		resp, err := client.NRClient.AuthorizationManagement.AuthorizationManagementGrantAccessWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGrantsRevoke = &cobra.Command{
+	Use:   "revoke",
+	Short: "Revoke an access grant from a group.",
+	Long: `Revoke an access grant from a group.
+
+Revokes the specified role from a group. Use --scope account with --accountId
+for account-scoped access, or --scope organization for organization-scoped access.
+`,
+	Example: `
+  # Revoke account-scoped access
+  newrelic accessmanagement grants revoke --groupId <groupId> --roleId <roleId> --scope account --accountId 12345678
+
+  # Revoke organization-scoped access
+  newrelic accessmanagement grants revoke --groupId <groupId> --roleId <roleId> --scope organization
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := authorizationmanagement.AuthorizationManagementRevokeAccess{
+			GroupId: groupID,
+		}
+
+		switch grantScope {
+		case "account":
+			if accountID == 0 {
+				log.Fatal("--accountId is required when --scope is account")
+			}
+			input.AccountAccessGrants = []authorizationmanagement.AuthorizationManagementAccountAccessGrant{
+				{AccountID: accountID, RoleId: roleID},
+			}
+		case "organization":
+			input.OrganizationAccessGrants = []authorizationmanagement.AuthorizationManagementOrganizationAccessGrant{
+				{RoleId: roleID},
+			}
+		default:
+			log.Fatal("--scope must be one of: account, organization")
+		}
+
+		_, err := client.NRClient.AuthorizationManagement.AuthorizationManagementRevokeAccessWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		log.Info("success")
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdGrants)
+
+	cmdGrants.AddCommand(cmdGrantsGet)
+	cmdGrantsGet.Flags().StringVar(&groupID, "groupId", "", "filter by group ID")
+
+	cmdGrants.AddCommand(cmdGrantsCreate)
+	cmdGrantsCreate.Flags().StringVar(&groupID, "groupId", "", "the ID of the group to grant access to")
+	cmdGrantsCreate.Flags().StringVar(&roleID, "roleId", "", "the ID of the role to grant")
+	cmdGrantsCreate.Flags().StringVar(&grantScope, "scope", "", "the scope of the grant: account or organization")
+	cmdGrantsCreate.Flags().IntVar(&accountID, "accountId", 0, "the account ID (required when scope is account)")
+	utils.LogIfError(cmdGrantsCreate.MarkFlagRequired("groupId"))
+	utils.LogIfError(cmdGrantsCreate.MarkFlagRequired("roleId"))
+	utils.LogIfError(cmdGrantsCreate.MarkFlagRequired("scope"))
+
+	cmdGrants.AddCommand(cmdGrantsRevoke)
+	cmdGrantsRevoke.Flags().StringVar(&groupID, "groupId", "", "the ID of the group to revoke access from")
+	cmdGrantsRevoke.Flags().StringVar(&roleID, "roleId", "", "the ID of the role to revoke")
+	cmdGrantsRevoke.Flags().StringVar(&grantScope, "scope", "", "the scope of the grant: account or organization")
+	cmdGrantsRevoke.Flags().IntVar(&accountID, "accountId", 0, "the account ID (required when scope is account)")
+	utils.LogIfError(cmdGrantsRevoke.MarkFlagRequired("groupId"))
+	utils.LogIfError(cmdGrantsRevoke.MarkFlagRequired("roleId"))
+	utils.LogIfError(cmdGrantsRevoke.MarkFlagRequired("scope"))
+}

--- a/internal/accessmanagement/command_grants_test.go
+++ b/internal/accessmanagement/command_grants_test.go
@@ -1,0 +1,29 @@
+//go:build unit
+
+package accessmanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestGrantsGet(t *testing.T) {
+	assert.Equal(t, "get", cmdGrantsGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdGrantsGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdGrantsGet, []string{})
+}
+
+func TestGrantsCreate(t *testing.T) {
+	assert.Equal(t, "create", cmdGrantsCreate.Name())
+	testcobra.CheckCobraMetadata(t, cmdGrantsCreate)
+	testcobra.CheckCobraRequiredFlags(t, cmdGrantsCreate, []string{"groupId", "roleId", "scope"})
+}
+
+func TestGrantsRevoke(t *testing.T) {
+	assert.Equal(t, "revoke", cmdGrantsRevoke.Name())
+	testcobra.CheckCobraMetadata(t, cmdGrantsRevoke)
+	testcobra.CheckCobraRequiredFlags(t, cmdGrantsRevoke, []string{"groupId", "roleId", "scope"})
+}

--- a/internal/accessmanagement/command_permissions.go
+++ b/internal/accessmanagement/command_permissions.go
@@ -1,0 +1,65 @@
+package accessmanagement
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/customeradministration"
+)
+
+var (
+	permissionScope string
+)
+
+var cmdPermissions = &cobra.Command{
+	Use:     "permissions",
+	Short:   "View permissions available for roles.",
+	Example: "newrelic accessmanagement permissions --help",
+	Long:    `View New Relic permissions available for roles.`,
+}
+
+var cmdPermissionsGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve permissions available in your organization.",
+	Long: `Retrieve permissions available in your organization.
+
+Returns all permissions, optionally filtered by role ID or scope.
+Valid scope values are "account" and "organization".
+`,
+	Example: `
+  # Get all permissions
+  newrelic accessmanagement permissions get
+
+  # Get permissions for a specific role
+  newrelic accessmanagement permissions get --roleId <roleId>
+
+  # Get permissions filtered by scope
+  newrelic accessmanagement permissions get --scope account
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		filter := customeradministration.MultiTenantAuthorizationPermissionFilter{}
+
+		if roleID != "" {
+			filter.RoleId = customeradministration.MultiTenantAuthorizationPermissionFilterRoleIdInput{Eq: roleID}
+		}
+
+		if permissionScope != "" {
+			filter.Scope = customeradministration.MultiTenantAuthorizationPermissionFilterScopeInput{Eq: permissionScope}
+		}
+
+		resp, err := client.NRClient.CustomerAdministration.GetPermissionsWithContext(utils.SignalCtx, "", filter)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdPermissions)
+
+	cmdPermissions.AddCommand(cmdPermissionsGet)
+	cmdPermissionsGet.Flags().StringVar(&roleID, "roleId", "", "filter by role ID")
+	cmdPermissionsGet.Flags().StringVar(&permissionScope, "scope", "", "filter by scope: account or organization")
+}

--- a/internal/accessmanagement/command_permissions_test.go
+++ b/internal/accessmanagement/command_permissions_test.go
@@ -1,0 +1,17 @@
+//go:build unit
+
+package accessmanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestPermissionsGet(t *testing.T) {
+	assert.Equal(t, "get", cmdPermissionsGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdPermissionsGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdPermissionsGet, []string{})
+}

--- a/internal/accessmanagement/command_roles.go
+++ b/internal/accessmanagement/command_roles.go
@@ -1,0 +1,69 @@
+package accessmanagement
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/customeradministration"
+)
+
+var (
+	roleName string
+)
+
+var cmdRoles = &cobra.Command{
+	Use:     "roles",
+	Short:   "View roles available in your organization.",
+	Example: "newrelic accessmanagement roles --help",
+	Long:    `View New Relic roles available for access grants.`,
+}
+
+var cmdRolesGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve roles available in your organization.",
+	Long: `Retrieve roles available in your organization.
+
+Returns all roles, optionally filtered by name or group. Role IDs are used
+when creating or revoking access grants.
+`,
+	Example: `
+  # Get all roles
+  newrelic accessmanagement roles get
+
+  # Filter by name (partial match)
+  newrelic accessmanagement roles get --name "Admin"
+
+  # Filter by group (roles granted to a specific group)
+  newrelic accessmanagement roles get --groupId <groupId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		filter := customeradministration.MultiTenantAuthorizationRoleFilterInputExpression{}
+
+		if roleName != "" {
+			filter.Name = &customeradministration.MultiTenantAuthorizationRoleNameInputFilter{
+				Contains: roleName,
+			}
+		}
+
+		if groupID != "" {
+			filter.GroupId = &customeradministration.MultiTenantAuthorizationRoleGroupIdInputFilter{
+				Eq: groupID,
+			}
+		}
+
+		resp, err := client.NRClient.CustomerAdministration.GetRolesWithContext(utils.SignalCtx, "", filter, nil)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdRoles)
+
+	cmdRoles.AddCommand(cmdRolesGet)
+	cmdRolesGet.Flags().StringVar(&roleName, "name", "", "filter by role name (partial match)")
+	cmdRolesGet.Flags().StringVar(&groupID, "groupId", "", "filter by group ID (roles granted to this group)")
+}

--- a/internal/accessmanagement/command_roles_test.go
+++ b/internal/accessmanagement/command_roles_test.go
@@ -1,0 +1,17 @@
+//go:build unit
+
+package accessmanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestRolesGet(t *testing.T) {
+	assert.Equal(t, "get", cmdRolesGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdRolesGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdRolesGet, []string{})
+}

--- a/internal/usermanagement/README.md
+++ b/internal/usermanagement/README.md
@@ -1,0 +1,536 @@
+# User Management CLI - Command Reference
+
+A command-line interface for managing New Relic users, groups, and authentication domains. These commands correspond to the **User Management** section of the New Relic Administration UI.
+
+User management covers the creation and lifecycle of users and groups within your organization's authentication domains. To manage what those groups can access — roles, grants, and permissions — see the [Access Management CLI](../accessmanagement/README.md).
+
+## Table of Contents
+
+- [Command Hierarchy](#command-hierarchy)
+- [Prerequisites](#prerequisites)
+- [Command Reference](#command-reference)
+  - [User Commands](#user-commands)
+  - [Group Commands](#group-commands)
+  - [Group Membership Commands](#group-membership-commands)
+  - [Authentication Domain Commands](#authentication-domain-commands)
+- [Working with JSON Responses](#working-with-json-responses)
+- [End-to-End Workflow](#end-to-end-workflow)
+- [Directory Structure](#directory-structure)
+- [Additional Resources](#additional-resources)
+
+---
+
+## Command Hierarchy
+
+```
+newrelic usermanagement
+├── users
+│   ├── get        # Retrieve users from an authentication domain
+│   ├── create     # Create a new user
+│   ├── update     # Update an existing user
+│   └── delete     # Delete a user
+│
+├── groups
+│   ├── get        # Retrieve groups and their members
+│   ├── create     # Create a new group
+│   ├── update     # Update a group's display name
+│   ├── delete     # Delete a group
+│   └── members
+│       ├── add    # Add a user to a group
+│       └── remove # Remove a user from a group
+│
+└── auth-domains
+    └── get        # Retrieve authentication domains
+```
+
+---
+
+## Prerequisites
+
+### Required Environment Variables
+
+```bash
+export NEW_RELIC_API_KEY="NRAK-YOUR-API-KEY-HERE"
+export NEW_RELIC_ACCOUNT_ID="your-account-id"
+```
+
+### Required Permissions
+
+Your API key must belong to a user with the **Authentication domain manager** or **Organization manager** role. Read-only operations require at minimum the **Authentication domain read-only** capability.
+
+### Finding Your Authentication Domain ID
+
+Most commands that create or query users and groups require an authentication domain ID. Retrieve yours with:
+
+```bash
+newrelic usermanagement auth-domains get
+```
+
+The `id` field in the response is what you pass as `--authDomainId` to other commands.
+
+---
+
+## Command Reference
+
+### User Commands
+
+#### `usermanagement users get` - Retrieve users
+
+Returns users from the specified authentication domain, with optional filters by user ID, email, or name.
+
+**Required Flags:**
+- `--authDomainId` - Authentication domain ID
+
+**Optional Flags:**
+- `--id` - Filter by user ID
+- `--email` - Filter by email address (exact match)
+- `--name` - Filter by name (exact match)
+
+**Examples:**
+
+```bash
+# Get all users in a domain
+newrelic usermanagement users get --authDomainId <authDomainId>
+
+# Filter by email
+newrelic usermanagement users get \
+  --authDomainId <authDomainId> \
+  --email user@example.com
+
+# Filter by user ID
+newrelic usermanagement users get \
+  --authDomainId <authDomainId> \
+  --id <userId>
+```
+
+**Response:**
+```json
+{
+  "authenticationDomains": [
+    {
+      "id": "<authDomainId>",
+      "name": "Default",
+      "users": {
+        "users": [
+          {
+            "id": "1234567",
+            "name": "Jane Smith",
+            "email": "jane@example.com",
+            "type": { "displayName": "Full platform", "id": "2" },
+            "lastActive": "2026-05-01T10:00:00Z",
+            "emailVerificationState": "Verified"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+#### `usermanagement users create` - Create a user
+
+Creates a new user in the specified authentication domain. The user receives an email invitation to set their password.
+
+**Required Flags:**
+- `--authDomainId` - Authentication domain ID
+- `--email` - User's email address
+- `--name` - User's full name
+
+**Optional Flags:**
+- `--userType` - User type: `BASIC_USER_TIER`, `CORE_USER_TIER`, or `FULL_USER_TIER`
+
+**Examples:**
+
+```bash
+# Create a full platform user
+newrelic usermanagement users create \
+  --authDomainId <authDomainId> \
+  --email jane@example.com \
+  --name "Jane Smith" \
+  --userType FULL_USER_TIER
+
+# Create a basic user
+newrelic usermanagement users create \
+  --authDomainId <authDomainId> \
+  --email dev@example.com \
+  --name "Dev User" \
+  --userType BASIC_USER_TIER
+```
+
+**Response:**
+```json
+{
+  "createdUser": {
+    "authenticationDomainId": "<authDomainId>",
+    "email": "jane@example.com",
+    "id": "7654321",
+    "name": "Jane Smith",
+    "type": { "displayName": "Full platform", "id": "2" }
+  }
+}
+```
+
+---
+
+#### `usermanagement users update` - Update a user
+
+Updates one or more fields on an existing user. Only the fields you provide are changed.
+
+**Required Flags:**
+- `--id` - User ID
+
+**Optional Flags:**
+- `--name` - New full name
+- `--email` - New email address
+- `--userType` - New user type: `BASIC_USER_TIER`, `CORE_USER_TIER`, or `FULL_USER_TIER`
+- `--timeZone` - Timezone string (e.g., `America/Chicago`)
+
+**Examples:**
+
+```bash
+# Upgrade user type
+newrelic usermanagement users update \
+  --id <userId> \
+  --userType FULL_USER_TIER
+
+# Update name and timezone
+newrelic usermanagement users update \
+  --id <userId> \
+  --name "Jane Smith-Jones" \
+  --timeZone America/Los_Angeles
+```
+
+**Response:**
+```json
+{
+  "user": {
+    "id": "7654321",
+    "name": "Jane Smith-Jones",
+    "email": "jane@example.com",
+    "type": { "displayName": "Full platform", "id": "2" },
+    "timeZone": "America/Los_Angeles"
+  }
+}
+```
+
+---
+
+#### `usermanagement users delete` - Delete a user
+
+Permanently removes a user from your organization. This action cannot be undone.
+
+**Required Flags:**
+- `--id` - User ID
+
+**Examples:**
+
+```bash
+newrelic usermanagement users delete --id <userId>
+```
+
+**Response:** Prints `success` on completion.
+
+---
+
+### Group Commands
+
+#### `usermanagement groups get` - Retrieve groups
+
+Returns groups and their members from the specified authentication domain.
+
+**Required Flags:**
+- `--authDomainId` - Authentication domain ID
+
+**Optional Flags:**
+- `--id` - Filter by group ID
+- `--name` - Filter by group display name (exact match)
+
+**Examples:**
+
+```bash
+# Get all groups in a domain
+newrelic usermanagement groups get --authDomainId <authDomainId>
+
+# Filter by name
+newrelic usermanagement groups get \
+  --authDomainId <authDomainId> \
+  --name "Developers"
+```
+
+**Response:**
+```json
+{
+  "authenticationDomains": [
+    {
+      "id": "<authDomainId>",
+      "name": "Default",
+      "groups": {
+        "groups": [
+          {
+            "id": "group-123",
+            "displayName": "Developers",
+            "users": {
+              "users": [
+                { "id": "7654321", "email": "jane@example.com", "name": "Jane Smith" }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+#### `usermanagement groups create` - Create a group
+
+Creates a new group in the specified authentication domain.
+
+**Required Flags:**
+- `--authDomainId` - Authentication domain ID
+- `--name` - Display name for the group
+
+**Examples:**
+
+```bash
+newrelic usermanagement groups create \
+  --authDomainId <authDomainId> \
+  --name "Developers"
+```
+
+**Response:**
+```json
+{
+  "group": {
+    "id": "group-123",
+    "displayName": "Developers"
+  }
+}
+```
+
+---
+
+#### `usermanagement groups update` - Update a group
+
+Updates the display name of an existing group.
+
+**Required Flags:**
+- `--id` - Group ID
+- `--name` - New display name
+
+**Examples:**
+
+```bash
+newrelic usermanagement groups update \
+  --id <groupId> \
+  --name "Senior Developers"
+```
+
+**Response:**
+```json
+{
+  "group": {
+    "id": "group-123",
+    "displayName": "Senior Developers"
+  }
+}
+```
+
+---
+
+#### `usermanagement groups delete` - Delete a group
+
+Permanently removes a group. Users in the group are not deleted, but they lose any access grants associated with the group. See [Access Management](../accessmanagement/README.md) for grant details.
+
+**Required Flags:**
+- `--id` - Group ID
+
+**Examples:**
+
+```bash
+newrelic usermanagement groups delete --id <groupId>
+```
+
+**Response:** Prints `success` on completion.
+
+---
+
+### Group Membership Commands
+
+#### `usermanagement groups members add` - Add a user to a group
+
+Adds a user to a group. Users inherit any access grants assigned to the group — see [accessmanagement grants get](../accessmanagement/README.md#accessmanagement-grants-get---retrieve-access-grants) to view what a group has access to.
+
+**Required Flags:**
+- `--groupId` - Group ID
+- `--userId` - User ID
+
+**Examples:**
+
+```bash
+newrelic usermanagement groups members add \
+  --groupId <groupId> \
+  --userId <userId>
+```
+
+**Response:**
+```json
+{
+  "groups": [
+    {
+      "id": "group-123",
+      "displayName": "Platform Engineers",
+      "users": {
+        "users": [
+          { "id": "7654321", "email": "jane@example.com", "name": "Jane Smith" }
+        ]
+      }
+    }
+  ]
+}
+```
+
+---
+
+#### `usermanagement groups members remove` - Remove a user from a group
+
+Removes a user from a group. The user loses any access inherited from that group's grants.
+
+**Required Flags:**
+- `--groupId` - Group ID
+- `--userId` - User ID
+
+**Examples:**
+
+```bash
+newrelic usermanagement groups members remove \
+  --groupId <groupId> \
+  --userId <userId>
+```
+
+**Response:** Prints `success` on completion.
+
+---
+
+### Authentication Domain Commands
+
+#### `usermanagement auth-domains get` - Retrieve authentication domains
+
+Returns the authentication domains in your organization. Authentication domains define how users are provisioned and authenticated (SAML, SCIM, username/password, etc.).
+
+**Optional Flags:**
+- `--id` - Filter by authentication domain ID
+
+**Examples:**
+
+```bash
+# Get all authentication domains
+newrelic usermanagement auth-domains get
+
+# Get a specific domain
+newrelic usermanagement auth-domains get --id <authDomainId>
+```
+
+**Response:**
+```json
+{
+  "authenticationDomains": [
+    {
+      "id": "<authDomainId>",
+      "name": "Default",
+      "provisioningType": "MANUAL"
+    }
+  ],
+  "nextCursor": null,
+  "totalCount": 1
+}
+```
+
+---
+
+## Working with JSON Responses
+
+```bash
+# Get all user IDs in a domain
+newrelic usermanagement users get --authDomainId <id> \
+  | jq -r '.authenticationDomains[].users.users[].id'
+
+# Get a user ID by email
+newrelic usermanagement users get \
+  --authDomainId <id> \
+  --email jane@example.com \
+  | jq -r '.authenticationDomains[].users.users[0].id'
+
+# Get all group IDs
+newrelic usermanagement groups get --authDomainId <id> \
+  | jq -r '.authenticationDomains[].groups.groups[] | "\(.id) \(.displayName)"'
+
+# Get your authentication domain ID
+newrelic usermanagement auth-domains get \
+  | jq -r '.authenticationDomains[0].id'
+```
+
+---
+
+## End-to-End Workflow
+
+The typical workflow is: create users and groups here, then grant those groups access to accounts and roles using [accessmanagement](../accessmanagement/README.md).
+
+```bash
+# 1. Find your authentication domain
+AUTH_DOMAIN=$(newrelic usermanagement auth-domains get \
+  | jq -r '.authenticationDomains[0].id')
+
+# 2. Create a group
+GROUP_ID=$(newrelic usermanagement groups create \
+  --authDomainId "$AUTH_DOMAIN" \
+  --name "Platform Engineers" \
+  | jq -r '.group.id')
+
+# 3. Create a user
+USER_ID=$(newrelic usermanagement users create \
+  --authDomainId "$AUTH_DOMAIN" \
+  --email engineer@example.com \
+  --name "Alex Engineer" \
+  --userType FULL_USER_TIER \
+  | jq -r '.createdUser.id')
+
+# 4. Add the user to the group
+newrelic usermanagement groups members add \
+  --groupId "$GROUP_ID" \
+  --userId "$USER_ID"
+
+# 5. Grant the group access to an account with a role
+#    (continues in accessmanagement — see link below)
+```
+
+For step 5, see [accessmanagement grants create](../accessmanagement/README.md#accessmanagement-grants-create---create-an-access-grant).
+
+---
+
+## Directory Structure
+
+```
+internal/usermanagement/
+├── README.md                    # This file
+├── command.go                   # Root command and shared flag variables
+├── command_users.go             # User CRUD commands
+├── command_groups.go            # Group CRUD and membership commands
+├── command_auth_domains.go      # Authentication domain commands
+├── command_users_test.go
+├── command_groups_test.go
+└── command_auth_domains_test.go
+```
+
+---
+
+## Additional Resources
+
+- [New Relic User Management Documentation](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/user-management-ui-and-tasks/)
+- [Authentication Domains](https://docs.newrelic.com/docs/accounts/accounts-billing/new-relic-one-user-management/authentication-domains-saml-sso-scim-more/)
+- [Access Management CLI](../accessmanagement/README.md) — assign roles and grants to the groups you create here
+- [New Relic CLI Overview](https://github.com/newrelic/newrelic-cli)

--- a/internal/usermanagement/command.go
+++ b/internal/usermanagement/command.go
@@ -1,0 +1,22 @@
+package usermanagement
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var (
+	authDomainID string
+	userID       string
+	userEmail    string
+	userName     string
+	userType     string
+	userTimeZone string
+	groupID      string
+	groupName    string
+)
+
+// Command represents the usermanagement command.
+var Command = &cobra.Command{
+	Use:   "usermanagement",
+	Short: "Manage New Relic users, groups, and authentication domains.",
+}

--- a/internal/usermanagement/command_auth_domains.go
+++ b/internal/usermanagement/command_auth_domains.go
@@ -1,0 +1,51 @@
+package usermanagement
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+)
+
+var cmdAuthDomains = &cobra.Command{
+	Use:     "auth-domains",
+	Short:   "View New Relic authentication domains.",
+	Example: "newrelic usermanagement auth-domains --help",
+	Long:    `View New Relic authentication domains in your organization.`,
+}
+
+var cmdAuthDomainsGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve authentication domains in your organization.",
+	Long: `Retrieve authentication domains in your organization.
+
+Returns all authentication domains, or a specific domain when filtered by ID.
+Authentication domains control how users are provisioned and authenticated.
+`,
+	Example: `
+  # Get all authentication domains
+  newrelic usermanagement auth-domains get
+
+  # Get a specific authentication domain by ID
+  newrelic usermanagement auth-domains get --id <authDomainId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		var domainIDs []string
+		if authDomainID != "" {
+			domainIDs = []string{authDomainID}
+		}
+
+		resp, err := client.NRClient.UserManagement.GetAuthenticationDomainsWithContext(utils.SignalCtx, "", domainIDs)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdAuthDomains)
+
+	cmdAuthDomains.AddCommand(cmdAuthDomainsGet)
+	cmdAuthDomainsGet.Flags().StringVar(&authDomainID, "id", "", "filter by authentication domain ID")
+}

--- a/internal/usermanagement/command_auth_domains_test.go
+++ b/internal/usermanagement/command_auth_domains_test.go
@@ -1,0 +1,17 @@
+//go:build unit
+
+package usermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestAuthDomainsGet(t *testing.T) {
+	assert.Equal(t, "get", cmdAuthDomainsGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdAuthDomainsGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdAuthDomainsGet, []string{})
+}

--- a/internal/usermanagement/command_groups.go
+++ b/internal/usermanagement/command_groups.go
@@ -1,0 +1,221 @@
+package usermanagement
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/usermanagement"
+)
+
+var cmdGroups = &cobra.Command{
+	Use:     "groups",
+	Short:   "Manage New Relic groups.",
+	Example: "newrelic usermanagement groups --help",
+	Long:    `Manage New Relic groups within an authentication domain.`,
+}
+
+var cmdGroupsGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve groups and their members from an authentication domain.",
+	Long: `Retrieve groups and their members from an authentication domain.
+
+Returns groups matching the specified filters. At least one authentication
+domain ID is required. Results can be further filtered by group ID or name.
+`,
+	Example: `
+  # Get all groups in an authentication domain
+  newrelic usermanagement groups get --authDomainId <authDomainId>
+
+  # Filter by group name
+  newrelic usermanagement groups get --authDomainId <authDomainId> --name "Developers"
+
+  # Filter by group ID
+  newrelic usermanagement groups get --authDomainId <authDomainId> --id <groupId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		var domainIDs []string
+		if authDomainID != "" {
+			domainIDs = []string{authDomainID}
+		}
+
+		var groupIDs []string
+		if groupID != "" {
+			groupIDs = []string{groupID}
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementGetGroupsWithUsersWithContext(
+			utils.SignalCtx,
+			domainIDs,
+			groupIDs,
+			groupName,
+		)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGroupsCreate = &cobra.Command{
+	Use:   "create",
+	Short: "Create a group in an authentication domain.",
+	Long: `Create a group in an authentication domain.
+
+Creates a new group with the specified display name in the given
+authentication domain.
+`,
+	Example: `
+  newrelic usermanagement groups create --authDomainId <authDomainId> --name "Developers"
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementCreateGroup{
+			AuthenticationDomainId: authDomainID,
+			DisplayName:            groupName,
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementCreateGroupWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGroupsUpdate = &cobra.Command{
+	Use:   "update",
+	Short: "Update an existing group.",
+	Long: `Update an existing group.
+
+Updates the display name of the group with the specified ID.
+`,
+	Example: `
+  newrelic usermanagement groups update --id <groupId> --name "Senior Developers"
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementUpdateGroup{
+			ID:          groupID,
+			DisplayName: groupName,
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementUpdateGroupWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGroupsDelete = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a group.",
+	Long: `Delete a group.
+
+Permanently deletes the group with the specified ID.
+`,
+	Example: `
+  newrelic usermanagement groups delete --id <groupId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementDeleteGroup{
+			ID: groupID,
+		}
+
+		_, err := client.NRClient.UserManagement.UserManagementDeleteGroupWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		log.Info("success")
+	},
+}
+
+var cmdGroupsMembers = &cobra.Command{
+	Use:     "members",
+	Short:   "Manage group membership.",
+	Example: "newrelic usermanagement groups members --help",
+	Long:    `Add or remove users from a group.`,
+}
+
+var cmdGroupsMembersAdd = &cobra.Command{
+	Use:   "add",
+	Short: "Add a user to a group.",
+	Long: `Add a user to a group.
+
+Adds the specified user to the specified group.
+`,
+	Example: `
+  newrelic usermanagement groups members add --groupId <groupId> --userId <userId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementUsersGroupsInput{
+			GroupIds: []string{groupID},
+			UserIDs:  []string{userID},
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementAddUsersToGroupsWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdGroupsMembersRemove = &cobra.Command{
+	Use:   "remove",
+	Short: "Remove a user from a group.",
+	Long: `Remove a user from a group.
+
+Removes the specified user from the specified group.
+`,
+	Example: `
+  newrelic usermanagement groups members remove --groupId <groupId> --userId <userId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementUsersGroupsInput{
+			GroupIds: []string{groupID},
+			UserIDs:  []string{userID},
+		}
+
+		_, err := client.NRClient.UserManagement.UserManagementRemoveUsersFromGroupsWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		log.Info("success")
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdGroups)
+
+	cmdGroups.AddCommand(cmdGroupsGet)
+	cmdGroupsGet.Flags().StringVar(&authDomainID, "authDomainId", "", "the ID of the authentication domain to query")
+	cmdGroupsGet.Flags().StringVar(&groupID, "id", "", "filter by group ID")
+	cmdGroupsGet.Flags().StringVar(&groupName, "name", "", "filter by group display name")
+	utils.LogIfError(cmdGroupsGet.MarkFlagRequired("authDomainId"))
+
+	cmdGroups.AddCommand(cmdGroupsCreate)
+	cmdGroupsCreate.Flags().StringVar(&authDomainID, "authDomainId", "", "the ID of the authentication domain")
+	cmdGroupsCreate.Flags().StringVar(&groupName, "name", "", "the display name for the new group")
+	utils.LogIfError(cmdGroupsCreate.MarkFlagRequired("authDomainId"))
+	utils.LogIfError(cmdGroupsCreate.MarkFlagRequired("name"))
+
+	cmdGroups.AddCommand(cmdGroupsUpdate)
+	cmdGroupsUpdate.Flags().StringVar(&groupID, "id", "", "the ID of the group to update")
+	cmdGroupsUpdate.Flags().StringVar(&groupName, "name", "", "the new display name for the group")
+	utils.LogIfError(cmdGroupsUpdate.MarkFlagRequired("id"))
+	utils.LogIfError(cmdGroupsUpdate.MarkFlagRequired("name"))
+
+	cmdGroups.AddCommand(cmdGroupsDelete)
+	cmdGroupsDelete.Flags().StringVar(&groupID, "id", "", "the ID of the group to delete")
+	utils.LogIfError(cmdGroupsDelete.MarkFlagRequired("id"))
+
+	cmdGroups.AddCommand(cmdGroupsMembers)
+
+	cmdGroupsMembers.AddCommand(cmdGroupsMembersAdd)
+	cmdGroupsMembersAdd.Flags().StringVar(&groupID, "groupId", "", "the ID of the group")
+	cmdGroupsMembersAdd.Flags().StringVar(&userID, "userId", "", "the ID of the user to add")
+	utils.LogIfError(cmdGroupsMembersAdd.MarkFlagRequired("groupId"))
+	utils.LogIfError(cmdGroupsMembersAdd.MarkFlagRequired("userId"))
+
+	cmdGroupsMembers.AddCommand(cmdGroupsMembersRemove)
+	cmdGroupsMembersRemove.Flags().StringVar(&groupID, "groupId", "", "the ID of the group")
+	cmdGroupsMembersRemove.Flags().StringVar(&userID, "userId", "", "the ID of the user to remove")
+	utils.LogIfError(cmdGroupsMembersRemove.MarkFlagRequired("groupId"))
+	utils.LogIfError(cmdGroupsMembersRemove.MarkFlagRequired("userId"))
+}

--- a/internal/usermanagement/command_groups_test.go
+++ b/internal/usermanagement/command_groups_test.go
@@ -1,0 +1,47 @@
+//go:build unit
+
+package usermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestGroupsGet(t *testing.T) {
+	assert.Equal(t, "get", cmdGroupsGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsGet, []string{"authDomainId"})
+}
+
+func TestGroupsCreate(t *testing.T) {
+	assert.Equal(t, "create", cmdGroupsCreate.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsCreate)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsCreate, []string{"authDomainId", "name"})
+}
+
+func TestGroupsUpdate(t *testing.T) {
+	assert.Equal(t, "update", cmdGroupsUpdate.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsUpdate)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsUpdate, []string{"id", "name"})
+}
+
+func TestGroupsDelete(t *testing.T) {
+	assert.Equal(t, "delete", cmdGroupsDelete.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsDelete)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsDelete, []string{"id"})
+}
+
+func TestGroupsMembersAdd(t *testing.T) {
+	assert.Equal(t, "add", cmdGroupsMembersAdd.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsMembersAdd)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsMembersAdd, []string{"groupId", "userId"})
+}
+
+func TestGroupsMembersRemove(t *testing.T) {
+	assert.Equal(t, "remove", cmdGroupsMembersRemove.Name())
+	testcobra.CheckCobraMetadata(t, cmdGroupsMembersRemove)
+	testcobra.CheckCobraRequiredFlags(t, cmdGroupsMembersRemove, []string{"groupId", "userId"})
+}

--- a/internal/usermanagement/command_users.go
+++ b/internal/usermanagement/command_users.go
@@ -1,0 +1,178 @@
+package usermanagement
+
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/usermanagement"
+)
+
+var cmdUsers = &cobra.Command{
+	Use:     "users",
+	Short:   "Manage New Relic users.",
+	Example: "newrelic usermanagement users --help",
+	Long:    `Manage New Relic users within an authentication domain.`,
+}
+
+var cmdUsersGet = &cobra.Command{
+	Use:   "get",
+	Short: "Retrieve users from an authentication domain.",
+	Long: `Retrieve users from an authentication domain.
+
+Returns users matching the specified filters. At least one authentication domain
+ID is required. Results can be further filtered by user ID, email, or name.
+`,
+	Example: `
+  # Get all users in an authentication domain
+  newrelic usermanagement users get --authDomainId <authDomainId>
+
+  # Filter by email
+  newrelic usermanagement users get --authDomainId <authDomainId> --email user@example.com
+
+  # Filter by user ID
+  newrelic usermanagement users get --authDomainId <authDomainId> --id <userId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		var domainIDs []string
+		if authDomainID != "" {
+			domainIDs = []string{authDomainID}
+		}
+
+		var userIDs []string
+		if userID != "" {
+			userIDs = []string{userID}
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementGetUsersWithContext(
+			utils.SignalCtx,
+			domainIDs,
+			userIDs,
+			userName,
+			userEmail,
+		)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdUsersCreate = &cobra.Command{
+	Use:   "create",
+	Short: "Create a user in an authentication domain.",
+	Long: `Create a user in an authentication domain.
+
+Creates a new user in the specified authentication domain. Valid user types
+are BASIC_USER_TIER, CORE_USER_TIER, and FULL_USER_TIER.
+`,
+	Example: `
+  # Create a full platform user
+  newrelic usermanagement users create --authDomainId <authDomainId> --email user@example.com --name "Jane Smith" --userType FULL_USER_TIER
+
+  # Create a basic user
+  newrelic usermanagement users create --authDomainId <authDomainId> --email user@example.com --name "Jane Smith" --userType BASIC_USER_TIER
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementCreateUser{
+			AuthenticationDomainId: authDomainID,
+			Email:                  userEmail,
+			Name:                   userName,
+			UserType:               usermanagement.UserManagementRequestedTierName(userType),
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementCreateUserWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdUsersUpdate = &cobra.Command{
+	Use:   "update",
+	Short: "Update an existing user.",
+	Long: `Update an existing user.
+
+Updates the specified fields on an existing user. Valid user types
+are BASIC_USER_TIER, CORE_USER_TIER, and FULL_USER_TIER.
+`,
+	Example: `
+  # Update a user's name
+  newrelic usermanagement users update --id <userId> --name "New Name"
+
+  # Update user type
+  newrelic usermanagement users update --id <userId> --userType FULL_USER_TIER
+
+  # Update timezone
+  newrelic usermanagement users update --id <userId> --timeZone America/Chicago
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementUpdateUser{
+			ID:       userID,
+			Email:    userEmail,
+			Name:     userName,
+			TimeZone: userTimeZone,
+			UserType: usermanagement.UserManagementRequestedTierName(userType),
+		}
+
+		resp, err := client.NRClient.UserManagement.UserManagementUpdateUserWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		utils.LogIfError(output.Print(resp))
+	},
+}
+
+var cmdUsersDelete = &cobra.Command{
+	Use:   "delete",
+	Short: "Delete a user.",
+	Long: `Delete a user.
+
+Permanently deletes the user with the specified ID.
+`,
+	Example: `
+  newrelic usermanagement users delete --id <userId>
+`,
+	PreRun: client.RequireClient,
+	Run: func(cmd *cobra.Command, args []string) {
+		input := usermanagement.UserManagementDeleteUser{
+			ID: userID,
+		}
+
+		_, err := client.NRClient.UserManagement.UserManagementDeleteUserWithContext(utils.SignalCtx, input)
+		utils.LogIfFatal(err)
+		log.Info("success")
+	},
+}
+
+func init() {
+	Command.AddCommand(cmdUsers)
+
+	cmdUsers.AddCommand(cmdUsersGet)
+	cmdUsersGet.Flags().StringVar(&authDomainID, "authDomainId", "", "the ID of the authentication domain to query")
+	cmdUsersGet.Flags().StringVar(&userID, "id", "", "filter by user ID")
+	cmdUsersGet.Flags().StringVar(&userEmail, "email", "", "filter by email address")
+	cmdUsersGet.Flags().StringVar(&userName, "name", "", "filter by name")
+	utils.LogIfError(cmdUsersGet.MarkFlagRequired("authDomainId"))
+
+	cmdUsers.AddCommand(cmdUsersCreate)
+	cmdUsersCreate.Flags().StringVar(&authDomainID, "authDomainId", "", "the ID of the authentication domain")
+	cmdUsersCreate.Flags().StringVar(&userEmail, "email", "", "the user's email address")
+	cmdUsersCreate.Flags().StringVar(&userName, "name", "", "the user's full name")
+	cmdUsersCreate.Flags().StringVar(&userType, "userType", "", "the user type: BASIC_USER_TIER, CORE_USER_TIER, or FULL_USER_TIER")
+	utils.LogIfError(cmdUsersCreate.MarkFlagRequired("authDomainId"))
+	utils.LogIfError(cmdUsersCreate.MarkFlagRequired("email"))
+	utils.LogIfError(cmdUsersCreate.MarkFlagRequired("name"))
+
+	cmdUsers.AddCommand(cmdUsersUpdate)
+	cmdUsersUpdate.Flags().StringVar(&userID, "id", "", "the ID of the user to update")
+	cmdUsersUpdate.Flags().StringVar(&userEmail, "email", "", "update the user's email address")
+	cmdUsersUpdate.Flags().StringVar(&userName, "name", "", "update the user's full name")
+	cmdUsersUpdate.Flags().StringVar(&userType, "userType", "", "update the user type: BASIC_USER_TIER, CORE_USER_TIER, or FULL_USER_TIER")
+	cmdUsersUpdate.Flags().StringVar(&userTimeZone, "timeZone", "", "update the user's timezone (e.g. America/Chicago)")
+	utils.LogIfError(cmdUsersUpdate.MarkFlagRequired("id"))
+
+	cmdUsers.AddCommand(cmdUsersDelete)
+	cmdUsersDelete.Flags().StringVar(&userID, "id", "", "the ID of the user to delete")
+	utils.LogIfError(cmdUsersDelete.MarkFlagRequired("id"))
+}

--- a/internal/usermanagement/command_users_test.go
+++ b/internal/usermanagement/command_users_test.go
@@ -1,0 +1,35 @@
+//go:build unit
+
+package usermanagement
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/newrelic/newrelic-cli/internal/testcobra"
+)
+
+func TestUsersGet(t *testing.T) {
+	assert.Equal(t, "get", cmdUsersGet.Name())
+	testcobra.CheckCobraMetadata(t, cmdUsersGet)
+	testcobra.CheckCobraRequiredFlags(t, cmdUsersGet, []string{"authDomainId"})
+}
+
+func TestUsersCreate(t *testing.T) {
+	assert.Equal(t, "create", cmdUsersCreate.Name())
+	testcobra.CheckCobraMetadata(t, cmdUsersCreate)
+	testcobra.CheckCobraRequiredFlags(t, cmdUsersCreate, []string{"authDomainId", "email", "name"})
+}
+
+func TestUsersUpdate(t *testing.T) {
+	assert.Equal(t, "update", cmdUsersUpdate.Name())
+	testcobra.CheckCobraMetadata(t, cmdUsersUpdate)
+	testcobra.CheckCobraRequiredFlags(t, cmdUsersUpdate, []string{"id"})
+}
+
+func TestUsersDelete(t *testing.T) {
+	assert.Equal(t, "delete", cmdUsersDelete.Name())
+	testcobra.CheckCobraMetadata(t, cmdUsersDelete)
+	testcobra.CheckCobraRequiredFlags(t, cmdUsersDelete, []string{"id"})
+}


### PR DESCRIPTION
Adds two new top-level commands that expose New Relic user and access management via the CLI.

## Command structure

The command hierarchy mirrors the two distinct sections of the New Relic Administration UI — User Management and Access Management — rather than the underlying SDK package layout. This gives CLI users a mental model consistent with the UI and the product documentation, regardless of how the NerdGraph schema is organized internally.

`usermanagement` (actor.organization.userManagement.*):
- users get/create/update/delete
- groups get/create/update/delete
- groups members add/remove
- auth-domains get

`accessmanagement`:
- grants get/create/revoke
- roles get
- permissions get

## SDK usage in accessmanagement

The Access Management UI makes NerdGraph calls to two different schema roots on the same page: actor.organization.authorizationManagement.* for grant mutations, and customerAdministration.* for reads (grants get, roles get, permissions get). We followed the same split here so CLI behavior matches what users see in the UI:

- grants create/revoke → authorizationManagement SDK
- grants get, roles get, permissions get → customerAdministration SDK

roles get uses customerAdministration specifically because it supports richer filtering (name contains, groupId) compared to the equivalent authorizationManagement method.

## Naming

- "grants create/revoke" follows the CRUD convention used elsewhere in the CLI rather than the SDK's GrantAccess/RevokeAccess naming.
- Flag names use camelCase to match existing CLI conventions (--authDomainId, --groupId, --userId, --roleId).

Includes per-package READMEs with command reference, flag docs, example responses, jq recipes, and an end-to-end workflow that spans both commands — since the natural flow is to create users/groups in usermanagement and then assign access in accessmanagement.