### PR TITLE
fix(security): bump Go toolchain to 1.26.7 and patch Alpine OpenSSL CVEs

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.24.1
 
+RUN apk upgrade --no-cache
+
 # Add the binary
 COPY newrelic /bin/newrelic
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/newrelic/newrelic-cli/tools
 
-go 1.26.6
+go 1.26.7
 
 require (
 	github.com/caarlos0/svu v1.9.0


### PR DESCRIPTION
## Summary

Addresses the 20 vulnerabilities reported in the [2026-08-27 daily security scan](https://newrelic.slack.com/archives/C01SKHCDYU8/p1787798146129349) and fixes the Go toolchain version mismatch in the module files.

### Root causes

1. **IDE toolchain mismatch** — `go.mod` and `tools/go.mod` were pinned to `go 1.26.6` while the installed Go toolchain is `1.26.7`, causing the IDE (gopls) to report a version mismatch. Fixed by bumping the `go` directive to match the installed toolchain.

2. **Alpine OpenSSL vulnerabilities** — All 20 CVEs are in the OS-level packages `libssl3` and `libcrypto3` inside the Docker image. These are **not** Go dependency issues. The fix version `3.5.8-r0` is already available in the Alpine 3.24 package repos (Trivy only reports CVEs where `only-fixed: true`). Adding `apk upgrade --no-cache` to the Dockerfile ensures the patched packages are pulled in at image build time.

### Changes

| File | Change |
|------|--------|
| `go.mod` | `go 1.26.6` → `go 1.26.7` |
| `tools/go.mod` | `go 1.26.6` → `go 1.26.7` |
| `build/package/Dockerfile` | Added `RUN apk upgrade --no-cache` |

### CVEs resolved (all via `apk upgrade --no-cache` → `libssl3/libcrypto3 3.5.8-r0`)

| Package | CVE | Severity | Fixed In |
|---------|-----|----------|----------|
| libcrypto3 / libssl3 | CVE-2026-14456 | HIGH | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-18798 | MEDIUM | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-63072 | MEDIUM | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-63076 | MEDIUM | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-14457 | LOW | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-54874 | LOW | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-63073 | LOW | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-63074 | LOW | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-63075 | LOW | 3.5.8-r0 |
| libcrypto3 / libssl3 | CVE-2026-75803 | LOW | 3.5.8-r0 |

_Each CVE above affects both `libcrypto3` and `libssl3` (20 findings total = 10 unique CVEs × 2 packages)._

## Test plan

- [ ] CI passes (build + unit tests)
- [ ] Docker image built with `--pull` flag (already set in `.goreleaser.yml`) will pull the fresh base layer and `apk upgrade` will resolve the patched packages
- [ ] Next daily Trivy scan should report 0 findings for `libssl3`/`libcrypto3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)