### PR TITLE
fix(profile): preserve "." in profile names so credentials are stored as a literal key

### DIFF
--- a/internal/config/json_store.go
+++ b/internal/config/json_store.go
@@ -442,9 +442,9 @@ func (p *JSONStore) SetWithScope(scope string, key FieldKey, value interface{}) 
 // the fields that appear underneath it. The resulting config will be persisted to
 // disk if PersistToDisk has been used.
 func (p *JSONStore) RemoveScope(scope string) error {
-	path := scope
+	path := escapePathSegment(scope)
 	if p.scope != "" {
-		path = fmt.Sprintf("%s.%s", p.scope, scope)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(p.scope), path)
 	}
 
 	return p.deletePath(path)
@@ -498,16 +498,28 @@ func (p *JSONStore) GetFieldDefinition(key FieldKey) *FieldDefinition {
 }
 
 func (p *JSONStore) getPath(scope string, key FieldKey) string {
-	path := string(key)
+	path := escapePathSegment(string(key))
 	if scope != "" {
-		path = fmt.Sprintf("%s.%s", scope, key)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(scope), path)
 	}
 
 	if p.scope != "" {
-		path = fmt.Sprintf("%s.%s", p.scope, path)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(p.scope), path)
 	}
 
 	return path
+}
+
+// escapePathSegment escapes the gjson/sjson path separator and escape character
+// inside a single segment so values like profile names containing a "." are
+// stored as a single literal key (e.g. {"first.last": {...}}) rather than as a
+// nested object hierarchy.
+func escapePathSegment(s string) string {
+	// Order matters: escape backslashes first so we don't double-escape the
+	// backslashes we introduce when escaping dots below.
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `.`, `\.`)
+	return s
 }
 
 func (p *JSONStore) deletePath(path string) error {

--- a/internal/config/json_store_test.go
+++ b/internal/config/json_store_test.go
@@ -770,3 +770,70 @@ func TestStore_GetScopes(t *testing.T) {
 	s := p.GetScopes()
 	require.Equal(t, 2, len(s))
 }
+
+// The following tests guard against a regression where scope names containing
+// a "." (e.g. profile names such as "ava.morgan") were treated by gjson/sjson
+// as nested object paths, causing values to be silently lost on read and
+// scopes to disappear from list operations.
+
+func TestStore_SetWithScope_DottedScopeName(t *testing.T) {
+	f, err := ioutil.TempFile("", "newrelic-cli.config_provider_test.*.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	p, err := NewJSONStore(PersistToFile(f.Name()))
+	require.NoError(t, err)
+
+	err = p.SetWithScope("ava.morgan", FieldKey("apiKey"), "NRAK-DOTTED-1")
+	require.NoError(t, err)
+
+	v, err := p.GetStringWithScope("ava.morgan", FieldKey("apiKey"))
+	require.NoError(t, err)
+	require.Equal(t, "NRAK-DOTTED-1", v)
+}
+
+func TestStore_GetScopes_DottedScopeName(t *testing.T) {
+	f, err := ioutil.TempFile("", "newrelic-cli.config_provider_test.*.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	p, err := NewJSONStore(PersistToFile(f.Name()))
+	require.NoError(t, err)
+
+	err = p.SetWithScope("riley.chen", FieldKey("apiKey"), "NRAK-DOTTED-2")
+	require.NoError(t, err)
+	err = p.SetWithScope("prod.us-east-1", FieldKey("apiKey"), "NRAK-DOTTED-3")
+	require.NoError(t, err)
+	err = p.SetWithScope("staging", FieldKey("apiKey"), "NRAK-PLAIN-4")
+	require.NoError(t, err)
+
+	scopes := p.GetScopes()
+	require.ElementsMatch(t,
+		[]string{"riley.chen", "prod.us-east-1", "staging"},
+		scopes,
+	)
+}
+
+func TestStore_RemoveScope_DottedScopeName(t *testing.T) {
+	f, err := ioutil.TempFile("", "newrelic-cli.config_provider_test.*.json")
+	require.NoError(t, err)
+	defer f.Close()
+
+	p, err := NewJSONStore(PersistToFile(f.Name()))
+	require.NoError(t, err)
+
+	err = p.SetWithScope("team.platform", FieldKey("apiKey"), "NRAK-DOTTED-5")
+	require.NoError(t, err)
+	err = p.SetWithScope("team.observability", FieldKey("apiKey"), "NRAK-DOTTED-6")
+	require.NoError(t, err)
+
+	err = p.RemoveScope("team.platform")
+	require.NoError(t, err)
+
+	// The removed scope is gone, the sibling that shares the "team" prefix is intact.
+	require.ElementsMatch(t, []string{"team.observability"}, p.GetScopes())
+
+	v, err := p.GetStringWithScope("team.observability", FieldKey("apiKey"))
+	require.NoError(t, err)
+	require.Equal(t, "NRAK-DOTTED-6", v)
+}


### PR DESCRIPTION
## What broke

Creating a CLI profile whose name contains a `.` — for example `newrelic profile add --profile ava.morgan ...` — appeared to succeed, but every subsequent command reported `FATAL profile ava.morgan does not exist`. The root cause is that the credentials store is JSON-backed via `gjson`/`sjson`, and those libraries treat `.` as a path separator for nested objects. So writing the value at the path `ava.morgan.apiKey` produced `{"ava":{"morgan":{"apiKey":"..."}}}` instead of `{"ava.morgan":{"apiKey":"..."}}`. Because the top-level key was now `ava` and not `ava.morgan`, `GetScopes()` lost the original name, and any read or delete keyed on `ava.morgan` failed. Underscores worked because they are not special characters to `gjson`/`sjson`. The customer-reported thread referenced this exact symptom with a profile name like `firstname.lastname`.

## What changed

The fix lives in `internal/config/json_store.go`: a small helper `escapePathSegment` runs over the user-controlled segments (the profile name passed as scope, and the optional global scope) before they're joined with the literal `.` separator used to build a `gjson`/`sjson` path. It escapes `\` first and then `.`, which is the documented escape syntax both libraries accept, so a name like `ava.morgan` becomes the path `ava\.morgan.apiKey` and is stored as a single literal top-level key. The same helper is also applied in `RemoveScope` so deleting a dotted profile no longer also nukes its siblings. Three new unit tests in `json_store_test.go` cover set+get, list-scopes, and remove for dotted names (`ava.morgan`, `riley.chen`, `prod.us-east-1`, `team.platform`, `team.observability`) and confirm that two profiles sharing a prefix like `team.*` are stored independently. The fix is a no-op for any profile name that does not contain `.` or `\`, so existing on-disk credentials and the common profile-naming case stay completely untouched.