### PR TITLE
fix(release): stop fetching install.ps1 from GitHub Release — use checkout copy instead

### DIFF
--- a/.github/workflows/release-publish-windows.yml
+++ b/.github/workflows/release-publish-windows.yml
@@ -90,15 +90,6 @@ jobs:
           target: "NewRelicCLIInstaller.msi"
           token: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Fetch Github Release Asset - install.ps1
-        uses: dsaltares/fetch-gh-release-asset@0.06
-        with:
-          repo: "newrelic/newrelic-cli"
-          version: "tags/${{ steps.get-latest-tag.outputs.tag }}"
-          file: "install.ps1"
-          target: "./scripts/install.ps1"
-          token: ${{ secrets.RELEASE_TOKEN }}
-
       - name: Upload Windows install script to AWS S3
         id: upload-install-script-windows
         run: |


### PR DESCRIPTION
## Summary

- Removes the `dsaltares/fetch-gh-release-asset@0.06` step in `release-publish-windows.yml` that was downloading `install.ps1` from the GitHub Release asset before uploading it to S3
- The `actions/checkout@v3` step at the top of this job already provides `./scripts/install.ps1` — using it directly mirrors exactly how `release.yml` already handles `install.sh`
- Fixes `install.ps1` showing as 0 bytes at `https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1`

## Confirmed prior art — how install.sh is already handled

In `.github/workflows/release.yml` at **line 176**, `install.sh` is uploaded to S3 directly from the checkout copy, with no intermediate fetch from the GitHub Release:

```yaml
# .github/workflows/release.yml — line 176
- name: Upload Unix based install script to AWS
  id: upload-install-script
  run: |
    aws s3 cp ./scripts/install.sh s3://nr-downloads-main/install/newrelic-cli/scripts/install.sh --profile virtuoso
```

No fetch step precedes it. The checkout is the source of truth. `install.sh` has worked reliably because of this. This fix makes `install.ps1` follow the identical pattern.

## Root cause

The broken step was overwriting the good local checkout file with a potentially 0-byte download:

```yaml
# This was overwriting ./scripts/install.ps1 with a 0-byte file on silent failure
- name: Fetch Github Release Asset - install.ps1
  uses: dsaltares/fetch-gh-release-asset@0.06   # very old action, silently exits 0 on failure
  with:
    file: "install.ps1"
    target: "./scripts/install.ps1"              # overwrites the checkout copy

# This then uploaded the 0-byte file to S3
- name: Upload Windows install script to AWS S3
  run: aws s3 cp ./scripts/install.ps1 s3://nr-downloads-main/install/newrelic-cli/scripts/install.ps1
```

## Test plan

- [ ] Confirm `install.ps1` at `s3://nr-downloads-main/install/newrelic-cli/scripts/install.ps1` is non-zero after the next release
- [ ] Confirm `NewRelicCLIInstaller.msi` upload (which still uses the fetch action legitimately — the MSI is not in the repo) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)