### PR TITLE
fix(profile): fix name truncation for dotted identifiers and related UX issues

### DIFF
--- a/internal/config/json_store.go
+++ b/internal/config/json_store.go
@@ -430,7 +430,8 @@ func (p *JSONStore) SetWithScope(scope string, key FieldKey, value interface{}) 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	cfg, err := sjson.Set(cfg, escapeWildcards(p.getPath(scope, key)), value)
+	// getPath() already escapes the scope segment; don't escape again here.
+	cfg, err := sjson.Set(cfg, p.getPath(scope, key), value)
 	if err != nil {
 		return err
 	}
@@ -442,9 +443,9 @@ func (p *JSONStore) SetWithScope(scope string, key FieldKey, value interface{}) 
 // the fields that appear underneath it. The resulting config will be persisted to
 // disk if PersistToDisk has been used.
 func (p *JSONStore) RemoveScope(scope string) error {
-	path := scope
+	path := escapePathSegment(scope)
 	if p.scope != "" {
-		path = fmt.Sprintf("%s.%s", p.scope, scope)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(p.scope), path)
 	}
 
 	return p.deletePath(path)
@@ -500,11 +501,11 @@ func (p *JSONStore) GetFieldDefinition(key FieldKey) *FieldDefinition {
 func (p *JSONStore) getPath(scope string, key FieldKey) string {
 	path := string(key)
 	if scope != "" {
-		path = fmt.Sprintf("%s.%s", scope, key)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(scope), key)
 	}
 
 	if p.scope != "" {
-		path = fmt.Sprintf("%s.%s", p.scope, path)
+		path = fmt.Sprintf("%s.%s", escapePathSegment(p.scope), path)
 	}
 
 	return path
@@ -514,7 +515,8 @@ func (p *JSONStore) deletePath(path string) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	cfg, err := sjson.Delete(p.getConfig(), escapeWildcards(path))
+	// path is pre-escaped by getPath()/RemoveScope(); don't escape again here.
+	cfg, err := sjson.Delete(p.getConfig(), path)
 	if err != nil {
 		return err
 	}
@@ -572,10 +574,17 @@ func (p *JSONStore) setConfigFromFile() {
 	p.cfg = data
 }
 
-// Escape wildcard characters, as required by sjson
-func escapeWildcards(key string) string {
-	re := regexp.MustCompile(`([*?])`)
-	return re.ReplaceAllString(key, "\\$1")
+// gjsonSpecialChars are the characters gjson/sjson treat as special within
+// a path segment (`. | # @ * ? \`). Escaping them lets a profile name like
+// "sanyam.saxena" be addressed as one literal key, not a nested path.
+var gjsonSpecialChars = regexp.MustCompile(`([\\.*?#@|])`)
+
+// escapePathSegment escapes special characters within a single path segment
+// (e.g. a profile name) before it's joined with others via ".". Apply only
+// to individual segments - escaping an already-joined path would also
+// escape the separators between them.
+func escapePathSegment(segment string) string {
+	return gjsonSpecialChars.ReplaceAllString(segment, `\$1`)
 }
 
 func (p *JSONStore) getConfigValueKeys() []FieldKey {

--- a/internal/config/json_store_test.go
+++ b/internal/config/json_store_test.go
@@ -770,3 +770,77 @@ func TestStore_GetScopes(t *testing.T) {
 	s := p.GetScopes()
 	require.Equal(t, 2, len(s))
 }
+
+// A scope value (e.g. a profile name) containing gjson-special characters
+// must round-trip as a single flat key, not be parsed as nested paths.
+func TestStore_SetGetWithScope_SpecialCharacters(t *testing.T) {
+	for _, scope := range []string{
+		"sanyam.saxena",
+		"a.b.c",
+		"a#b",
+		"a@b",
+		"a|b",
+		"a*b",
+		"a?b",
+		`a\b`,
+		"a.b#c@d|e*f?g",
+	} {
+		t.Run(scope, func(t *testing.T) {
+			p, err := NewJSONStore(
+				ConfigureFields(FieldDefinition{Key: "testKey"}),
+			)
+			require.NoError(t, err)
+
+			err = p.SetWithScope(scope, FieldKey("testKey"), "testValue")
+			require.NoError(t, err)
+
+			actual, err := p.GetStringWithScope(scope, "testKey")
+			require.NoError(t, err)
+			require.Equal(t, "testValue", actual)
+
+			scopes := p.GetScopes()
+			require.Equal(t, []string{scope}, scopes)
+		})
+	}
+}
+
+// Removing a scope with gjson-special characters must not affect a sibling
+// scope sharing a prefix up to the first special character.
+func TestStore_RemoveScope_SpecialCharacters(t *testing.T) {
+	p, err := NewJSONStore(
+		ConfigureFields(FieldDefinition{Key: "testKey"}),
+	)
+	require.NoError(t, err)
+
+	err = p.SetWithScope("sanyam.saxena", FieldKey("testKey"), "testValue")
+	require.NoError(t, err)
+
+	err = p.SetWithScope("sanyam.other", FieldKey("testKey"), "testValue")
+	require.NoError(t, err)
+
+	err = p.RemoveScope("sanyam.saxena")
+	require.NoError(t, err)
+
+	_, err = p.GetStringWithScope("sanyam.saxena", "testKey")
+	require.Error(t, err)
+
+	actual, err := p.GetStringWithScope("sanyam.other", "testKey")
+	require.NoError(t, err)
+	require.Equal(t, "testValue", actual)
+}
+
+// A plain scope value with no special characters - every pre-existing
+// profile - must continue to round-trip unchanged.
+func TestStore_SetGetWithScope_PlainName(t *testing.T) {
+	p, err := NewJSONStore(
+		ConfigureFields(FieldDefinition{Key: "testKey"}),
+	)
+	require.NoError(t, err)
+
+	err = p.SetWithScope("plainScopeName", FieldKey("testKey"), "testValue")
+	require.NoError(t, err)
+
+	actual, err := p.GetStringWithScope("plainScopeName", "testKey")
+	require.NoError(t, err)
+	require.Equal(t, "testValue", actual)
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -85,6 +85,16 @@ func SetFormat(format Format) (err error) {
 	return nil
 }
 
+// GetFormat returns the currently configured output format, so callers can
+// skip human-readable decoration (e.g. ANSI codes) for structured formats.
+func GetFormat() (format Format) {
+	if err := ensureGlobalOutput(); err != nil {
+		return DefaultFormat
+	}
+
+	return globalOutput.format
+}
+
 func SetPrettyPrint(pretty bool) (err error) {
 	if err = ensureGlobalOutput(); err != nil {
 		return err

--- a/internal/profile/command.go
+++ b/internal/profile/command.go
@@ -160,6 +160,12 @@ func addIntValueToProfile(profileName string, val int, key config.FieldKey, labe
 		}
 	}
 
+	if val == 0 {
+		// Optional field skipped - leave unset rather than writing 0, which
+		// would fail IntGreaterThan(0) validation and abort the command.
+		return
+	}
+
 	if err := configAPI.SetProfileValue(profileName, key, val); err != nil {
 		log.Fatal(err)
 	}
@@ -196,6 +202,7 @@ var cmdDefault = &cobra.Command{
 The default command sets the profile to use by default using the specified name.
 `,
 	Example: "newrelic profile default --profile <profile>",
+	PreRun:  requireProfileName,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := configAPI.SetDefaultProfile(config.FlagProfileName)
 		if err != nil {
@@ -215,20 +222,42 @@ The list command prints out the available profiles' credentials.
 `,
 	Example: "newrelic profile list",
 	Run: func(cmd *cobra.Command, args []string) {
+		// Preserve the pre-existing table default unless --format was
+		// explicitly passed (output.Print()'s own default is JSON).
+		effectiveFormat := output.FormatText
+		if cmd.Flags().Changed("format") {
+			effectiveFormat = output.GetFormat()
+		}
+		isTableOutput := effectiveFormat == output.FormatText
+
+		// Persisted default, not the --profile-flag-overridable active profile.
+		defaultProfileName, err := configAPI.GetDefaultProfileName()
+		if err != nil {
+			log.Fatal(err)
+		}
+
 		list := []map[string]interface{}{}
 		for _, p := range configAPI.GetProfileNames() {
 			out := map[string]interface{}{}
 
+			isDefault := p == defaultProfileName
+
 			name := p
-			if p == configAPI.GetActiveProfileName() {
+			if isDefault && isTableOutput {
+				// Colorized suffix for table output only; JSON/YAML get the
+				// isDefault field below instead of ANSI codes in a string.
 				name += text.FgHiBlack.Sprint(defaultProfileString)
 			}
 			out["Name"] = name
+			out["isDefault"] = isDefault
 
 			configAPI.ForEachProfileFieldDefinition(p, func(d config.FieldDefinition) {
 				v := configAPI.GetProfileString(p, d.Key)
 				if !showKeys && d.Sensitive {
-					v = text.FgHiBlack.Sprint(utils.Obfuscate(v))
+					v = utils.Obfuscate(v)
+					if isTableOutput {
+						v = text.FgHiBlack.Sprint(v)
+					}
 				}
 
 				out[string(d.Key)] = v
@@ -237,7 +266,11 @@ The list command prints out the available profiles' credentials.
 			list = append(list, out)
 		}
 
-		output.Text(list)
+		if isTableOutput {
+			output.Text(list)
+		} else {
+			output.Print(list)
+		}
 	},
 	Aliases: []string{
 		"ls",
@@ -252,6 +285,7 @@ var cmdDelete = &cobra.Command{
 The delete command removes the profile specified by name.
 `,
 	Example: "newrelic profile delete --profile <profile>",
+	PreRun:  requireProfileName,
 	Run: func(cmd *cobra.Command, args []string) {
 		err := configAPI.RemoveProfile(config.FlagProfileName)
 		if err != nil {

--- a/internal/profile/command_integration_test.go
+++ b/internal/profile/command_integration_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package profile
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/newrelic/newrelic-cli/internal/config"
+	configAPI "github.com/newrelic/newrelic-cli/internal/config/api"
+	"github.com/newrelic/newrelic-cli/internal/output"
+	"github.com/newrelic/newrelic-cli/internal/utils"
+)
+
+// clearAmbientCredentialEnvVars unsets NEW_RELIC_* env vars so a developer's
+// shell can't leak an override into these tests. Must fully unset, not set
+// to "" - os.LookupEnv treats present-but-empty as a real override too.
+func clearAmbientCredentialEnvVars(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"NEW_RELIC_ACCOUNT_ID", "NEW_RELIC_API_KEY", "NEW_RELIC_LICENSE_KEY", "NEW_RELIC_REGION"} {
+		name := name
+		original, wasSet := os.LookupEnv(name)
+		require.NoError(t, os.Unsetenv(name))
+		if wasSet {
+			t.Cleanup(func() { os.Setenv(name, original) })
+		}
+	}
+}
+
+// resetListFormatFlagState clears stale Changed state on cmdList's merged
+// "format" flag. cmdList is a package-level singleton reused across tests,
+// and cobra caches a parent's persistent flags into it on first Execute() -
+// a later test's fresh root command has its "format" flag silently ignored
+// in favor of that cached one, Changed value included.
+func resetListFormatFlagState() {
+	if f := cmdList.Flags().Lookup("format"); f != nil {
+		f.Changed = false
+	}
+}
+
+// buildTestRootCmd replicates the real root command's persistent --format
+// flag (cmd/newrelic/command.go) with the `profile` tree attached beneath
+// it, so cmd.Flags().Changed("format") behaves as it does in production -
+// a bare *cobra.Command never has --format registered.
+func buildTestRootCmd() *cobra.Command {
+	var outputFormat string
+
+	root := &cobra.Command{
+		Use: "newrelic",
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			utils.LogIfError(output.SetFormat(output.ParseFormat(outputFormat)))
+		},
+	}
+	root.PersistentFlags().StringVar(&outputFormat, "format", output.DefaultFormat.String(), "")
+	root.PersistentFlags().StringVar(&config.FlagProfileName, "profile", "", "")
+	root.AddCommand(Command)
+
+	return root
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	fn()
+
+	require.NoError(t, w.Close())
+	os.Stdout = old
+
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func setupTwoProfilesWithADefault(t *testing.T) {
+	t.Helper()
+	clearAmbientCredentialEnvVars(t)
+
+	config.Init(t.TempDir())
+	t.Cleanup(func() { config.FlagProfileName = "" })
+
+	require.NoError(t, configAPI.SetProfileValue("A", config.APIKey, "key-A"))
+	require.NoError(t, configAPI.SetProfileValue("A", config.Region, "US"))
+	require.NoError(t, configAPI.SetProfileValue("B", config.APIKey, "key-B"))
+	require.NoError(t, configAPI.SetProfileValue("B", config.Region, "EU"))
+	require.NoError(t, configAPI.SetDefaultProfile("A"))
+}
+
+// Skipping the Account ID prompt must leave the field unset, not written as
+// 0 (which used to fail validation and abort `profile add`).
+func TestAddIntValueToProfile_SkipsAccountIDWhenZero(t *testing.T) {
+	clearAmbientCredentialEnvVars(t)
+	config.Init(t.TempDir())
+
+	acceptDefaults = true
+	defer func() { acceptDefaults = false }()
+
+	addIntValueToProfile("no-account-id", 0, config.AccountID, "Account ID", nil)
+
+	_, err := config.CredentialsProvider.GetIntWithScope("no-account-id", config.AccountID)
+	require.Error(t, err, "accountID must remain unset (no value at all), not written as 0")
+}
+
+// Sanity check that the skip-on-zero path didn't disable the normal set path.
+func TestAddIntValueToProfile_SetsNonZeroValue(t *testing.T) {
+	clearAmbientCredentialEnvVars(t)
+	config.Init(t.TempDir())
+
+	addIntValueToProfile("with-account-id", 12345, config.AccountID, "Account ID", nil)
+
+	v, err := config.CredentialsProvider.GetIntWithScope("with-account-id", config.AccountID)
+	require.NoError(t, err)
+	require.Equal(t, int64(12345), v)
+}
+
+// `--profile B` selects which profile's credentials to use, but must not
+// make `list` mislabel B as the persisted default - only A may be marked so.
+func TestCmdList_MarksTruePersistedDefault_RegardlessOfProfileFlag(t *testing.T) {
+	setupTwoProfilesWithADefault(t)
+	config.FlagProfileName = "B"
+
+	root := buildTestRootCmd()
+	resetListFormatFlagState()
+	out := captureStdout(t, func() {
+		root.SetArgs([]string{"profile", "list", "--profile", "B", "--format", "json"})
+		require.NoError(t, root.Execute())
+	})
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &rows))
+
+	byName := map[string]map[string]interface{}{}
+	for _, r := range rows {
+		byName[r["Name"].(string)] = r
+	}
+
+	require.Equal(t, true, byName["A"]["isDefault"], "A is the persisted default and must be marked so even with --profile B active")
+	require.Equal(t, false, byName["B"]["isDefault"])
+}
+
+// With no --format flag, `list` must still render a table, not fall through
+// to output.Print()'s own default of JSON.
+func TestCmdList_DefaultsToTableFormat_WhenFormatFlagNotPassed(t *testing.T) {
+	setupTwoProfilesWithADefault(t)
+
+	root := buildTestRootCmd()
+	resetListFormatFlagState()
+	out := captureStdout(t, func() {
+		root.SetArgs([]string{"profile", "list"})
+		require.NoError(t, root.Execute())
+	})
+
+	require.NotEmpty(t, out)
+	require.NotEqual(t, byte('['), out[0], "no --format flag was passed; output must not be JSON")
+	require.Contains(t, out, "Name")
+	require.Contains(t, out, "isDefault")
+}
+
+// An explicit --format json must take effect and contain no ANSI codes -
+// not in the Name field's "(default)" suffix, nor in obfuscated values.
+func TestCmdList_RespectsExplicitJSONFormat_CleanOfANSI(t *testing.T) {
+	setupTwoProfilesWithADefault(t)
+
+	root := buildTestRootCmd()
+	resetListFormatFlagState()
+	out := captureStdout(t, func() {
+		root.SetArgs([]string{"profile", "list", "--format", "json"})
+		require.NoError(t, root.Execute())
+	})
+
+	require.NotContains(t, out, "\x1b", "JSON output must contain no ANSI escape codes")
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &rows))
+	require.Len(t, rows, 2)
+
+	byName := map[string]map[string]interface{}{}
+	for _, r := range rows {
+		byName[r["Name"].(string)] = r
+	}
+
+	require.Equal(t, "A", byName["A"]["Name"], "Name must be the clean profile name, with no embedded ANSI suffix")
+	require.Equal(t, true, byName["A"]["isDefault"])
+}

--- a/internal/profile/command_test.go
+++ b/internal/profile/command_test.go
@@ -32,6 +32,11 @@ func TestProfilesDefault(t *testing.T) {
 	testcobra.CheckCobraCommandAliases(t, cmdDefault, []string{})
 }
 
+// `profile default` must have the same PreRun guard as `profile add`.
+func TestProfilesDefault_RequiresProfileName(t *testing.T) {
+	assert.NotNil(t, cmdDefault.PreRun)
+}
+
 func TestProfilesList(t *testing.T) {
 	assert.Equal(t, "list", cmdList.Name())
 
@@ -45,4 +50,9 @@ func TestProfilesDelete(t *testing.T) {
 
 	testcobra.CheckCobraMetadata(t, cmdDelete)
 	testcobra.CheckCobraCommandAliases(t, cmdDelete, []string{"remove", "rm"}) // DEPRECATED: from nr1 cli
+}
+
+// `profile delete` must have the same PreRun guard as `profile add`.
+func TestProfilesDelete_RequiresProfileName(t *testing.T) {
+	assert.NotNil(t, cmdDelete.PreRun)
 }


### PR DESCRIPTION
## Summary

Fixes [NR-613553](https://new-relic.atlassian.net/browse/NR-613553): the CLI `profile` command silently truncated profile names containing a `.` (e.g. `sanyam.saxena` → stored as `sanyam`), plus 4 related bugs found during the same investigation ([NR-579514](https://new-relic.atlassian.net/browse/NR-579514)).

**Root cause:** profile names are used as raw gjson/sjson path segments in `internal/config/json_store.go`. `.` is gjson's path separator, so a dotted name was parsed as a nested object instead of a flat key. The existing `escapeWildcards()` only escaped `*`/`?`.

## What changed

| # | Bug | Fix |
|---|---|---|
| 1 | Dotted/special-char profile names truncated | `getPath()`/`RemoveScope()` now escape `. # @ \| * ? \` in the scope segment before it's joined into a path, so it's addressed as one literal key |
| 2 | Skipping Account ID in `profile add` crashes | `addIntValueToProfile` leaves the field unset instead of writing `0`, which failed `IntGreaterThan(0)` validation |
| 3 | `profile default`/`delete` don't require `--profile` | Added the same `PreRun: requireProfileName` guard `profile add` already had |
| 4 | `profile list` marks wrong profile as default with `--profile` flag | Uses `GetDefaultProfileName()` (persisted default) instead of `GetActiveProfileName()` (flag-overridable) |
| 5 | ANSI codes in profile name pollute `--format json` output | `--format` is now actually respected (was previously ignored - `list` always rendered a table); `isDefault` is a separate boolean field; ANSI decoration only applied for table output, including in obfuscated `apiKey`/`licenseKey` values |

Scope is deliberately limited to the bugs above - the ticket's "nice-to-have" UX suggestions (API key validation, delete confirmation, overwrite warning, `--show-keys` help text) are **not** included.

## Test plan

- [x] `go build ./...` - clean
- [x] `go test -tags "unit integration" ./...` - all packages pass, no regressions
- [x] `gofmt -l` on all changed files - clean
- [x] New tests: `TestStore_SetGetWithScope_SpecialCharacters` (`.`, `#`, `@`, `|`, `*`, `?`, `\`, mixed), `TestStore_RemoveScope_SpecialCharacters`, `TestStore_SetGetWithScope_PlainName` (backward compat), `TestAddIntValueToProfile_SkipsAccountIDWhenZero`, `TestAddIntValueToProfile_SetsNonZeroValue`, `TestCmdList_MarksTruePersistedDefault_RegardlessOfProfileFlag`, `TestCmdList_DefaultsToTableFormat_WhenFormatFlagNotPassed`, `TestCmdList_RespectsExplicitJSONFormat_CleanOfANSI`, plus `PreRun` guard assertions for `default`/`delete`
- [x] Manually verified end-to-end against the built binary: create/list/delete a profile named `sanyam.saxena` and `a#b@c`, confirm no truncation; confirmed pre-existing plain-name profiles still round-trip unchanged (no migration needed); confirmed `profile default`/`delete` without `--profile` fail with the clear error message; confirmed `profile list --format json`/`yaml` is ANSI-free with correct `isDefault`, and that the no-flag default still renders the original table
- [x] Regression check: `newrelic install` with a dotted-name profile active correctly reads `apiKey`/`accountID`/`region`/`licenseKey` through the same read path (fails only on unrelated API-key-format validation, confirming the profile itself resolved correctly)

## Risk / safety

- No new dependencies, no config/schema changes, no exported API removed.
- `escapePathSegment` is applied only at the point profile names are read/written as JSON path segments - existing profiles with no special characters are unaffected (escaping a name with none of `. # @ | * ? \` is a no-op).
- No sensitive data (API keys, tokens, credentials) is included in this diff - test fixtures use placeholder values (`key-A`, `lic-A`, etc.) only.

[NR-613553]: https://new-relic.atlassian.net/browse/NR-613553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NR-579514]: https://new-relic.atlassian.net/browse/NR-579514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 