### PR TITLE
chore(docker): revert apk upgrade, await Alpine 3.24.2 for CVE fix

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -1,7 +1,5 @@
 FROM alpine:3.24.1
 
-RUN apk upgrade --no-cache
-
 # Add the binary
 COPY newrelic /bin/newrelic
 


### PR DESCRIPTION
Reverts the `RUN apk upgrade --no-cache` added in #1875.

**Why:** Adding a `RUN` command to the Dockerfile breaks the multi-arch release build. goreleaser builds both `linux/amd64` and `linux/arm64` images on the x86_64 CI runner — executing the arm64 Alpine shell requires QEMU emulation, which is not set up in the release workflow. Result: `exec format error`, exit code 255.

**The actual fix:** `libssl3/libcrypto3 3.5.8-r0` (which patches all 20 CVEs) landed in the Alpine v3.24 package repo on 2026-08-25. Once Alpine publishes `alpine:3.24.2` with those packages bundled, the fix is a single tag bump — no `RUN` commands, no workflow changes needed.