### PR TITLE
fix(fleetcontrol): paginate fleet search across all pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,7 @@ require (
 )
 
 replace github.com/go-task/task/v3 => github.com/newrelic-forks/task/v3 v3.11.0
+
+// TEMPORARY: points at newrelic/newrelic-client-go#1442 (fix/fleetcontrol-entity-search-cursor)
+// for local testing while that PR is in review. Revert to a released version before merging.
+replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.91.0
+	github.com/newrelic/newrelic-client-go/v2 v2.93.2
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3
@@ -76,7 +76,3 @@ require (
 )
 
 replace github.com/go-task/task/v3 => github.com/newrelic-forks/task/v3 v3.11.0
-
-// TEMPORARY: points at newrelic/newrelic-client-go#1442 (fix/fleetcontrol-entity-search-cursor)
-// for local testing while that PR is in review. Revert to a released version before merging.
-replace github.com/newrelic/newrelic-client-go/v2 => github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94 h1:LQlQrXBREfuwIN/dfFsBeLmfJhQg2wYL5+mrBLUEGUo=
-github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.2 h1:OPrJPULKBH38VZVIrTsrMBx5iJURgT5obpzMKNNcBw4=
+github.com/newrelic/newrelic-client-go/v2 v2.93.2/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.91.0 h1:HkpzaCXOl0yJaemRGPzijHthL5X3kzTyrQYZkgCGa94=
-github.com/newrelic/newrelic-client-go/v2 v2.91.0/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94 h1:LQlQrXBREfuwIN/dfFsBeLmfJhQg2wYL5+mrBLUEGUo=
+github.com/newrelic/newrelic-client-go/v2 v2.93.1-0.20260810175905-93cb87f7dc94/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/fleetcontrol/fleet_management_search.go
+++ b/internal/fleetcontrol/fleet_management_search.go
@@ -11,50 +11,39 @@ import (
 	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
 )
 
-// handleFleetSearch implements the 'search' command to search for fleet entities by name.
-//
-// This command searches for fleet entities and optionally filters them based on name criteria.
-// Users can search using exact match (--name-equals), substring match (--name-contains),
-// or retrieve all fleets (no flags). The flags are mutually exclusive.
-//
-// The command:
-// 1. Validates that at most one search flag is provided (mutually exclusive)
-// 2. Calls the New Relic API to search for fleet entities (type='FLEET')
-// 3. Filters results based on the name criteria (if provided)
-// 4. Returns filtered results in JSON or table format
-//
-// Parameters:
-//   - cmd: The cobra command being executed
-//   - args: Command arguments (not used)
-//   - flags: Validated flag values from YAML configuration
-//
-// Returns:
-//   - Error if search fails, nil on success
-func handleFleetSearch(cmd *cobra.Command, args []string, flags *FlagValues) error {
-	// Get typed flag values
-	f := flags.Search()
+// maxSearchPages bounds how many pages searchFleetEntities will fetch, as a safety net
+// against a misbehaving API returning a cursor that never terminates.
+const maxSearchPages = 1000
 
-	// Validate that both flags are not provided simultaneously (mutually exclusive)
-	if f.NameEquals != "" && f.NameContains != "" {
-		return PrintError(fmt.Errorf("--name-equals and --name-contains are mutually exclusive"))
+// searchFleetEntities fetches every page of type='FLEET' entities via GetEntitySearch,
+// following NextCursor until the API reports no more pages, then applies the name filter
+// against the full accumulated set. The API only supports filtering by type, so name
+// filtering has to happen client-side - which only works correctly if every page has
+// been fetched first.
+func searchFleetEntities(f SearchFlags) ([]FleetEntityOutput, error) {
+	var allEntities []fleetcontrol.EntityManagementEntityInterface
+
+	var cursor *string
+	for range maxSearchPages {
+		results, err := client.NRClient.FleetControl.GetEntitySearch(cursor, "type='FLEET'")
+		if err != nil {
+			return nil, fmt.Errorf("failed to search fleets: %w", err)
+		}
+		if results == nil {
+			break
+		}
+
+		allEntities = append(allEntities, results.Entities...)
+
+		if results.NextCursor == "" {
+			break
+		}
+		nextCursor := results.NextCursor
+		cursor = &nextCursor
 	}
 
-	// Call New Relic API to search for fleet entities
-	// The backend only supports filtering by type, so we filter by name on the client side
-	results, err := client.NRClient.FleetControl.GetEntitySearch("", "type='FLEET'")
-	if err != nil {
-		return PrintError(fmt.Errorf("failed to search fleets: %w", err))
-	}
-
-	if results == nil || len(results.Entities) == 0 {
-		// Return empty array for JSON without wrapper (supports table format)
-		return output.Print([]FleetEntityOutput{})
-	}
-
-	// Filter results based on name criteria
 	var filteredFleets []FleetEntityOutput
-
-	for _, entity := range results.Entities {
+	for _, entity := range allEntities {
 		// Type assert to fleet entity (pointer type)
 		fleetEntity, ok := entity.(*fleetcontrol.EntityManagementFleetEntity)
 		if !ok {
@@ -74,6 +63,41 @@ func handleFleetSearch(cmd *cobra.Command, args []string, flags *FlagValues) err
 			filteredFleet := FilterFleetEntityFromEntityManagement(*fleetEntity, f.ShowTags)
 			filteredFleets = append(filteredFleets, *filteredFleet)
 		}
+	}
+
+	return filteredFleets, nil
+}
+
+// handleFleetSearch implements the 'search' command to search for fleet entities by name.
+//
+// This command searches for fleet entities and optionally filters them based on name criteria.
+// Users can search using exact match (--name-equals), substring match (--name-contains),
+// or retrieve all fleets (no flags). The flags are mutually exclusive.
+//
+// Parameters:
+//   - cmd: The cobra command being executed
+//   - args: Command arguments (not used)
+//   - flags: Validated flag values from YAML configuration
+//
+// Returns:
+//   - Error if search fails, nil on success
+func handleFleetSearch(cmd *cobra.Command, args []string, flags *FlagValues) error {
+	// Get typed flag values
+	f := flags.Search()
+
+	// Validate that both flags are not provided simultaneously (mutually exclusive)
+	if f.NameEquals != "" && f.NameContains != "" {
+		return PrintError(fmt.Errorf("--name-equals and --name-contains are mutually exclusive"))
+	}
+
+	filteredFleets, err := searchFleetEntities(f)
+	if err != nil {
+		return PrintError(err)
+	}
+
+	if filteredFleets == nil {
+		// Return empty array for JSON without wrapper (supports table format)
+		filteredFleets = []FleetEntityOutput{}
 	}
 
 	// Output results directly without status wrapper (supports table format with --format=text)

--- a/internal/fleetcontrol/fleet_management_search_test.go
+++ b/internal/fleetcontrol/fleet_management_search_test.go
@@ -1,0 +1,182 @@
+//go:build unit
+// +build unit
+
+package fleetcontrol
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-cli/internal/client"
+	"github.com/newrelic/newrelic-client-go/v2/newrelic"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/fleetcontrol"
+	"github.com/newrelic/newrelic-client-go/v2/pkg/testhelpers"
+)
+
+// entitySearchPage is one canned response for a single GetEntitySearch call.
+type entitySearchPage struct {
+	fleetNames []string
+	nextCursor string
+	statusCode int
+	graphQLErr string
+}
+
+func (p entitySearchPage) body() string {
+	if p.graphQLErr != "" {
+		errBody, _ := json.Marshal(map[string]interface{}{
+			"errors": []map[string]string{{"message": p.graphQLErr}},
+		})
+		return string(errBody)
+	}
+
+	entities := make([]map[string]string, 0, len(p.fleetNames))
+	for i, name := range p.fleetNames {
+		entities = append(entities, map[string]string{
+			"__typename": "EntityManagementFleetEntity",
+			"id":         name + "-id",
+			"name":       name,
+			"type":       "FLEET",
+		})
+		_ = i
+	}
+
+	respBody, _ := json.Marshal(map[string]interface{}{
+		"data": map[string]interface{}{
+			"actor": map[string]interface{}{
+				"entityManagement": map[string]interface{}{
+					"entitySearch": map[string]interface{}{
+						"entities":   entities,
+						"nextCursor": p.nextCursor,
+					},
+				},
+			},
+		},
+	})
+	return string(respBody)
+}
+
+// requestCursor pulls the "cursor" GraphQL variable out of a captured request body,
+// so tests can assert the CLI actually forwards NextCursor back on the next call.
+func requestCursor(t *testing.T, body []byte) interface{} {
+	t.Helper()
+	var req struct {
+		Variables map[string]interface{} `json:"variables"`
+	}
+	require.NoError(t, json.Unmarshal(body, &req))
+	return req.Variables["cursor"]
+}
+
+// stubEntitySearch points client.NRClient.FleetControl at a test server that serves
+// the given pages in order, one per GetEntitySearch call, and restores the original
+// client.NRClient when the test finishes. Returns the raw request bodies received, in order.
+func stubEntitySearch(t *testing.T, pages []entitySearchPage) *[][]byte {
+	t.Helper()
+
+	var requests [][]byte
+	callCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		requests = append(requests, buf)
+
+		if callCount >= len(pages) {
+			t.Fatalf("unexpected extra GetEntitySearch call (call #%d), only %d pages configured", callCount+1, len(pages))
+		}
+		page := pages[callCount]
+		callCount++
+
+		status := page.statusCode
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, writeErr := w.Write([]byte(page.body()))
+		require.NoError(t, writeErr)
+	}))
+	t.Cleanup(server.Close)
+
+	tc := testhelpers.NewTestConfig(t, server)
+
+	original := client.NRClient
+	client.NRClient = &newrelic.NewRelic{FleetControl: fleetcontrol.New(tc)}
+	t.Cleanup(func() { client.NRClient = original })
+
+	return &requests
+}
+
+func TestSearchFleetEntities_MatchOnFirstPage(t *testing.T) {
+	stubEntitySearch(t, []entitySearchPage{
+		{fleetNames: []string{"alpha-fleet", "target-fleet"}},
+	})
+
+	got, err := searchFleetEntities(SearchFlags{NameEquals: "target-fleet"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "target-fleet", got[0].Name)
+}
+
+// TestSearchFleetEntities_MatchOnSecondPage is the regression test for the pagination bug:
+// without looping on NextCursor, a fleet that only exists on page 2+ is never seen and
+// --name-equals silently returns empty.
+func TestSearchFleetEntities_MatchOnSecondPage(t *testing.T) {
+	requests := stubEntitySearch(t, []entitySearchPage{
+		{fleetNames: []string{"alpha-fleet", "beta-fleet"}, nextCursor: "cursor-page-2"},
+		{fleetNames: []string{"target-fleet", "gamma-fleet"}},
+	})
+
+	got, err := searchFleetEntities(SearchFlags{NameEquals: "target-fleet"})
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "target-fleet", got[0].Name)
+
+	require.Len(t, *requests, 2, "expected exactly two GetEntitySearch calls (one per page)")
+	assert.Equal(t, "cursor-page-2", requestCursor(t, (*requests)[1]),
+		"second call should forward the NextCursor returned by the first")
+}
+
+func TestSearchFleetEntities_NoMatchAcrossAllPages(t *testing.T) {
+	stubEntitySearch(t, []entitySearchPage{
+		{fleetNames: []string{"alpha-fleet"}, nextCursor: "cursor-page-2"},
+		{fleetNames: []string{"beta-fleet"}},
+	})
+
+	got, err := searchFleetEntities(SearchFlags{NameEquals: "does-not-exist"})
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestSearchFleetEntities_ErrorOnLaterPagePropagates(t *testing.T) {
+	stubEntitySearch(t, []entitySearchPage{
+		{fleetNames: []string{"alpha-fleet"}, nextCursor: "cursor-page-2"},
+		{graphQLErr: "internal error", statusCode: http.StatusBadRequest},
+	})
+
+	got, err := searchFleetEntities(SearchFlags{NameEquals: "alpha-fleet"})
+	assert.Error(t, err, "an error on a later page should propagate, not be silently swallowed")
+	assert.Nil(t, got, "no partial results should be returned when a later page errors")
+}
+
+func TestSearchFleetEntities_NameContainsAcrossPages(t *testing.T) {
+	stubEntitySearch(t, []entitySearchPage{
+		{fleetNames: []string{"prod-fleet-a"}, nextCursor: "cursor-page-2"},
+		{fleetNames: []string{"prod-fleet-b", "staging-fleet"}},
+	})
+
+	got, err := searchFleetEntities(SearchFlags{NameContains: "prod-fleet"})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	var names []string
+	for _, f := range got {
+		names = append(names, f.Name)
+	}
+	assert.ElementsMatch(t, []string{"prod-fleet-a", "prod-fleet-b"}, names)
+}


### PR DESCRIPTION
`fleetcontrol fleet search --name-equals`/`--name-contains` only inspected the first page of `GetEntitySearch` results, so the client-side name filter silently missed any fleet that wasn't on page 1 (confirmed live: a known fleet absent from a 100-entity first page, found instantly via a name-scoped query against the general `entitySearch` API).

`searchFleetEntities` now loops on `NextCursor` (capped at 1000 pages as a safety net against a misbehaving cursor) and accumulates entities across every page before applying the name filter. This intentionally does not expose a `--next-cursor` flag the way `fleet members list` does - a name search's entire point is "does this exist," and the caller has no way to know which page a match might be on, so partial/manual paging would defeat the feature.

Depended on newrelic/newrelic-client-go#1442, which fixed the same bug one layer down: `GetEntitySearch`'s cursor parameter was a no-op because the generated query never declared/passed `$cursor`. **That PR has merged and shipped in client-go v2.93.2** - `go.mod` now points at the real release instead of the temporary commit-pinned replace directive, so this is ready for review.

## Test plan

- `internal/fleetcontrol/fleet_management_search_test.go`: 5 unit tests against a mock NerdGraph server - match on page 1, match only on page 2+ (the regression test for this bug), no match across all pages, error on a later page propagates (no partial results), `--name-contains` spanning multiple pages.
- Verified the page-2 regression test isn't vacuous: temporarily capped the loop at one iteration and confirmed that test fails, then restored the fix.
- `make test-unit` - 526 tests passing. `gofmt` / `golangci-lint` clean.
- Live-verified against a real account (~800 fleets) with the actual built binary: unfiltered search returns all 798 fleets with no duplication, and `--name-equals` finds fleets at page 2+ that a pre-fix build returns `null` for. Details in the PR comments.
