### PR TITLE
feat(region): add GOV/FedRAMP region support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.86.1
+	github.com/newrelic/newrelic-client-go/v2 v2.91.0
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.86.1 h1:B9hpEyRU6t70lnlNV6bO0wF9nvGw660fjFoAk28NdCs=
-github.com/newrelic/newrelic-client-go/v2 v2.86.1/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.91.0 h1:HkpzaCXOl0yJaemRGPzijHthL5X3kzTyrQYZkgCGa94=
+github.com/newrelic/newrelic-client-go/v2 v2.91.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,8 @@ func InitializeCredentialsStore() {
 					region.US.String(),
 					region.EU.String(),
 					region.JP.String(),
+					region.GOV.String(),
+					"FEDRAMP", // alias for GOV; Parse() normalises both to region.GOV
 				),
 				Default:      region.US.String(),
 				SetValueFunc: ToLower(),

--- a/internal/install/command.go
+++ b/internal/install/command.go
@@ -168,7 +168,7 @@ func validateProfile() *types.DetailError {
 	}
 
 	if _, err := nrRegion.Parse(region); err != nil {
-		return types.NewDetailError(types.EventTypes.InvalidRegion, `Invalid region provided. Valid regions are "US", "EU", or "JP".`)
+		return types.NewDetailError(types.EventTypes.InvalidRegion, `Invalid region provided. Valid regions are "US", "EU", "JP", "GOV", or "FEDRAMP".`)
 	}
 
 	return nil

--- a/internal/install/execution/platform_link_generator.go
+++ b/internal/install/execution/platform_link_generator.go
@@ -272,6 +272,12 @@ func nrPlatformHostname() string {
 		return nrPlatformHostnames.JP
 	}
 
+	// GOV/FedRAMP does not have a publicly accessible platform hostname;
+	// fall back to the US host so post-install links remain navigable.
+	if strings.EqualFold(r, region.GOV.String()) || strings.EqualFold(r, "fedramp") {
+		return nrPlatformHostnames.US
+	}
+
 	return nrPlatformHostnames.US
 }
 

--- a/internal/profile/command.go
+++ b/internal/profile/command.go
@@ -56,7 +56,7 @@ for posting custom events with the ` + "`newrelic events`" + `command.
 	PreRun:  requireProfileName,
 	Run: func(cmd *cobra.Command, args []string) {
 		addStringValueToProfile(config.FlagProfileName, apiKey, config.APIKey, "User API Key", nil, nil)
-		addStringValueToProfile(config.FlagProfileName, flagRegion, config.Region, "Region", nil, []string{"US", "EU", "JP"})
+		addStringValueToProfile(config.FlagProfileName, flagRegion, config.Region, "Region", nil, []string{"US", "EU", "JP", "GOV", "FEDRAMP"})
 		addIntValueToProfile(config.FlagProfileName, accountID, config.AccountID, "Account ID", fetchAccountIDs)
 		addStringValueToProfile(config.FlagProfileName, licenseKey, config.LicenseKey, "License Key", fetchLicenseKey(), nil)
 
@@ -275,7 +275,7 @@ func requireProfileName(cmd *cobra.Command, args []string) {
 func init() {
 	// Add
 	Command.AddCommand(cmdAdd)
-	cmdAdd.Flags().StringVarP(&flagRegion, "region", "r", "", "the US, EU, or JP region")
+	cmdAdd.Flags().StringVarP(&flagRegion, "region", "r", "", "the US, EU, JP, GOV, or FEDRAMP region")
 	cmdAdd.Flags().StringVarP(&apiKey, "apiKey", "", "", "your personal API key")
 	cmdAdd.Flags().StringVarP(&licenseKey, "licenseKey", "", "", "your license key")
 	cmdAdd.Flags().IntVarP(&accountID, "accountId", "", 0, "your account ID")


### PR DESCRIPTION
## Summary

- Accepts both `GOV` and `FEDRAMP` as valid values for `NEW_RELIC_REGION` — via environment variable, `newrelic profile add --region`, and `newrelic config set`
- Bumps `newrelic-client-go` to **v2.91.0** which introduces the `GOV` region with FedRAMP-compliant endpoints
- Updates all user-facing strings (error messages, help flags) to list both `GOV` and `FEDRAMP`
- Adds an explicit `GOV`/`FEDRAMP` branch in `platform_link_generator`; falls back to `one.newrelic.com` since no public GOV platform hostname exists

`FEDRAMP` is a user-facing alias for `GOV`. Both flow through `nrRegion.Parse()` which normalises either to `region.GOV`, ensuring consistent FedRAMP-compliant endpoint selection regardless of spelling.

## Changes

| File | What changed |
|---|---|
| `go.mod` | `newrelic-client-go` v2.86.1 → v2.91.0 (drops local replace directive) |
| `internal/config/config.go` | Added `"FEDRAMP"` to `StringInStrings` allowed list (case-insensitive) |
| `internal/install/command.go` | Error message lists `"GOV"` and `"FEDRAMP"` |
| `internal/profile/command.go` | Valid values slice and `--region` flag description include `FEDRAMP` |
| `internal/install/execution/platform_link_generator.go` | Explicit `GOV`/`FEDRAMP` case with US fallback and comment |

## Endpoint summary (from v2.91.0 Go client)

| Field | GOV URL | Status |
|---|---|---|
| NerdGraph | `gov-api.newrelic.com/graphql` | ✅ confirmed 200 |
| Infrastructure | `gov-infra-api.newrelic.com/v2` | ✅ infra agent reports successfully |
| Insights/Event API | `gov-insights-collector.newrelic.com/v1` | ✅ confirmed 200; US endpoint 403s |
| Logs | `gov-log-api.newrelic.com/log/v1` | ✅ per FedRAMP docs |
| Metrics | `gov-metric-api.newrelic.com/metric/v1` | ✅ per FedRAMP docs |
| REST | `gov-api.newrelic.com/v2` | Same host as NerdGraph |
| Synthetics / InsightsKeys / Blob | US fallback | No GOV variants exist (DNS 000) |

## Test plan

- [x] `newrelic profile add --region GOV` — accepted, stored as `gov`
- [x] `newrelic profile add --region FEDRAMP` — accepted (new), stored as `fedramp`
- [x] `NEW_RELIC_REGION=GOV newrelic install -n ebpf-agent-installer` — all requests route to `gov-api.newrelic.com` and `gov-insights-collector.newrelic.com`; install completes successfully on Ubuntu 22.04 EC2
- [x] `NEW_RELIC_REGION=FEDRAMP` via env var — accepted, `Parse("fedramp")` returns `region.GOV`
- [x] US `insights-collector` 403s with GOV license key; GOV `insights-collector` 200s — confirms correct cell routing

## Known gaps (separate work items)

1. **eBPF agent** (Kapil's team): v1.4.5 maps `region=GOV` to `otlp.nr-data.net` (US OTLP) instead of `gov-otlp.nr-data.net` → 403 on all OTLP exports. Fix is in `env.cc` of the eBPF binary.
2. **Infra recipe** (`open-install-library`): `infrastructure-agent-installer` recipe does not write `fedramp: true` to `/etc/newrelic-infra.yml` when the region is GOV. Without it the infra agent 401s against the US ingest endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)