### PR TITLE
fix: bump Go stdlib to 1.26.3 to resolve 21 CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli
 
-go 1.26.1
+go 1.26.3
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
Jira - https://new-relic.atlassian.net/browse/NR-545930

## Summary
                                                                                                                                                                                                                 
  - Bumps `go` directive in `go.mod` from `1.26.1` to `1.26.3`                                                                                                                                                   
  - Resolves all 21 `stdlib` CVEs reported in the 2026-05-14 Trivy/Grype security scan [here](https://github.com/newrelic/newrelic-cli/actions/runs/25836558613) (1 Critical, 12 High, 8 Medium)   
