### PR TITLE
chore(deps): configure Renovate to auto-bump Alpine patch version

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,5 +10,16 @@
   "reviewers": ["team:developer-toolkit"],
   "labels": ["dependencies"],
   "prConcurrentLimit": 4,
-  "postUpdateOptions": ["gomodTidy"]
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["alpine"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "reviewers": ["pranav-new-relic", "Nandu-pns"],
+      "labels": ["dependencies", "security"],
+      "commitMessagePrefix": "fix(security):",
+      "prPriority": 10
+    }
+  ]
 }


### PR DESCRIPTION
## What & Why

Our Docker image is built on `alpine:3.24.1`. When Alpine releases security patches (like the OpenSSL CVEs we hit today), they ship as a new image tag — e.g. `alpine:3.24.2` or `alpine:3.25.0`. Without automation, someone has to manually notice the new tag and open a PR to bump the `FROM` line in the Dockerfile.

This PR teaches **Renovate** (a bot already running in this repo that auto-updates dependencies) to handle that for us.

## What Renovate will do

When a new Alpine minor or patch version is published on Docker Hub, Renovate will:
1. Detect the new tag automatically
2. Open a PR that updates the single `FROM alpine:x.y.z` line in `build/package/Dockerfile`
3. Tag `@pranav-new-relic` and `@Nandu-pns` as reviewers
4. Label it `security` + `dependencies` so it's easy to find
5. Give it higher priority (`prPriority: 10`, default is `0`) so it surfaces above routine dep bumps

## What it won't do

- It won't bump to Alpine 4.x — `matchUpdateTypes: ["minor", "patch"]` excludes major version jumps, which should be a deliberate decision
- It won't change anything about how Renovate handles Go modules, GitHub Actions, or any other dependency — `packageRules` is additive and this rule only matches the `alpine` Docker package

## Change

`.github/renovate.json` — one new entry in `packageRules`. Everything else is untouched.