### PR TITLE
chore: bump newrelic-client-go/v2 to v2.93.3 (latest)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.4
 	github.com/joshdk/go-junit v0.0.0-20210226021600-6145f504ca0d
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/newrelic/newrelic-client-go/v2 v2.93.2
+	github.com/newrelic/newrelic-client-go/v2 v2.93.3
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mitchellh/mapstructure v1.4.3 h1:OVowDSCllw/YjdLkam3/sm7wEtOy59d8ndGg
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/newrelic-forks/task/v3 v3.11.0 h1:8Gwo33tMTqQkWlekCChbCZqf0nrXI85UqVeIgXk73L0=
 github.com/newrelic-forks/task/v3 v3.11.0/go.mod h1:rzfFpA7kl0CsL44ZQd2F2Hic5xOb2m03N6Y2lUjdNo4=
-github.com/newrelic/newrelic-client-go/v2 v2.93.2 h1:OPrJPULKBH38VZVIrTsrMBx5iJURgT5obpzMKNNcBw4=
-github.com/newrelic/newrelic-client-go/v2 v2.93.2/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
+github.com/newrelic/newrelic-client-go/v2 v2.93.3 h1:QGYhoFCtLqeA2Zk+tmvR885kjZhdOaqR0PyavUfewfs=
+github.com/newrelic/newrelic-client-go/v2 v2.93.3/go.mod h1:kROngr/zeNyxbdOI3zPK4Al+ze32XjLEVUDzjxsKW9g=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Summary

Bumps `github.com/newrelic/newrelic-client-go/v2` to `v2.93.3`, the latest published version, ahead of an upcoming CLI release.

Checked the client-go changelog directly — no `BREAKING CHANGE` entries in this version. No source changes needed; just `go.mod`/`go.sum`.

## Test plan
- [x] `go build ./...` and `go vet ./...` — clean.
- [x] `go test ./...` (default build tags) — all packages pass.
- [x] `go test -tags=integration ./...` — all packages pass.
