### PR TITLE
fix(install): exit non-zero when a targeted install installs no recipes

### DIFF
--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -116,6 +116,10 @@ var Command = &cobra.Command{
 				return err
 			}
 
+			if len(extractedRecipeNames) > 0 && errors.Is(err, types.ErrNoRecipesInstalled) {
+				return err
+			}
+
 			if i.shouldInstallCore() {
 				fallbackErrorMsg := fmt.Sprintf("\nWe encountered an issue during the installation: %s.", err)
 				fallbackHelpMsg := "If this problem persists, visit the documentation and support page for additional help here at https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/get-started/requirements-infrastructure-agent/"

--- a/internal/install/recipe_installer.go
+++ b/internal/install/recipe_installer.go
@@ -503,9 +503,7 @@ func (i *RecipeInstall) installAdditionalBundle(bundler RecipeBundler, bundleIns
 			}
 		}
 
-		return &types.UncaughtError{
-			Err: fmt.Errorf("no recipes were installed"),
-		}
+		return types.ErrNoRecipesInstalled
 	}
 	if len(i.RecipeNames) > len(additionalBundle.BundleRecipes) {
 		return &types.UncaughtError{

--- a/internal/install/types/errors.go
+++ b/internal/install/types/errors.go
@@ -17,6 +17,7 @@ var (
 	ErrPostEvent              = errors.New("there was a failure posting data to New Relic. Please try again later or contact New Relic support. For real-time platform status info visit https://status.newrelic.com/")
 	ErrLicenseKey             = errors.New("the configured license key is invalid for the configured account. Please set a valid license key with the `newrelic profile` command. For more details visit https://docs.newrelic.com/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key")
 	ErrAgentControl           = errors.New("agent control is installed, preventing the installation of this recipe")
+	ErrNoRecipesInstalled     = errors.New("no recipes were installed")
 )
 
 type EventType string


### PR DESCRIPTION
**Description**

When users specify recipes via `-n/--recipe` and none of the requested recipes end up installed (for example, every requested recipe is unsupported on the host OS), the CLI currently exits `0`. Automation wrapping the CLI cannot distinguish between "install succeeded" and "install did nothing," which masks failures during unattended provisioning. This change adds an `ErrNoRecipesInstalled` sentinel and returns a non-zero exit code specifically for the fully-failed targeted-install case.

A broader change — returning non-zero whenever any targeted recipe fails — was considered but rejected. That approach would flip the outcome of installs that partially succeed (for example, two of three requested recipes install cleanly while one is unsupported), and some existing pipelines legitimately treat a mixed outcome as an acceptable state. Scoping the fix to the "zero installed" case addresses the reported problem without changing behavior for partial-success runs, so the additional risk surface stays minimal.