### PR TITLE
security: bump Go toolchain to 1.26.6 to fix 4 stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli/tools
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/caarlos0/svu v1.9.0


### PR DESCRIPTION
## Summary

Bumps the `go` directive from `1.26.5` → `1.26.6` in both `go.mod` and `tools/go.mod` to resolve all four HIGH-severity `stdlib` findings from the [2026-08-15 security scan](https://github.com/newrelic/newrelic-cli/actions/runs/31856645239).

## Vulnerabilities resolved

| CVE / ID | Severity | Description |
|---|---|---|
| CVE-2026-39821 | **HIGH** | stdlib — fixed in Go 1.26.6 |
| CVE-2026-46600 | **HIGH** | stdlib — fixed in Go 1.26.6 |
| GO-2026-5026 | **HIGH** | stdlib — fixed in Go 1.26.6 |
| GO-2026-5942 | **HIGH** | stdlib — fixed in Go 1.26.6 |

Additional Grype-only UNKNOWN findings (GO-2026-5972, GO-2026-6088, GO-2026-6089, GO-2026-6090, GO-2026-6091, GO-2026-6218) are also addressed by the same bump.

## Change

- `go.mod`: `go 1.26.5` → `go 1.26.6`
- `tools/go.mod`: `go 1.26.5` → `go 1.26.6`
- `go.sum` / `tools/go.sum`: unchanged — stdlib bump adds no new module dependencies

`go build ./...` verified with `GOTOOLCHAIN=go1.26.6`. Trivy rescan post-patch returns **0 HIGH/CRITICAL findings**.

## Test plan

- [ ] CI passes (all 30+ checks)
- [ ] Verify security scan no longer flags CVE-2026-39821, CVE-2026-46600, GO-2026-5026, GO-2026-5942 after merge