### PR TITLE
fix(deps): bump go 1.26.4 -> 1.26.5 to patch stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7


### PR DESCRIPTION
## Summary

Bumps the `go` directive in `go.mod` from `1.26.4` to `1.26.5` to resolve the Go **stdlib** vulnerabilities flagged by the daily Trivy/Grype security scan ([scan run](https://github.com/newrelic/newrelic-cli/actions/runs/29298822586)).

## CVEs resolved

| CVE / ID | Severity | Source | Fixed in |
|---|---|---|---|
| CVE-2026-39822 | HIGH | Trivy | 1.25.12, **1.26.5**, 1.27.0-rc.2 |
| GO-2026-4970 | HIGH | Grype | 1.25.12 |
| CVE-2026-42505 | MEDIUM | Trivy | 1.25.12, **1.26.5**, 1.27.0-rc.2 |
| GO-2026-5856 | MEDIUM | Grype | 1.25.12 |

Trivy and Grype each report the same two underlying stdlib issues under different IDs, so this is 2 vulnerabilities — both patched on the 1.26 line by **Go 1.26.5**.

## Why this is the right fix

- The scan workflow builds the scanned binary using `setup-go` with `go-version-file: go.mod` (`.github/workflows/vuln-scan-report.yml:33`), so the `go` directive is exactly what pins the compiled-in stdlib version.
- All other workflows (test, release, e2e, snapshot, compile) already float on `go-version: 1.26.x` and will pick up the 1.26.5 patch automatically — no changes needed there.

## Verification

Built `./cmd/newrelic/` locally and confirmed the resulting binary reports `go1.26.5` (patched stdlib):

```
$ go version /tmp/nr-test
/tmp/nr-test: go1.26.5
```

The next scheduled scan (1:00 AM UTC daily) should report clean once this merges.
