### PR TITLE
fix(deps): bump alpine 3.24.0 -> 3.24.1 + apk upgrade for libssl/libcrypto CVEs

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,4 +1,10 @@
-FROM alpine:3.24.0
+FROM alpine:3.24.1
+
+# Refresh installed packages so we pick up any libcrypto3/libssl3 (and other)
+# security fixes published to the v3.24 repo after this base image was tagged.
+# Without this, scanners flag CVEs whose fixes are in the live repo but not
+# yet baked into a new alpine point release.
+RUN apk upgrade --no-cache
 
 # Add the binary
 COPY newrelic /bin/newrelic


### PR DESCRIPTION
## Summary

Resolves the 30 libssl3 / libcrypto3 CVEs flagged by the daily Trivy scan on 2026-06-18 against the prod docker image:

- **High (2)**: CVE-2026-45447 (libcrypto3, libssl3)
- **Medium (8)**: CVE-2026-34182, CVE-2026-34183, CVE-2026-42764, CVE-2026-45445 — each on both libcrypto3 and libssl3
- **Low (20)**: CVE-2026-34180, CVE-2026-34181, CVE-2026-42766–70, CVE-2026-45446, CVE-2026-7383, CVE-2026-9076 — each on both libcrypto3 and libssl3

## Why this is needed despite #1852

PR #1852 already bumped `alpine:3.23.4` → `alpine:3.24.0` expecting these to be fixed via `libcrypto3-3.5.7-r0`. But `alpine:3.24.0` was tagged **2026-06-10** — **before** `libcrypto3-3.5.7-r0` / `libssl3-3.5.7-r0` were published to the v3.24 repo. So the image baked an older OpenSSL even though the live repo already had the fix.

## Changes

- **Base image**: `alpine:3.24.0` → `alpine:3.24.1` (tagged 2026-06-16, picks up a fresher snapshot)
- **`apk upgrade --no-cache`**: refreshes installed packages from the live v3.24 repo at build time so we don't hit the same lag again if libcrypto3 ships another patch before the next alpine point release

## Test plan

- [ ] CI green (compile, test, lint, e2e)
- [ ] Next daily scan (post-merge + release) confirms libssl3/libcrypto3 items drop to 0